### PR TITLE
fix(reconciler): index missing for token updates

### DIFF
--- a/pkg/migrations/apidb/11_add_user_token_balances_indexes.go
+++ b/pkg/migrations/apidb/11_add_user_token_balances_indexes.go
@@ -26,8 +26,6 @@ func init() {
 		log.Println("adding unique indexes to user_token_balances...")
 
 		// These unique indexes back the ON CONFLICT upserts in reconciler/store/pg.go.
-		// Because the identifier columns are nullable, PostgreSQL allows multiple NULL rows
-		// in a unique index (NULL != NULL), so rows without a given identifier do not conflict.
 		for _, idx := range utbIndexes {
 			if _, err := db.NewCreateIndex().
 				Model((*reconcilerstore.UserTokenBalanceDao)(nil)).

--- a/pkg/migrations/apidb/11_add_user_token_balances_indexes.go
+++ b/pkg/migrations/apidb/11_add_user_token_balances_indexes.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"log"
 
+	reconcilerstore "github.com/chainsafe/canton-middleware/pkg/reconciler/store"
+	mghelper "github.com/chainsafe/canton-middleware/pkg/pgutil/migrations"
+
 	"github.com/uptrace/bun"
 )
 
@@ -14,30 +17,17 @@ func init() {
 		// These unique indexes back the ON CONFLICT upserts in reconciler/store/pg.go.
 		// Because the identifier columns are nullable, PostgreSQL allows multiple NULL rows
 		// in a unique index (NULL != NULL), so rows without a given identifier do not conflict.
-		for _, ddl := range []string{
-			`CREATE UNIQUE INDEX IF NOT EXISTS idx_utb_fingerprint_token
-				ON user_token_balances (fingerprint, token_symbol)`,
-			`CREATE UNIQUE INDEX IF NOT EXISTS idx_utb_evm_address_token
-				ON user_token_balances (evm_address, token_symbol)`,
-			`CREATE UNIQUE INDEX IF NOT EXISTS idx_utb_canton_party_token
-				ON user_token_balances (canton_party_id, token_symbol)`,
-		} {
-			if _, err := db.ExecContext(ctx, ddl); err != nil {
-				return err
-			}
-		}
-		return nil
+		return mghelper.CreateModelUniqueIndexes(ctx, db, &reconcilerstore.UserTokenBalanceDao{},
+			"fingerprint,token_symbol",
+			"evm_address,token_symbol",
+			"canton_party_id,token_symbol",
+		)
 	}, func(ctx context.Context, db *bun.DB) error {
 		log.Println("dropping unique indexes from user_token_balances...")
-		for _, ddl := range []string{
-			`DROP INDEX IF EXISTS idx_utb_fingerprint_token`,
-			`DROP INDEX IF EXISTS idx_utb_evm_address_token`,
-			`DROP INDEX IF EXISTS idx_utb_canton_party_token`,
-		} {
-			if _, err := db.ExecContext(ctx, ddl); err != nil {
-				return err
-			}
-		}
-		return nil
+		return mghelper.DropModelIndexes(ctx, db, &reconcilerstore.UserTokenBalanceDao{},
+			"fingerprint,token_symbol",
+			"evm_address,token_symbol",
+			"canton_party_id,token_symbol",
+		)
 	})
 }

--- a/pkg/migrations/apidb/11_add_user_token_balances_indexes.go
+++ b/pkg/migrations/apidb/11_add_user_token_balances_indexes.go
@@ -5,10 +5,21 @@ import (
 	"log"
 
 	reconcilerstore "github.com/chainsafe/canton-middleware/pkg/reconciler/store"
-	mghelper "github.com/chainsafe/canton-middleware/pkg/pgutil/migrations"
 
 	"github.com/uptrace/bun"
 )
+
+// utbIndex describes a composite unique index on user_token_balances.
+type utbIndex struct {
+	name    string
+	columns []string
+}
+
+var utbIndexes = []utbIndex{
+	{"idx_utb_fingerprint_token", []string{"fingerprint", "token_symbol"}},
+	{"idx_utb_evm_address_token", []string{"evm_address", "token_symbol"}},
+	{"idx_utb_canton_party_token", []string{"canton_party_id", "token_symbol"}},
+}
 
 func init() {
 	Migrations.MustRegister(func(ctx context.Context, db *bun.DB) error {
@@ -17,17 +28,28 @@ func init() {
 		// These unique indexes back the ON CONFLICT upserts in reconciler/store/pg.go.
 		// Because the identifier columns are nullable, PostgreSQL allows multiple NULL rows
 		// in a unique index (NULL != NULL), so rows without a given identifier do not conflict.
-		return mghelper.CreateModelUniqueIndexes(ctx, db, &reconcilerstore.UserTokenBalanceDao{},
-			"fingerprint,token_symbol",
-			"evm_address,token_symbol",
-			"canton_party_id,token_symbol",
-		)
+		for _, idx := range utbIndexes {
+			if _, err := db.NewCreateIndex().
+				Model((*reconcilerstore.UserTokenBalanceDao)(nil)).
+				Index(idx.name).
+				Column(idx.columns...).
+				Unique().
+				IfNotExists().
+				Exec(ctx); err != nil {
+				return err
+			}
+		}
+		return nil
 	}, func(ctx context.Context, db *bun.DB) error {
 		log.Println("dropping unique indexes from user_token_balances...")
-		return mghelper.DropModelIndexes(ctx, db, &reconcilerstore.UserTokenBalanceDao{},
-			"fingerprint,token_symbol",
-			"evm_address,token_symbol",
-			"canton_party_id,token_symbol",
-		)
+		for _, idx := range utbIndexes {
+			if _, err := db.NewDropIndex().
+				Index(idx.name).
+				IfExists().
+				Exec(ctx); err != nil {
+				return err
+			}
+		}
+		return nil
 	})
 }

--- a/pkg/migrations/apidb/11_add_user_token_balances_indexes.go
+++ b/pkg/migrations/apidb/11_add_user_token_balances_indexes.go
@@ -1,0 +1,43 @@
+package apidb
+
+import (
+	"context"
+	"log"
+
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	Migrations.MustRegister(func(ctx context.Context, db *bun.DB) error {
+		log.Println("adding unique indexes to user_token_balances...")
+
+		// These unique indexes back the ON CONFLICT upserts in reconciler/store/pg.go.
+		// Because the identifier columns are nullable, PostgreSQL allows multiple NULL rows
+		// in a unique index (NULL != NULL), so rows without a given identifier do not conflict.
+		for _, ddl := range []string{
+			`CREATE UNIQUE INDEX IF NOT EXISTS idx_utb_fingerprint_token
+				ON user_token_balances (fingerprint, token_symbol)`,
+			`CREATE UNIQUE INDEX IF NOT EXISTS idx_utb_evm_address_token
+				ON user_token_balances (evm_address, token_symbol)`,
+			`CREATE UNIQUE INDEX IF NOT EXISTS idx_utb_canton_party_token
+				ON user_token_balances (canton_party_id, token_symbol)`,
+		} {
+			if _, err := db.ExecContext(ctx, ddl); err != nil {
+				return err
+			}
+		}
+		return nil
+	}, func(ctx context.Context, db *bun.DB) error {
+		log.Println("dropping unique indexes from user_token_balances...")
+		for _, ddl := range []string{
+			`DROP INDEX IF EXISTS idx_utb_fingerprint_token`,
+			`DROP INDEX IF EXISTS idx_utb_evm_address_token`,
+			`DROP INDEX IF EXISTS idx_utb_canton_party_token`,
+		} {
+			if _, err := db.ExecContext(ctx, ddl); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
# Problem

Migration 10_create_user_token_balances.go only calls CreateSchema, which creates the table but no unique indexes. Three ON CONFLICT clauses in pg.go require unique constraints that don't exist in the DB

```
/Users/arundhyani/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.darwin-amd64/src/runtime/proc.go:283
2026-04-01T18:52:04.236+0530	DEBUG	reconciler/reconciler.go:253	Updated user balances from holdings	{"party_id": "native_interop_2::1220ca015ab07c6d832b50dca28486cecf1bdc856deb81735441e731c6d3858b3aaa", "demo_balance": "0", "prompt_balance": "0"}
2026-04-01T18:52:04.238+0530	WARN	reconciler/reconciler.go:234	Failed to update DEMO balance	{"party_id": "native_interop_1::1220d0feac28475ae1f58f872a3d69677e650abb3b7dd2eef03c796669fa9af92c85", "error": "set balance for party native_interop_1::1220d0feac28475ae1f58f872a3d69677e650abb3b7dd2eef03c796669fa9af92c85 token DEMO: ERROR: there is no unique or exclusion constraint matching the ON CONFLICT specification (SQLSTATE=42P10)"}
github.com/chainsafe/canton-middleware/pkg/reconciler.(*Reconciler).ReconcileUserBalancesFromHoldings
	/Users/arundhyani/Stuff/Project/canton/canton-middleware/pkg/reconciler/reconciler.go:234
main.main
	/Users/arundhyani/Stuff/Project/canton/canton-middleware/scripts/testing/interop-demo.go:220
runtime.main
```


# Solution

Add the indexes in migration
