### PR TITLE
Update devnet configs to v2.0.0 packages and fix scripts

### DIFF
--- a/config.api-server.local-devnet.yaml
+++ b/config.api-server.local-devnet.yaml
@@ -18,11 +18,13 @@ canton:
   application_id: "erc20-api"
   relayer_party: "daml-autopilot::1220096316d4ea75c021d89123cfd2792cfeac80dfbf90bfbca21bcd8bf1bb40d84c"
   
-  # v1.2.0 packages (uploaded 2026-01-22)
-  bridge_package_id: "2f7a146ffc5bdb1365c818c461ecfeafda78fc99e014fb793539aa1a87fe6c99"
-  core_package_id: "32df30f15a3eed8c319d541e9f6332f173a7b738dd121cf666fc54185f4f05c0"
-  cip56_package_id: "c649b42035710f991345b9f010f599870842a821d52c676cb235dcda419407df"
-  common_package_id: "d36f79e9e092169c097cfff43f6e45a5b96594e7445d4cedf5602f838a4d3651"
+  # v2.0.0 packages (uploaded 2026-03-05)
+  cip56_package_id: "c8c6fe7c34d96b88d6471769aae85063c8045783b2a226fd24f8c573603d17c2"
+  common_package_id: "c4d8bc62b74dfb93c0feda15cbceb5db16aef37d0e7ee37c17887faa9cbd33b9"
+  splice_holding_package_id: "718a0f77e505a8de22f188bd4c87fe74101274e9d4cb1bfac7d09aec7158d35b"
+  splice_transfer_package_id: "55ba4deb0ad4662c4168b39859738a0e91388d252286480c7331b3f71a517281"
+  bridge_package_id: "6fac182df4943e7e2f70360b413b6e3ab10e65289ba0d971978b6d861a860d72"
+  core_package_id: "be290fc1304d9a221def6e04a291368600599c9265f58f942a2b80478c348fca"
   bridge_module: "Wayfinder.Bridge"
   
   tls:

--- a/config.local-devnet.yaml
+++ b/config.local-devnet.yaml
@@ -31,11 +31,13 @@ canton:
   application_id: "canton-middleware"
   relayer_party: "daml-autopilot::1220096316d4ea75c021d89123cfd2792cfeac80dfbf90bfbca21bcd8bf1bb40d84c"
 
-  # v1.2.0 packages (uploaded 2026-01-22)
-  bridge_package_id: "2f7a146ffc5bdb1365c818c461ecfeafda78fc99e014fb793539aa1a87fe6c99"
-  core_package_id: "32df30f15a3eed8c319d541e9f6332f173a7b738dd121cf666fc54185f4f05c0"
-  cip56_package_id: "c649b42035710f991345b9f010f599870842a821d52c676cb235dcda419407df"
-  common_package_id: "d36f79e9e092169c097cfff43f6e45a5b96594e7445d4cedf5602f838a4d3651"
+  # v2.0.0 packages (uploaded 2026-03-05)
+  bridge_package_id: "6fac182df4943e7e2f70360b413b6e3ab10e65289ba0d971978b6d861a860d72"
+  core_package_id: "be290fc1304d9a221def6e04a291368600599c9265f58f942a2b80478c348fca"
+  cip56_package_id: "c8c6fe7c34d96b88d6471769aae85063c8045783b2a226fd24f8c573603d17c2"
+  common_package_id: "c4d8bc62b74dfb93c0feda15cbceb5db16aef37d0e7ee37c17887faa9cbd33b9"
+  splice_holding_package_id: "718a0f77e505a8de22f188bd4c87fe74101274e9d4cb1bfac7d09aec7158d35b"
+  splice_transfer_package_id: "55ba4deb0ad4662c4168b39859738a0e91388d252286480c7331b3f71a517281"
   bridge_module: "Wayfinder.Bridge"
   bridge_contract: "0x363Dd0b55bf74D5b494B064AA8E8c2Ef5eD58d75"
 

--- a/scripts/archive/archive-cip56.go
+++ b/scripts/archive/archive-cip56.go
@@ -89,6 +89,7 @@ var templatesByPackageType = map[string][]TemplateInfo{
 		{ModuleName: "CIP56.Token", EntityName: "CIP56Manager"},
 		{ModuleName: "CIP56.Token", EntityName: "CIP56Holding"},
 		{ModuleName: "CIP56.Token", EntityName: "LockedAsset"},
+		{ModuleName: "CIP56.TransferFactory", EntityName: "CIP56TransferFactory"},
 		{ModuleName: "CIP56.Compliance", EntityName: "ComplianceRules"},
 		{ModuleName: "CIP56.Compliance", EntityName: "ComplianceProof"},
 		{ModuleName: "CIP56.Config", EntityName: "TokenConfig"},
@@ -292,6 +293,8 @@ func main() {
 		"DepositReceipt", "PendingDeposit",
 		// Fingerprint mappings
 		"FingerprintMapping",
+		// Transfer factories (before managers since they reference managers)
+		"CIP56TransferFactory",
 		// Managers/configs last (they are referenced by other contracts)
 		"CIP56Manager",
 		"TokenConfig",

--- a/scripts/setup/setup-devnet.sh
+++ b/scripts/setup/setup-devnet.sh
@@ -25,7 +25,7 @@
 set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-PROJECT_ROOT="$( cd "$SCRIPT_DIR/.." && pwd )"
+PROJECT_ROOT="$( cd "$SCRIPT_DIR/../.." && pwd )"
 
 # Colors
 RED='\033[0;31m'

--- a/scripts/testing/e2e-test.go
+++ b/scripts/testing/e2e-test.go
@@ -842,15 +842,15 @@ func transferTokens(ethRPCURL string, tokenAddress string, chainID uint64, priva
 	gasPrice := new(big.Int).SetBytes(gasPriceBytes)
 
 	// Create transaction
+	contractAddr := common.HexToAddress(tokenAddress)
 	tx := types.NewTx(&types.LegacyTx{
 		Nonce:    nonce,
-		To:       &common.Address{},
+		To:       &contractAddr,
 		Value:    big.NewInt(0),
 		Gas:      100000,
 		GasPrice: gasPrice,
 		Data:     data,
 	})
-	*tx.To() = common.HexToAddress(tokenAddress)
 
 	// Sign transaction
 	signer := types.NewEIP155Signer(big.NewInt(int64(chainID)))


### PR DESCRIPTION
## Summary
- Update local-devnet config files (`config.local-devnet.yaml`, `config.api-server.local-devnet.yaml`) with new chain-agnostic v2.0.0 Daml package IDs and add required `splice_holding_package_id` / `splice_transfer_package_id` fields
- Fix `setup-devnet.sh` `PROJECT_ROOT` resolving to `scripts/` instead of repo root (`$SCRIPT_DIR/..` → `$SCRIPT_DIR/../..`)
- Fix `e2e-test.go` transaction `To` address bug where `*tx.To() = ...` after `types.NewTx` deep copy results in zero address being sent
- Add `CIP56TransferFactory` template to `archive-cip56.go` so transfer factories are archived during contract cleanup

## Test plan
- [x] E2E test passes end-to-end against DevNet (whitelist, register, deposit, transfer, verify balances, ERC20 metadata)
- [x] Archive script successfully archives all contract types including CIP56TransferFactory
- [x] Bootstrap script creates fresh infrastructure contracts (CIP56Manager, TokenConfig, CIP56TransferFactory, WayfinderBridgeConfig)
- [x] CI passes (go test, golangci-lint)