### PR TITLE
fix: reconciliation no longer overwrites user balances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ bin/
 *.dll
 *.so
 *.dylib
+relayer
+api-server
+e2e-test
 
 # Test binary
 *.test

--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -1,0 +1,652 @@
+# Canton Bridge API Documentation
+
+## API Endpoint
+
+**Mainnet URL:** `https://middleware-api-prod1.02.chainsafe.dev/rpc`  
+*(Replace with actual mainnet URL when available)*
+
+**Health Check:** `GET /health`
+
+---
+
+## Overview
+
+The Canton Bridge API provides a JSON-RPC 2.0 interface for interacting with bridged ERC-20 tokens on the Canton Network. It enables users to:
+
+- **Register** with their Ethereum wallet (Web3 login)
+- **Query balances** of bridged tokens
+- **Transfer tokens** between users on Canton
+- **Access token metadata** (name, symbol, decimals, total supply)
+
+### Architecture: Issuer-Centric Model
+
+The bridge uses an **issuer-centric model** where:
+
+1. **Single Issuer Party**: All bridged tokens are managed by a single issuer (the bridge relayer party) on Canton
+2. **Fingerprint Mapping**: Users are identified by a cryptographic fingerprint derived from their Ethereum address (`keccak256(address)`)
+3. **CIP-56 Tokens**: Tokens follow the CIP-56 standard on Canton, enabling compliant asset management
+4. **No Canton Keys Required**: Users authenticate with their existing Ethereum wallets—no Canton-specific keys needed
+
+### How Bridging Works
+
+```
+┌─────────────┐      Deposit       ┌─────────────┐      Mint        ┌─────────────┐
+│  Ethereum   │ ──────────────────▶│ Middleware  │ ───────────────▶ │   Canton    │
+│   (ERC-20)  │                    │   Relayer   │                  │  (CIP-56)   │
+└─────────────┘                    └─────────────┘                  └─────────────┘
+       │                                  │                                │
+       │  1. User deposits tokens         │  2. Relayer detects event      │
+       │     to bridge contract           │     and mints on Canton        │
+       │                                  │                                │
+       │◀─────────────────────────────────│◀────────────────────────────────│
+       │         Withdrawal               │          Burn                  │
+       │  4. Relayer releases tokens      │  3. User initiates withdrawal  │
+```
+
+---
+
+## Authentication
+
+### Web3 Wallet Authentication (EIP-191)
+
+All authenticated endpoints require an **EIP-191 personal signature** from the user's Ethereum wallet.
+
+#### Required Headers
+
+| Header | Description |
+|--------|-------------|
+| `X-Signature` | EIP-191 signature of the message (hex string with `0x` prefix) |
+| `X-Message` | The signed message in format: `{method}:{timestamp}` |
+
+#### Signing Example
+
+```javascript
+// Message format: "method_name:unix_timestamp"
+const message = `erc20_balanceOf:${Math.floor(Date.now() / 1000)}`;
+
+// Sign with wallet (MetaMask, ethers.js, etc.)
+const signature = await wallet.signMessage(message);
+
+// Send with request
+fetch('/rpc', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'X-Signature': signature,
+    'X-Message': message
+  },
+  body: JSON.stringify({
+    jsonrpc: '2.0',
+    method: 'erc20_balanceOf',
+    params: {},
+    id: 1
+  })
+});
+```
+
+### Whitelisting
+
+Before users can register, their Ethereum address must be **whitelisted** by an administrator. This provides access control for the bridge during controlled rollout phases.
+
+---
+
+## JSON-RPC 2.0 Methods
+
+### Public Methods (No Authentication)
+
+#### `erc20_name`
+
+Returns the token name.
+
+**Request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "erc20_name",
+  "params": {},
+  "id": 1
+}
+```
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "result": "PROMPT",
+  "id": 1
+}
+```
+
+**Curl Example:**
+```bash
+curl -X POST https://middleware-api-prod1.02.chainsafe.dev/rpc \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc": "2.0", "method": "erc20_name", "params": {}, "id": 1}'
+```
+
+---
+
+#### `erc20_symbol`
+
+Returns the token symbol.
+
+**Request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "erc20_symbol",
+  "params": {},
+  "id": 1
+}
+```
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "result": "PROMPT",
+  "id": 1
+}
+```
+
+**Curl Example:**
+```bash
+curl -X POST https://middleware-api-prod1.02.chainsafe.dev/rpc \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc": "2.0", "method": "erc20_symbol", "params": {}, "id": 1}'
+```
+
+---
+
+#### `erc20_decimals`
+
+Returns the token decimals.
+
+**Request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "erc20_decimals",
+  "params": {},
+  "id": 1
+}
+```
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "result": 18,
+  "id": 1
+}
+```
+
+**Curl Example:**
+```bash
+curl -X POST https://middleware-api-prod1.02.chainsafe.dev/rpc \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc": "2.0", "method": "erc20_decimals", "params": {}, "id": 1}'
+```
+
+---
+
+#### `erc20_totalSupply`
+
+Returns the total supply of bridged tokens on Canton.
+
+**Request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "erc20_totalSupply",
+  "params": {},
+  "id": 1
+}
+```
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "totalSupply": "1000000.000000000000000000"
+  },
+  "id": 1
+}
+```
+
+**Curl Example:**
+```bash
+curl -X POST https://middleware-api-prod1.02.chainsafe.dev/rpc \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc": "2.0", "method": "erc20_totalSupply", "params": {}, "id": 1}'
+```
+
+---
+
+### Authenticated Methods
+
+#### `user_register`
+
+Registers a new user with their Ethereum wallet. Requires the user's address to be whitelisted.
+
+**Authentication:** Required (EIP-191 signature)
+
+**Request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "user_register",
+  "params": {},
+  "id": 1
+}
+```
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "party": "daml-autopilot::122043f0b94e28125e4c65aa7e0f0ded912472731695f01cc83aa41ad3f03965a19b",
+    "fingerprint": "0x97226fafd8c54f2ba4556c78d1e7d235b08918b3fbd8e84d023bc2375cd46609",
+    "mappingCid": "00abc123..."
+  },
+  "id": 1
+}
+```
+
+**Errors:**
+- `-32004` - Address not whitelisted
+- `-32005` - User already registered
+
+**Curl Example:**
+```bash
+MESSAGE="user_register:$(date +%s)"
+SIGNATURE=$(cast wallet sign --private-key $PRIVATE_KEY "$MESSAGE")
+
+curl -X POST https://middleware-api-prod1.02.chainsafe.dev/rpc \
+  -H "Content-Type: application/json" \
+  -H "X-Signature: $SIGNATURE" \
+  -H "X-Message: $MESSAGE" \
+  -d '{"jsonrpc": "2.0", "method": "user_register", "params": {}, "id": 1}'
+```
+
+---
+
+#### `erc20_balanceOf`
+
+Returns the token balance for the authenticated user.
+
+**Authentication:** Required (EIP-191 signature)
+
+**Request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "erc20_balanceOf",
+  "params": {},
+  "id": 1
+}
+```
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "balance": "100.000000000000000000",
+    "address": "0x4768CCb3cE015698468A65bf8208b3f6919c769e"
+  },
+  "id": 1
+}
+```
+
+**Curl Example:**
+```bash
+MESSAGE="erc20_balanceOf:$(date +%s)"
+SIGNATURE=$(cast wallet sign --private-key $PRIVATE_KEY "$MESSAGE")
+
+curl -X POST https://middleware-api-prod1.02.chainsafe.dev/rpc \
+  -H "Content-Type: application/json" \
+  -H "X-Signature: $SIGNATURE" \
+  -H "X-Message: $MESSAGE" \
+  -d '{"jsonrpc": "2.0", "method": "erc20_balanceOf", "params": {}, "id": 1}'
+```
+
+---
+
+#### `erc20_transfer`
+
+Transfers tokens from the authenticated user to another registered user.
+
+**Authentication:** Required (EIP-191 signature)
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `to` | string | Yes | Recipient's Ethereum address |
+| `amount` | string | Yes | Amount to transfer (with decimals, e.g., "10.5") |
+
+**Request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "erc20_transfer",
+  "params": {
+    "to": "0x79B3ff7ca5D5eeeF4d60bcEcD5C1294e0F328431",
+    "amount": "10.0"
+  },
+  "id": 1
+}
+```
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "success": true,
+    "txId": "1220abc123..."
+  },
+  "id": 1
+}
+```
+
+**Errors:**
+- `-32001` - Unauthorized (user not registered)
+- `-32002` - Recipient not found/registered
+- `-32003` - Insufficient funds
+- `-32602` - Invalid parameters
+
+**Curl Example:**
+```bash
+MESSAGE="erc20_transfer:$(date +%s)"
+SIGNATURE=$(cast wallet sign --private-key $PRIVATE_KEY "$MESSAGE")
+
+curl -X POST https://middleware-api-prod1.02.chainsafe.dev/rpc \
+  -H "Content-Type: application/json" \
+  -H "X-Signature: $SIGNATURE" \
+  -H "X-Message: $MESSAGE" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "erc20_transfer",
+    "params": {"to": "0x79B3ff7ca5D5eeeF4d60bcEcD5C1294e0F328431", "amount": "10.0"},
+    "id": 1
+  }'
+```
+
+---
+
+## Error Codes
+
+| Code | Message | Description |
+|------|---------|-------------|
+| `-32700` | Parse error | Invalid JSON |
+| `-32600` | Invalid Request | Invalid JSON-RPC request |
+| `-32601` | Method not found | Unknown method |
+| `-32602` | Invalid params | Invalid method parameters |
+| `-32603` | Internal error | Server error |
+| `-32001` | Unauthorized | Authentication failed or user not registered |
+| `-32002` | Not found | Resource not found |
+| `-32003` | Insufficient funds | Not enough balance for transfer |
+| `-32004` | Address not whitelisted | User address not on whitelist |
+| `-32005` | User already registered | Cannot register twice |
+
+---
+
+## OpenAPI Specification
+
+```yaml
+openapi: 3.0.3
+info:
+  title: Canton Bridge API
+  description: JSON-RPC 2.0 API for Canton-Ethereum token bridge
+  version: 1.0.0
+  contact:
+    name: ChainSafe Systems
+    url: https://chainsafe.io
+
+servers:
+  - url: https://middleware-api-prod1.02.chainsafe.dev/
+    description: Mainnet API
+
+paths:
+  /health:
+    get:
+      summary: Health check
+      responses:
+        '200':
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: "ok"
+
+  /rpc:
+    post:
+      summary: JSON-RPC 2.0 endpoint
+      description: |
+        All API methods are accessed via this single endpoint using JSON-RPC 2.0 protocol.
+        
+        **Public methods:** erc20_name, erc20_symbol, erc20_decimals, erc20_totalSupply
+        
+        **Authenticated methods:** user_register, erc20_balanceOf, erc20_transfer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JsonRpcRequest'
+            examples:
+              getBalance:
+                summary: Get balance
+                value:
+                  jsonrpc: "2.0"
+                  method: "erc20_balanceOf"
+                  params: {}
+                  id: 1
+              transfer:
+                summary: Transfer tokens
+                value:
+                  jsonrpc: "2.0"
+                  method: "erc20_transfer"
+                  params:
+                    to: "0x79B3ff7ca5D5eeeF4d60bcEcD5C1294e0F328431"
+                    amount: "10.0"
+                  id: 1
+      parameters:
+        - name: X-Signature
+          in: header
+          description: EIP-191 signature (required for authenticated methods)
+          schema:
+            type: string
+            example: "0x1234567890abcdef..."
+        - name: X-Message
+          in: header
+          description: Signed message in format "method:timestamp"
+          schema:
+            type: string
+            example: "erc20_balanceOf:1703001234"
+      responses:
+        '200':
+          description: JSON-RPC response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsonRpcResponse'
+
+components:
+  schemas:
+    JsonRpcRequest:
+      type: object
+      required:
+        - jsonrpc
+        - method
+        - id
+      properties:
+        jsonrpc:
+          type: string
+          enum: ["2.0"]
+        method:
+          type: string
+          enum:
+            - erc20_name
+            - erc20_symbol
+            - erc20_decimals
+            - erc20_totalSupply
+            - erc20_balanceOf
+            - erc20_transfer
+            - user_register
+        params:
+          type: object
+        id:
+          oneOf:
+            - type: string
+            - type: integer
+
+    JsonRpcResponse:
+      type: object
+      properties:
+        jsonrpc:
+          type: string
+          enum: ["2.0"]
+        result:
+          description: Result on success
+        error:
+          $ref: '#/components/schemas/JsonRpcError'
+        id:
+          oneOf:
+            - type: string
+            - type: integer
+
+    JsonRpcError:
+      type: object
+      properties:
+        code:
+          type: integer
+        message:
+          type: string
+        data:
+          description: Additional error data
+
+    BalanceResult:
+      type: object
+      properties:
+        balance:
+          type: string
+          example: "100.000000000000000000"
+        address:
+          type: string
+          example: "0x4768CCb3cE015698468A65bf8208b3f6919c769e"
+
+    TransferResult:
+      type: object
+      properties:
+        success:
+          type: boolean
+        txId:
+          type: string
+
+    RegisterResult:
+      type: object
+      properties:
+        party:
+          type: string
+        fingerprint:
+          type: string
+        mappingCid:
+          type: string
+
+    SupplyResult:
+      type: object
+      properties:
+        totalSupply:
+          type: string
+          example: "1000000.000000000000000000"
+```
+
+---
+
+## Example: Complete Flow
+
+### 1. Check Whitelist Status & Register
+
+```bash
+# Sign message with your wallet
+MESSAGE="user_register:$(date +%s)"
+SIGNATURE=$(cast wallet sign --private-key $PRIVATE_KEY "$MESSAGE")
+
+# Register
+curl -X POST https://middleware-api-prod1.02.chainsafe.dev/rpc \
+  -H "Content-Type: application/json" \
+  -H "X-Signature: $SIGNATURE" \
+  -H "X-Message: $MESSAGE" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "user_register",
+    "params": {},
+    "id": 1
+  }'
+```
+
+### 2. Check Balance
+
+```bash
+MESSAGE="erc20_balanceOf:$(date +%s)"
+SIGNATURE=$(cast wallet sign --private-key $PRIVATE_KEY "$MESSAGE")
+
+curl -X POST https://middleware-api-prod1.02.chainsafe.dev/rpc \
+  -H "Content-Type: application/json" \
+  -H "X-Signature: $SIGNATURE" \
+  -H "X-Message: $MESSAGE" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "erc20_balanceOf",
+    "params": {},
+    "id": 1
+  }'
+```
+
+### 3. Transfer Tokens
+
+```bash
+MESSAGE="erc20_transfer:$(date +%s)"
+SIGNATURE=$(cast wallet sign --private-key $PRIVATE_KEY "$MESSAGE")
+
+curl -X POST https://middleware-api-prod1.02.chainsafe.dev/rpc \
+  -H "Content-Type: application/json" \
+  -H "X-Signature: $SIGNATURE" \
+  -H "X-Message: $MESSAGE" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "erc20_transfer",
+    "params": {
+      "to": "0x79B3ff7ca5D5eeeF4d60bcEcD5C1294e0F328431",
+      "amount": "25.5"
+    },
+    "id": 1
+  }'
+```
+
+---
+
+## Rate Limits
+
+| Endpoint | Limit |
+|----------|-------|
+| Public methods | 100 requests/minute |
+| Authenticated methods | 50 requests/minute per user |
+
+---
+
+## Support
+
+For issues or questions, please contact:
+- **GitHub:** [ChainSafe/canton-middleware](https://github.com/ChainSafe/canton-middleware)
+- **Email:** support@chainsafe.io
+

--- a/scripts/check-balances.go
+++ b/scripts/check-balances.go
@@ -1,0 +1,107 @@
+//go:build ignore
+
+package main
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+const (
+	apiURL   = "https://middleware-api-prod1.02.chainsafe.dev/rpc"
+	user1Key = "eacbff42147f4a4493e2212a70ace9e0ef4e40532e5aa3e049a0eb355e8fc5be"
+	user2Key = "e9fe9a4abcaed48276a80923e1514779a7d7a872d5a9c2fbb2681062e115390f"
+)
+
+func main() {
+	key1, _ := crypto.HexToECDSA(user1Key)
+	key2, _ := crypto.HexToECDSA(user2Key)
+
+	addr1 := crypto.PubkeyToAddress(key1.PublicKey)
+	addr2 := crypto.PubkeyToAddress(key2.PublicKey)
+
+	fmt.Println("=== Canton Bridge Balance Check ===")
+	fmt.Printf("API: %s\n\n", apiURL)
+
+	// Check User1 balance
+	bal1, err := getBalance(key1)
+	if err != nil {
+		fmt.Printf("✗ User1 (%s): Error - %v\n", addr1.Hex(), err)
+	} else {
+		fmt.Printf("✓ User1 (%s): %s PROMPT\n", addr1.Hex(), bal1)
+	}
+
+	// Check User2 balance
+	bal2, err := getBalance(key2)
+	if err != nil {
+		fmt.Printf("✗ User2 (%s): Error - %v\n", addr2.Hex(), err)
+	} else {
+		fmt.Printf("✓ User2 (%s): %s PROMPT\n", addr2.Hex(), bal2)
+	}
+}
+
+func signEIP191(message string, key *ecdsa.PrivateKey) string {
+	prefix := fmt.Sprintf("\x19Ethereum Signed Message:\n%d", len(message))
+	hash := crypto.Keccak256Hash([]byte(prefix + message))
+	sig, _ := crypto.Sign(hash.Bytes(), key)
+	if sig[64] < 27 {
+		sig[64] += 27
+	}
+	return "0x" + hex.EncodeToString(sig)
+}
+
+func rpcCall(key *ecdsa.PrivateKey, method string, params map[string]interface{}) (json.RawMessage, error) {
+	ts := time.Now().Unix()
+	msg := fmt.Sprintf("%s:%d", method, ts)
+	sig := signEIP191(msg, key)
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"jsonrpc": "2.0", "method": method, "params": params, "id": 1,
+	})
+
+	req, _ := http.NewRequest("POST", apiURL, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Signature", sig)
+	req.Header.Set("X-Message", msg)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+
+	var result struct {
+		Result json.RawMessage `json:"result"`
+		Error  *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	json.Unmarshal(respBody, &result)
+
+	if result.Error != nil {
+		return nil, fmt.Errorf("%s", result.Error.Message)
+	}
+	return result.Result, nil
+}
+
+func getBalance(key *ecdsa.PrivateKey) (string, error) {
+	result, err := rpcCall(key, "erc20_balanceOf", map[string]interface{}{})
+	if err != nil {
+		return "", err
+	}
+	var bal struct {
+		Balance string `json:"balance"`
+	}
+	json.Unmarshal(result, &bal)
+	return bal.Balance, nil
+}

--- a/scripts/check-mappings.go
+++ b/scripts/check-mappings.go
@@ -1,0 +1,163 @@
+//go:build ignore
+
+// Check FingerprintMapping contracts on Canton
+
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"os"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"gopkg.in/yaml.v3"
+
+	lapiv2 "github.com/chainsafe/canton-middleware/pkg/canton/lapi/v2"
+)
+
+type Config struct {
+	Canton struct {
+		RPCURL       string `yaml:"rpc_url"`
+		RelayerParty string `yaml:"relayer_party"`
+		TLS          struct {
+			Enabled bool `yaml:"enabled"`
+		} `yaml:"tls"`
+		Auth struct {
+			ClientID     string `yaml:"client_id"`
+			ClientSecret string `yaml:"client_secret"`
+			Audience     string `yaml:"audience"`
+			TokenURL     string `yaml:"token_url"`
+		} `yaml:"auth"`
+	} `yaml:"canton"`
+}
+
+func main() {
+	// Load config
+	data, _ := os.ReadFile("config.mainnet.yaml")
+	var cfg Config
+	yaml.Unmarshal(data, &cfg)
+
+	// Connect
+	var opts []grpc.DialOption
+	if cfg.Canton.TLS.Enabled {
+		opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})))
+	} else {
+		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	}
+
+	conn, err := grpc.NewClient(cfg.Canton.RPCURL, opts...)
+	if err != nil {
+		fmt.Printf("Connect error: %v\n", err)
+		return
+	}
+	defer conn.Close()
+
+	// Get OAuth token
+	token, err := getToken(&cfg)
+	if err != nil {
+		fmt.Printf("Auth error: %v\n", err)
+		return
+	}
+
+	ctx := metadata.AppendToOutgoingContext(context.Background(), "authorization", "Bearer "+token)
+	stateService := lapiv2.NewStateServiceClient(conn)
+
+	// Get ledger end
+	ledgerEnd, _ := stateService.GetLedgerEnd(ctx, &lapiv2.GetLedgerEndRequest{})
+
+	fmt.Println("=== FingerprintMapping Contracts on Mainnet ===")
+	fmt.Printf("Ledger offset: %d\n\n", ledgerEnd.Offset)
+
+	// Query all contracts
+	resp, err := stateService.GetActiveContracts(ctx, &lapiv2.GetActiveContractsRequest{
+		ActiveAtOffset: ledgerEnd.Offset,
+		EventFormat: &lapiv2.EventFormat{
+			FiltersByParty: map[string]*lapiv2.Filters{
+				cfg.Canton.RelayerParty: {
+					Cumulative: []*lapiv2.CumulativeFilter{{
+						IdentifierFilter: &lapiv2.CumulativeFilter_WildcardFilter{
+							WildcardFilter: &lapiv2.WildcardFilter{},
+						},
+					}},
+				},
+			},
+			Verbose: true,
+		},
+	})
+	if err != nil {
+		fmt.Printf("Query error: %v\n", err)
+		return
+	}
+
+	mappingCount := 0
+	for {
+		msg, err := resp.Recv()
+		if err != nil {
+			break
+		}
+		if contract := msg.GetActiveContract(); contract != nil {
+			templateId := contract.CreatedEvent.TemplateId
+			if templateId.ModuleName == "Common.FingerprintAuth" && templateId.EntityName == "FingerprintMapping" {
+				mappingCount++
+				fmt.Printf("[%d] FingerprintMapping\n", mappingCount)
+				fmt.Printf("    CID: %s...\n", contract.CreatedEvent.ContractId[:40])
+
+				// Extract fingerprint
+				if contract.CreatedEvent.CreateArguments != nil {
+					for _, f := range contract.CreatedEvent.CreateArguments.Fields {
+						if f.Label == "fingerprint" {
+							if t, ok := f.Value.Sum.(*lapiv2.Value_Text); ok {
+								fmt.Printf("    Fingerprint: %s\n", t.Text)
+							}
+						}
+					}
+				}
+				fmt.Println()
+			}
+		}
+	}
+
+	if mappingCount == 0 {
+		fmt.Println("No FingerprintMapping contracts found!")
+		fmt.Println("\nThis means users haven't been registered on mainnet Canton yet.")
+		fmt.Println("The API server might have cached data from a different network.")
+	} else {
+		fmt.Printf("Found %d FingerprintMapping contract(s)\n", mappingCount)
+	}
+}
+
+func getToken(cfg *Config) (string, error) {
+	data := url.Values{}
+	data.Set("grant_type", "client_credentials")
+	data.Set("client_id", cfg.Canton.Auth.ClientID)
+	data.Set("client_secret", cfg.Canton.Auth.ClientSecret)
+	data.Set("audience", cfg.Canton.Auth.Audience)
+
+	req, _ := http.NewRequest("POST", cfg.Canton.Auth.TokenURL, strings.NewReader(data.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	var tokenResp struct {
+		AccessToken string `json:"access_token"`
+	}
+	json.Unmarshal(body, &tokenResp)
+	return tokenResp.AccessToken, nil
+}

--- a/scripts/check-user-holdings.go
+++ b/scripts/check-user-holdings.go
@@ -1,0 +1,297 @@
+//go:build ignore
+
+// Check actual user holdings from Canton directly (bypasses API cache)
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/shopspring/decimal"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"gopkg.in/yaml.v3"
+
+	lapiv2 "github.com/chainsafe/canton-middleware/pkg/canton/lapi/v2"
+)
+
+type Config struct {
+	Canton struct {
+		RPCURL       string `yaml:"rpc_url"`
+		RelayerParty string `yaml:"relayer_party"`
+		Auth         struct {
+			ClientID     string `yaml:"client_id"`
+			ClientSecret string `yaml:"client_secret"`
+			Audience     string `yaml:"audience"`
+			TokenURL     string `yaml:"token_url"`
+		} `yaml:"auth"`
+	} `yaml:"canton"`
+}
+
+type UserMapping struct {
+	Fingerprint string
+	Party       string
+	EvmAddress  string
+}
+
+func main() {
+	configFile := "config.mainnet.yaml"
+	if len(os.Args) > 1 {
+		configFile = os.Args[1]
+	}
+
+	data, err := os.ReadFile(configFile)
+	if err != nil {
+		fmt.Printf("Failed to read config: %v\n", err)
+		return
+	}
+	var cfg Config
+	yaml.Unmarshal(data, &cfg)
+
+	token := getToken(cfg.Canton.Auth.TokenURL, cfg.Canton.Auth.ClientID, cfg.Canton.Auth.ClientSecret, cfg.Canton.Auth.Audience)
+	if token == "" {
+		fmt.Println("Failed to get OAuth token")
+		return
+	}
+
+	conn, err := grpc.NewClient(cfg.Canton.RPCURL, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		fmt.Printf("Failed to connect: %v\n", err)
+		return
+	}
+	defer conn.Close()
+
+	stateService := lapiv2.NewStateServiceClient(conn)
+	ctx := metadata.AppendToOutgoingContext(context.Background(), "authorization", "Bearer "+token)
+
+	resp, err := stateService.GetLedgerEnd(ctx, &lapiv2.GetLedgerEndRequest{})
+	if err != nil {
+		fmt.Printf("Failed to get ledger end: %v\n", err)
+		return
+	}
+
+	fmt.Println("=== User Holdings on Canton (Direct Query) ===")
+	fmt.Printf("Config: %s\n", configFile)
+	fmt.Printf("Ledger offset: %d\n\n", resp.Offset)
+
+	// Step 1: Get all FingerprintMappings to know which party belongs to which user
+	mappings := make(map[string]*UserMapping) // party -> mapping
+	contracts, _ := stateService.GetActiveContracts(ctx, &lapiv2.GetActiveContractsRequest{
+		ActiveAtOffset: resp.Offset,
+		EventFormat: &lapiv2.EventFormat{
+			FiltersByParty: map[string]*lapiv2.Filters{
+				cfg.Canton.RelayerParty: {
+					Cumulative: []*lapiv2.CumulativeFilter{{
+						IdentifierFilter: &lapiv2.CumulativeFilter_WildcardFilter{
+							WildcardFilter: &lapiv2.WildcardFilter{},
+						},
+					}},
+				},
+			},
+			Verbose: true,
+		},
+	})
+
+	mappingCount := 0
+	for {
+		msg, err := contracts.Recv()
+		if err != nil {
+			break
+		}
+		if c := msg.GetActiveContract(); c != nil {
+			tid := c.CreatedEvent.TemplateId
+			if tid.ModuleName == "Common.FingerprintAuth" && tid.EntityName == "FingerprintMapping" {
+				mappingCount++
+				fields := recordToMap(c.CreatedEvent.CreateArguments)
+				fp := extractText(fields["fingerprint"])
+				userParty := extractParty(fields["userParty"])
+				evmAddr := ""
+				if opt := fields["evmAddress"]; opt != nil {
+					if optVal := opt.GetOptional(); optVal != nil && optVal.Value != nil {
+						if rec := optVal.Value.GetRecord(); rec != nil {
+							for _, f := range rec.Fields {
+								if f.Label == "evmAddress" {
+									evmAddr = extractText(f.Value)
+								}
+							}
+						}
+					}
+				}
+				mappings[userParty] = &UserMapping{
+					Fingerprint: fp,
+					Party:       userParty,
+					EvmAddress:  evmAddr,
+				}
+			}
+		}
+	}
+
+	fmt.Printf("Found %d FingerprintMappings (%d unique parties)\n\n", mappingCount, len(mappings))
+
+	// Step 2: Get all CIP56Holdings and sum by owner party
+	partyBalances := make(map[string]decimal.Decimal) // party -> balance
+	totalSupply := decimal.Zero
+
+	contracts2, _ := stateService.GetActiveContracts(ctx, &lapiv2.GetActiveContractsRequest{
+		ActiveAtOffset: resp.Offset,
+		EventFormat: &lapiv2.EventFormat{
+			FiltersByParty: map[string]*lapiv2.Filters{
+				cfg.Canton.RelayerParty: {
+					Cumulative: []*lapiv2.CumulativeFilter{{
+						IdentifierFilter: &lapiv2.CumulativeFilter_WildcardFilter{
+							WildcardFilter: &lapiv2.WildcardFilter{},
+						},
+					}},
+				},
+			},
+			Verbose: true,
+		},
+	})
+
+	holdingCount := 0
+	for {
+		msg, err := contracts2.Recv()
+		if err != nil {
+			break
+		}
+		if c := msg.GetActiveContract(); c != nil {
+			tid := c.CreatedEvent.TemplateId
+			if tid.ModuleName == "CIP56.Token" && tid.EntityName == "CIP56Holding" {
+				holdingCount++
+				fields := recordToMap(c.CreatedEvent.CreateArguments)
+				owner := extractParty(fields["owner"])
+				amountStr := extractNumeric(fields["amount"])
+
+				amount, err := decimal.NewFromString(amountStr)
+				if err != nil {
+					continue
+				}
+
+				totalSupply = totalSupply.Add(amount)
+
+				if current, ok := partyBalances[owner]; ok {
+					partyBalances[owner] = current.Add(amount)
+				} else {
+					partyBalances[owner] = amount
+				}
+			}
+		}
+	}
+
+	fmt.Printf("Found %d CIP56Holding contracts\n", holdingCount)
+	fmt.Printf("Total Supply: %s PROMPT\n\n", totalSupply.String())
+
+	// Check if multiple users share the same party (issuer-centric model issue)
+	if mappingCount > len(mappings) {
+		fmt.Println("⚠️  WARNING: Multiple users share the same Canton party!")
+		fmt.Println("   In this setup, individual user balances CANNOT be determined")
+		fmt.Println("   because all holdings are owned by the shared party.")
+		fmt.Println()
+	}
+
+	// Step 3: Map holdings to users
+	fmt.Println("--- User Balances (by Party) ---")
+	for party, mapping := range mappings {
+		balance := decimal.Zero
+		if bal, ok := partyBalances[party]; ok {
+			balance = bal
+		}
+		shortFp := mapping.Fingerprint
+		if len(shortFp) > 20 {
+			shortFp = shortFp[:20] + "..."
+		}
+		if mapping.EvmAddress != "" {
+			fmt.Printf("✓ EVM: %s\n", mapping.EvmAddress)
+		} else {
+			fmt.Printf("✓ Fingerprint: %s\n", shortFp)
+		}
+		fmt.Printf("  Party: %s...\n", truncate(party, 50))
+		fmt.Printf("  Holdings owned by this party: %s PROMPT\n\n", balance.String())
+	}
+
+	// Show any holdings that don't belong to registered users
+	var unmappedTotal decimal.Decimal
+	for party, balance := range partyBalances {
+		if _, ok := mappings[party]; !ok {
+			unmappedTotal = unmappedTotal.Add(balance)
+		}
+	}
+	if !unmappedTotal.IsZero() {
+		fmt.Printf("--- Holdings by other parties: %s PROMPT ---\n", unmappedTotal.String())
+	}
+
+	// Summary
+	fmt.Println("=== Summary ===")
+	fmt.Printf("Total Supply: %s PROMPT\n", totalSupply.String())
+	fmt.Printf("Registered Users: %d (mapped to %d unique parties)\n", mappingCount, len(mappings))
+	if mappingCount > len(mappings) {
+		fmt.Println("\nNOTE: Individual user balances are indistinguishable on-chain")
+		fmt.Println("because multiple users share the same Canton party.")
+	}
+}
+
+func getToken(tokenURL, clientID, clientSecret, audience string) string {
+	data := url.Values{
+		"grant_type":    {"client_credentials"},
+		"client_id":     {clientID},
+		"client_secret": {clientSecret},
+		"audience":      {audience},
+	}
+	resp, err := http.Post(tokenURL, "application/x-www-form-urlencoded", strings.NewReader(data.Encode()))
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	var result struct {
+		AccessToken string `json:"access_token"`
+	}
+	json.Unmarshal(body, &result)
+	return result.AccessToken
+}
+
+func recordToMap(r *lapiv2.Record) map[string]*lapiv2.Value {
+	m := make(map[string]*lapiv2.Value)
+	if r != nil {
+		for _, f := range r.Fields {
+			m[f.Label] = f.Value
+		}
+	}
+	return m
+}
+
+func extractParty(v *lapiv2.Value) string {
+	if v != nil {
+		return v.GetParty()
+	}
+	return ""
+}
+
+func extractNumeric(v *lapiv2.Value) string {
+	if v != nil {
+		return v.GetNumeric()
+	}
+	return ""
+}
+
+func extractText(v *lapiv2.Value) string {
+	if v != nil {
+		return v.GetText()
+	}
+	return ""
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}

--- a/scripts/quick-test.go
+++ b/scripts/quick-test.go
@@ -1,0 +1,131 @@
+//go:build ignore
+
+package main
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+const (
+	apiURL    = "https://middleware-api-prod1.02.chainsafe.dev/rpc"
+	user1Key  = "eacbff42147f4a4493e2212a70ace9e0ef4e40532e5aa3e049a0eb355e8fc5be"
+	user2Key  = "e9fe9a4abcaed48276a80923e1514779a7d7a872d5a9c2fbb2681062e115390f"
+	user2Addr = "0x79B3ff7ca5D5eeeF4d60bcEcD5C1294e0F328431"
+)
+
+func main() {
+	key1, _ := crypto.HexToECDSA(user1Key)
+	key2, _ := crypto.HexToECDSA(user2Key)
+
+	fmt.Println("=== Checking Mainnet Canton Balances ===")
+	fmt.Println()
+
+	// Check User1 balance
+	bal1, err := getBalance(key1)
+	if err != nil {
+		fmt.Printf("User1 balance error: %v\n", err)
+	} else {
+		fmt.Printf("✓ User1 balance: %s PROMPT\n", bal1)
+	}
+
+	// Check User2 balance
+	bal2, err := getBalance(key2)
+	if err != nil {
+		fmt.Printf("User2 balance error: %v\n", err)
+	} else {
+		fmt.Printf("✓ User2 balance: %s PROMPT\n", bal2)
+	}
+
+	fmt.Println()
+	fmt.Println("=== Testing Transfer (User1 → User2, 1.0 PROMPT) ===")
+	fmt.Println()
+
+	// Transfer 1.0 PROMPT from User1 to User2
+	err = transfer(key1, user2Addr, "1.0")
+	if err != nil {
+		fmt.Printf("✗ Transfer failed: %v\n", err)
+		return
+	}
+	fmt.Println("✓ Transfer successful!")
+
+	// Wait and check new balances
+	time.Sleep(2 * time.Second)
+	fmt.Println()
+	fmt.Println("=== Final Balances ===")
+
+	bal1, _ = getBalance(key1)
+	bal2, _ = getBalance(key2)
+	fmt.Printf("✓ User1 final balance: %s PROMPT\n", bal1)
+	fmt.Printf("✓ User2 final balance: %s PROMPT\n", bal2)
+}
+
+func signEIP191(message string, key *ecdsa.PrivateKey) string {
+	prefix := fmt.Sprintf("\x19Ethereum Signed Message:\n%d", len(message))
+	hash := crypto.Keccak256Hash([]byte(prefix + message))
+	sig, _ := crypto.Sign(hash.Bytes(), key)
+	if sig[64] < 27 {
+		sig[64] += 27
+	}
+	return "0x" + hex.EncodeToString(sig)
+}
+
+func rpcCall(key *ecdsa.PrivateKey, method string, params map[string]interface{}) (json.RawMessage, error) {
+	ts := time.Now().Unix()
+	msg := fmt.Sprintf("%s:%d", method, ts)
+	sig := signEIP191(msg, key)
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"jsonrpc": "2.0", "method": method, "params": params, "id": 1,
+	})
+
+	req, _ := http.NewRequest("POST", apiURL, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Signature", sig)
+	req.Header.Set("X-Message", msg)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	var rpcResp struct {
+		Result json.RawMessage `json:"result"`
+		Error  *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	json.Unmarshal(respBody, &rpcResp)
+	if rpcResp.Error != nil {
+		return nil, fmt.Errorf("%s", rpcResp.Error.Message)
+	}
+	return rpcResp.Result, nil
+}
+
+func getBalance(key *ecdsa.PrivateKey) (string, error) {
+	result, err := rpcCall(key, "erc20_balanceOf", map[string]interface{}{})
+	if err != nil {
+		return "", err
+	}
+	var bal struct {
+		Balance string `json:"balance"`
+	}
+	json.Unmarshal(result, &bal)
+	return bal.Balance, nil
+}
+
+func transfer(key *ecdsa.PrivateKey, to, amount string) error {
+	_, err := rpcCall(key, "erc20_transfer", map[string]interface{}{"to": to, "amount": amount})
+	return err
+}
+


### PR DESCRIPTION
Bug Fix:
- Fixed ReconcileAll() to only update total supply from Canton
- Removed user balance reconciliation that was incorrectly overwriting transaction-based balances with Canton holdings
- In the issuer-centric model, all CIP56 holdings are owned by the same party (issuer), making individual user balances indistinguishable on-chain
- User balances are now correctly tracked via transaction history (deposits, transfers, withdrawals) which is the source of truth
- Removed unused ReconcileUser() function and strings import

Testing Scripts Added:
- scripts/check-balances.go - Check user balances via API
- scripts/check-mappings.go - Query FingerprintMapping contracts on Canton
- scripts/check-user-holdings.go - Direct Canton holdings query
- scripts/quick-test.go - Quick balance and transfer testing

Documentation:
- docs/API_DOCUMENTATION.md - Comprehensive API documentation with OpenAPI spec, authentication details, and usage examples

Other:
- .gitignore - Added compiled binaries (relayer, api-server, e2e-test)