### PR TITLE
refactor: replace WildcardFilter with TemplateFilter for server-side contract filtering

### DIFF
--- a/pkg/canton/client.go
+++ b/pkg/canton/client.go
@@ -89,15 +89,16 @@ func NewClient(config *config.CantonConfig, logger *zap.Logger) (*Client, error)
 		zap.String("ledger_id", config.LedgerID))
 
 	// Validate required package IDs for server-side TemplateFilter queries
-	if config.CIP56PackageID == "" {
-		return nil, fmt.Errorf("canton.cip56_package_id is required")
+requiredPackages := map[string]string{
+	"canton.cip56_package_id": config.CIP56PackageID,
+	"canton.common_package_id": config.CommonPackageID,
+	"canton.bridge_package_id": config.BridgePackageID,
+}
+for name, id := range requiredPackages {
+	if id == "" {
+		return nil, fmt.Errorf("%s is required", name)
 	}
-	if config.CommonPackageID == "" {
-		return nil, fmt.Errorf("canton.common_package_id is required")
-	}
-	if config.BridgePackageID == "" {
-		return nil, fmt.Errorf("canton.bridge_package_id is required")
-	}
+}
 
 	c := &Client{
 		config:                 config,


### PR DESCRIPTION
## Summary

Resolves issue #91 

- Replace client-side template filtering with server-side `TemplateFilter` in all Canton Ledger API v2 `GetActiveContracts` calls, reducing network traffic and improving scalability
- Add `templateFilter()`, `cip56HoldingFilter()`, and `tokenConfigFilter()` helper functions for consistent filter construction
- Add startup validation in `NewClient` requiring `cip56_package_id`, `common_package_id`, and `bridge_package_id` — fails fast on misconfiguration instead of silently degrading at runtime
- Remove redundant client-side `templateId` checks that are now handled server-side

### Methods updated (10 total)

| Method | Filter Before | Filter After |
|--------|--------------|-------------|
| `GetFingerprintMapping` | Wildcard fallback | `TemplateFilter` (FingerprintMapping) |
| `IsDepositProcessed` | Wildcard | Dual `TemplateFilter` (PendingDeposit + DepositReceipt) |
| `GetUserBalance` | Wildcard | `TemplateFilter` (CIP56Holding) |
| `GetTotalSupply` | Wildcard | `TemplateFilter` (CIP56Holding) |
| `getTokenConfigCidFromBridge` | Wildcard | `TemplateFilter` (WayfinderBridgeConfig) |
| `findHoldingForTransfer` | Wildcard | `TemplateFilter` (CIP56Holding) |
| `findRecipientHolding` | Wildcard | `TemplateFilter` (CIP56Holding) |
| `GetAllCIP56Holdings` | Wildcard | `TemplateFilter` (CIP56Holding) |
| `GetTokenConfig` | Wildcard | `TemplateFilter` (TokenConfig) |
| `getActiveContractsByTemplate` | Wildcard | Wildcard (kept — generic helper) |

### Configuration validation

`NewClient` now validates that all required package IDs are configured at startup:
- `canton.cip56_package_id`
- `canton.common_package_id`
- `canton.bridge_package_id`

If any are missing, the client fails to create with a clear error message rather than silently sending empty `PackageId` values in `TemplateFilter` queries (which would match nothing).

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all existing tests)
- [x] `go vet ./...` clean
- [x] Local interop test — full demo-activity smoke test passes
- [x] Local interop test — full interop-demo (MetaMask↔Native transfers, holding merge, reconciliation) passes