### PR TITLE
fix(bridge-activity): track DepositReceipt contracts in raw events

### DIFF
--- a/scripts/bridge-activity.go
+++ b/scripts/bridge-activity.go
@@ -367,16 +367,17 @@ func queryRawEvents(ctx context.Context, client lapiv2.UpdateServiceClient, part
 func isBridgeContract(templateID *lapiv2.Identifier) bool {
 	module := templateID.ModuleName
 	entity := templateID.EntityName
-	// Deposit-related
-	if module == "Common.FingerprintAuth" && entity == "PendingDeposit" {
-		return true
+	// Deposit-related (Common.FingerprintAuth module)
+	if module == "Common.FingerprintAuth" {
+		if entity == "PendingDeposit" || entity == "DepositReceipt" {
+			return true
+		}
 	}
-	if entity == "DepositEvent" {
-		return true
-	}
-	// Withdrawal-related
-	if module == "Bridge.Contracts" && (entity == "WithdrawalRequest" || entity == "WithdrawalEvent") {
-		return true
+	// Withdrawal-related (Bridge.Contracts module)
+	if module == "Bridge.Contracts" {
+		if entity == "WithdrawalRequest" || entity == "WithdrawalEvent" {
+			return true
+		}
 	}
 	return false
 }


### PR DESCRIPTION
Add DepositReceipt to tracked contracts so deposit flow shows same level of detail as withdrawal flow in the bridge activity report.

DEPOSIT FLOW (EVM → Canton):
  PendingDeposit (offset N)     - Created when EVM deposit detected
       ↓ ProcessDeposit
  DepositReceipt (offset N+1)   - Created when fingerprint resolved  [NEW]
       ↓ AcknowledgeReceipt
  (archived after mint)

WITHDRAWAL FLOW (Canton → EVM):
  WithdrawalRequest (offset N)  - Created when withdrawal initiated
       ↓ ProcessWithdrawal (burns tokens)
  WithdrawalEvent Pending (N+1) - Waiting for EVM release
       ↓ CompleteWithdrawal (EVM tx confirmed)
  WithdrawalEvent Completed (N+2)

Previously only PendingDeposit was shown for deposits while all 3 withdrawal steps were tracked. This change adds DepositReceipt so both flows display their complete lifecycle.

Also removes unused DepositEvent check (no such contract exists).