### PR TITLE
feat: GET /user endpoint with EIP-191 login signature

### DIFF
--- a/pkg/user/service/http.go
+++ b/pkg/user/service/http.go
@@ -30,6 +30,7 @@ func RegisterRoutes(r chi.Router, service Service, logger *zap.Logger) {
 
 	r.Post("/register", apphttp.HandleError(h.register))
 	r.Post("/register/prepare-topology", apphttp.HandleError(h.prepareTopology))
+	r.Get("/user", apphttp.HandleError(h.getUser))
 }
 
 // register handles HTTP requests
@@ -107,6 +108,32 @@ func (h *HTTP) prepareTopology(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	resp, err := h.service.PrepareExternalRegistration(r.Context(), &req)
+	if err != nil {
+		return err
+	}
+
+	h.writeJSON(w, http.StatusOK, resp)
+	return nil
+}
+
+// getUser handles GET /user?address=0x... and returns the registered user profile.
+// The caller must provide an EIP-191 signature over the message via X-Signature and
+// X-Message headers. Credentials are kept out of query params to avoid leaking them
+// into server access logs, CDN logs, and browser history.
+// Returns 404 if the address is not registered.
+func (h *HTTP) getUser(w http.ResponseWriter, r *http.Request) error {
+	address := r.URL.Query().Get("address")
+	if address == "" {
+		return apperrors.BadRequestError(nil, "address query parameter required")
+	}
+
+	signature := r.Header.Get("X-Signature")
+	message := r.Header.Get("X-Message")
+	if signature == "" || message == "" {
+		return apperrors.UnAuthorizedError(nil, "X-Signature and X-Message headers required")
+	}
+
+	resp, err := h.service.GetUser(r.Context(), address, message, signature)
 	if err != nil {
 		return err
 	}

--- a/pkg/user/service/http_test.go
+++ b/pkg/user/service/http_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap"
 
+	apperrors "github.com/chainsafe/canton-middleware/pkg/app/errors"
 	"github.com/chainsafe/canton-middleware/pkg/user"
 	"github.com/chainsafe/canton-middleware/pkg/user/service/mocks"
 )
@@ -141,5 +142,126 @@ func TestRegisterHTTP_CantonNative_ResponseCheck(t *testing.T) {
 	}
 	if got.EVMAddress != "0xabc" {
 		t.Fatalf("expected evm_address %q, got %q", "0xabc", got.EVMAddress)
+	}
+}
+
+func TestGetUserHTTP_MissingAddress_ReturnsBadRequest(t *testing.T) {
+	svc := mocks.NewService(t)
+	handler := newRegisterTestServer(svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/user", nil)
+	req.Header.Set("X-Signature", "0xsig")
+	req.Header.Set("X-Message", "login:0xabc:1234567890")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, rec.Code)
+	}
+}
+
+func TestGetUserHTTP_MissingHeaders_ReturnsUnauthorized(t *testing.T) {
+	svc := mocks.NewService(t)
+	handler := newRegisterTestServer(svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/user?address=0xabc", nil)
+	// no X-Signature / X-Message headers
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status %d, got %d", http.StatusUnauthorized, rec.Code)
+	}
+
+	var got struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("failed to decode response JSON: %v", err)
+	}
+	if got.Error != "X-Signature and X-Message headers required" {
+		t.Fatalf("unexpected error %q", got.Error)
+	}
+}
+
+func TestGetUserHTTP_ValidHeaders_ReturnsUser(t *testing.T) {
+	svc := mocks.NewService(t)
+	svc.EXPECT().
+		GetUser(mock.Anything, "0xabc", "login:0xabc:1234567890", "0xsig").
+		Return(&user.User{EVMAddress: "0xabc", CantonParty: "party::xyz"}, nil)
+	handler := newRegisterTestServer(svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/user?address=0xabc", nil)
+	req.Header.Set("X-Signature", "0xsig")
+	req.Header.Set("X-Message", "login:0xabc:1234567890")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+
+	var got user.User
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("failed to decode response JSON: %v", err)
+	}
+	if got.EVMAddress != "0xabc" {
+		t.Fatalf("expected evm_address %q, got %q", "0xabc", got.EVMAddress)
+	}
+}
+
+func TestGetUserHTTP_ServiceReturnsNotFound_Returns404(t *testing.T) {
+	svc := mocks.NewService(t)
+	svc.EXPECT().
+		GetUser(mock.Anything, "0xabc", "login:0xabc:1234567890", "0xsig").
+		Return(nil, apperrors.ResourceNotFoundError(nil, "user not found"))
+	handler := newRegisterTestServer(svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/user?address=0xabc", nil)
+	req.Header.Set("X-Signature", "0xsig")
+	req.Header.Set("X-Message", "login:0xabc:1234567890")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected status %d, got %d", http.StatusNotFound, rec.Code)
+	}
+
+	var got struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("failed to decode response JSON: %v", err)
+	}
+	if got.Error != "user not found" {
+		t.Fatalf("expected error %q, got %q", "user not found", got.Error)
+	}
+}
+
+func TestGetUserHTTP_ServiceReturnsUnauthorized_Returns401(t *testing.T) {
+	svc := mocks.NewService(t)
+	svc.EXPECT().
+		GetUser(mock.Anything, "0xabc", "login:0xabc:1234567890", "0xsig").
+		Return(nil, apperrors.UnAuthorizedError(nil, "invalid signature"))
+	handler := newRegisterTestServer(svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/user?address=0xabc", nil)
+	req.Header.Set("X-Signature", "0xsig")
+	req.Header.Set("X-Message", "login:0xabc:1234567890")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status %d, got %d", http.StatusUnauthorized, rec.Code)
+	}
+
+	var got struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("failed to decode response JSON: %v", err)
+	}
+	if got.Error != "invalid signature" {
+		t.Fatalf("expected error %q, got %q", "invalid signature", got.Error)
 	}
 }

--- a/pkg/user/service/log.go
+++ b/pkg/user/service/log.go
@@ -163,6 +163,36 @@ func (ls *logService) PrepareExternalRegistration(
 	return ls.svc.PrepareExternalRegistration(ctx, req)
 }
 
+func (ls *logService) GetUser(ctx context.Context, evmAddress, msg, sig string) (usr *user.User, err error) {
+	start := time.Now()
+	// Execute the actual service method
+	defer func() {
+		duration := time.Since(start)
+
+		if err != nil {
+			// Log error case
+			ls.logger.Error("GetUser failed",
+				zap.String("service", serviceName),
+				zap.String("method", "GetUser"),
+				zap.String("evmAddress", evmAddress),
+				zap.Duration("duration", duration),
+				zap.Error(err),
+			)
+		} else {
+			// Log success case
+			// Log method entry
+			ls.logger.Info("Get User",
+				zap.String("service", serviceName),
+				zap.String("method", "GetUser"),
+				zap.String("evmAddress", evmAddress),
+				zap.Duration("duration", duration),
+			)
+		}
+	}()
+
+	return ls.svc.GetUser(ctx, evmAddress, msg, sig)
+}
+
 // Helper functions for sensitive data redaction
 
 // truncateString limits string length for logging to prevent log spam

--- a/pkg/user/service/log.go
+++ b/pkg/user/service/log.go
@@ -165,26 +165,29 @@ func (ls *logService) PrepareExternalRegistration(
 
 func (ls *logService) GetUser(ctx context.Context, evmAddress, msg, sig string) (usr *user.User, err error) {
 	start := time.Now()
-	// Execute the actual service method
+
+	ls.logger.Info("GetUser started",
+		zap.String("service", serviceName),
+		zap.String("method", "GetUser"),
+		zap.String("evm_address", evmAddress),
+	)
+
 	defer func() {
 		duration := time.Since(start)
 
 		if err != nil {
-			// Log error case
 			ls.logger.Error("GetUser failed",
 				zap.String("service", serviceName),
 				zap.String("method", "GetUser"),
-				zap.String("evmAddress", evmAddress),
+				zap.String("evm_address", evmAddress),
 				zap.Duration("duration", duration),
 				zap.Error(err),
 			)
 		} else {
-			// Log success case
-			// Log method entry
-			ls.logger.Info("Get User",
+			ls.logger.Info("GetUser completed",
 				zap.String("service", serviceName),
 				zap.String("method", "GetUser"),
-				zap.String("evmAddress", evmAddress),
+				zap.String("evm_address", evmAddress),
 				zap.Duration("duration", duration),
 			)
 		}

--- a/pkg/user/service/mocks/mock_service.go
+++ b/pkg/user/service/mocks/mock_service.go
@@ -23,6 +23,67 @@ func (_m *Service) EXPECT() *Service_Expecter {
 	return &Service_Expecter{mock: &_m.Mock}
 }
 
+// GetUser provides a mock function with given fields: ctx, evmAddress, msg, sig
+func (_m *Service) GetUser(ctx context.Context, evmAddress string, msg string, sig string) (*user.User, error) {
+	ret := _m.Called(ctx, evmAddress, msg, sig)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUser")
+	}
+
+	var r0 *user.User
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) (*user.User, error)); ok {
+		return rf(ctx, evmAddress, msg, sig)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) *user.User); ok {
+		r0 = rf(ctx, evmAddress, msg, sig)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*user.User)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
+		r1 = rf(ctx, evmAddress, msg, sig)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Service_GetUser_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUser'
+type Service_GetUser_Call struct {
+	*mock.Call
+}
+
+// GetUser is a helper method to define mock.On call
+//   - ctx context.Context
+//   - evmAddress string
+//   - msg string
+//   - sig string
+func (_e *Service_Expecter) GetUser(ctx interface{}, evmAddress interface{}, msg interface{}, sig interface{}) *Service_GetUser_Call {
+	return &Service_GetUser_Call{Call: _e.mock.On("GetUser", ctx, evmAddress, msg, sig)}
+}
+
+func (_c *Service_GetUser_Call) Run(run func(ctx context.Context, evmAddress string, msg string, sig string)) *Service_GetUser_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string))
+	})
+	return _c
+}
+
+func (_c *Service_GetUser_Call) Return(_a0 *user.User, _a1 error) *Service_GetUser_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Service_GetUser_Call) RunAndReturn(run func(context.Context, string, string, string) (*user.User, error)) *Service_GetUser_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // PrepareExternalRegistration provides a mock function with given fields: ctx, req
 func (_m *Service) PrepareExternalRegistration(ctx context.Context, req *user.RegisterRequest) (*user.PrepareTopologyResponse, error) {
 	ret := _m.Called(ctx, req)

--- a/pkg/user/service/mocks/mock_store.go
+++ b/pkg/user/service/mocks/mock_store.go
@@ -176,6 +176,65 @@ func (_c *Store_GetUserByCantonPartyID_Call) RunAndReturn(run func(context.Conte
 	return _c
 }
 
+// GetUserByEVMAddress provides a mock function with given fields: ctx, evmAddress
+func (_m *Store) GetUserByEVMAddress(ctx context.Context, evmAddress string) (*user.User, error) {
+	ret := _m.Called(ctx, evmAddress)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUserByEVMAddress")
+	}
+
+	var r0 *user.User
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*user.User, error)); ok {
+		return rf(ctx, evmAddress)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) *user.User); ok {
+		r0 = rf(ctx, evmAddress)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*user.User)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, evmAddress)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Store_GetUserByEVMAddress_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUserByEVMAddress'
+type Store_GetUserByEVMAddress_Call struct {
+	*mock.Call
+}
+
+// GetUserByEVMAddress is a helper method to define mock.On call
+//   - ctx context.Context
+//   - evmAddress string
+func (_e *Store_Expecter) GetUserByEVMAddress(ctx interface{}, evmAddress interface{}) *Store_GetUserByEVMAddress_Call {
+	return &Store_GetUserByEVMAddress_Call{Call: _e.mock.On("GetUserByEVMAddress", ctx, evmAddress)}
+}
+
+func (_c *Store_GetUserByEVMAddress_Call) Run(run func(ctx context.Context, evmAddress string)) *Store_GetUserByEVMAddress_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *Store_GetUserByEVMAddress_Call) Return(_a0 *user.User, _a1 error) *Store_GetUserByEVMAddress_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Store_GetUserByEVMAddress_Call) RunAndReturn(run func(context.Context, string) (*user.User, error)) *Store_GetUserByEVMAddress_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // IsWhitelisted provides a mock function with given fields: ctx, evmAddress
 func (_m *Store) IsWhitelisted(ctx context.Context, evmAddress string) (bool, error) {
 	ret := _m.Called(ctx, evmAddress)

--- a/pkg/user/service/service.go
+++ b/pkg/user/service/service.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
@@ -31,6 +32,10 @@ const (
 
 	// cantonKeySize is the required size for Canton private keys (32 bytes for secp256k1)
 	cantonKeySize = 32
+
+	// loginMessageMaxAge is the maximum age accepted for a GET /user login message.
+	// Must match SESSION_MAX_AGE_MS in the dapp's session.ts.
+	loginMessageMaxAge = 24 * time.Hour
 )
 
 var (
@@ -50,6 +55,7 @@ type Store interface {
 	IsWhitelisted(ctx context.Context, evmAddress string) (bool, error)
 	CreateUser(ctx context.Context, user *user.User) error
 	GetUserByCantonPartyID(ctx context.Context, partyID string) (*user.User, error)
+	GetUserByEVMAddress(ctx context.Context, evmAddress string) (*user.User, error)
 	DeleteUser(ctx context.Context, evmAddress string) error
 }
 
@@ -60,6 +66,7 @@ type Service interface {
 	RegisterWeb3User(ctx context.Context, req *user.RegisterRequest) (*user.RegisterResponse, error)
 	RegisterCantonNativeUser(ctx context.Context, req *user.RegisterRequest) (*user.RegisterResponse, error)
 	PrepareExternalRegistration(ctx context.Context, req *user.RegisterRequest) (*user.PrepareTopologyResponse, error)
+	GetUser(ctx context.Context, evmAddress, msg, sig string) (*user.User, error)
 }
 
 type registrationService struct {
@@ -456,6 +463,28 @@ func (s *registrationService) PrepareExternalRegistration(
 		PublicKeyFingerprint: topology.Fingerprint,
 		RegistrationToken:    registrationToken,
 	}, nil
+}
+
+func (s *registrationService) GetUser(ctx context.Context, evmAddress, msg, sig string) (*user.User, error) {
+	recoveredAddr, err := auth.VerifyEIP191Signature(msg, sig)
+	if err != nil {
+		return nil, apperrors.UnAuthorizedError(err, "invalid signature")
+	}
+	if !strings.EqualFold(recoveredAddr.Hex(), evmAddress) {
+		return nil, apperrors.UnAuthorizedError(nil, "signature does not match address")
+	}
+	if err = auth.ValidateTimedMessage(msg, loginMessageMaxAge); err != nil {
+		return nil, apperrors.UnAuthorizedError(err, "message expired or malformed")
+	}
+
+	usr, err := s.store.GetUserByEVMAddress(ctx, evmAddress)
+	if err != nil && !errors.Is(err, user.ErrUserNotFound) {
+		return nil, fmt.Errorf("failed to get user: %w", err)
+	}
+	if usr == nil {
+		return nil, apperrors.ResourceNotFoundError(err, "user not found")
+	}
+	return usr, nil
 }
 
 // compressedKeyToSPKI derives an SPKI DER public key from a hex-encoded compressed secp256k1 public key.

--- a/pkg/user/service/service.go
+++ b/pkg/user/service/service.go
@@ -466,6 +466,7 @@ func (s *registrationService) PrepareExternalRegistration(
 }
 
 func (s *registrationService) GetUser(ctx context.Context, evmAddress, msg, sig string) (*user.User, error) {
+	evmAddress = auth.NormalizeAddress(evmAddress)
 	recoveredAddr, err := auth.VerifyEIP191Signature(msg, sig)
 	if err != nil {
 		return nil, apperrors.UnAuthorizedError(err, "invalid signature")

--- a/pkg/user/service/service_test.go
+++ b/pkg/user/service/service_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"go.uber.org/zap"
@@ -183,5 +184,127 @@ func TestRegistrationService_RegisterCantonNativeUser_PartyAlreadyRegistered(t *
 	}
 	if !apperrors.Is(err, apperrors.CategoryDataConflict) {
 		t.Fatalf("expected CategoryDataConflict, got %v", err)
+	}
+}
+
+// signLoginMessage creates a valid timed EIP-191 login message and signature.
+// offsetFromNow shifts the embedded timestamp by the given duration (use a negative
+// value to simulate an expired message).
+func signLoginMessage(t *testing.T, offsetFromNow time.Duration) (evmAddress, message, signature string) {
+	t.Helper()
+
+	privateKey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey() failed: %v", err)
+	}
+
+	ts := time.Now().Add(offsetFromNow).Unix()
+	addr := auth.NormalizeAddress(crypto.PubkeyToAddress(privateKey.PublicKey).Hex())
+	message = fmt.Sprintf("login:%s:%d", strings.ToLower(addr), ts)
+
+	prefixed := fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", len(message), message)
+	hash := crypto.Keccak256Hash([]byte(prefixed))
+
+	sig, err := crypto.Sign(hash.Bytes(), privateKey)
+	if err != nil {
+		t.Fatalf("Sign() failed: %v", err)
+	}
+
+	return addr, message, "0x" + hex.EncodeToString(sig)
+}
+
+func TestGetUser_Success(t *testing.T) {
+	ctx := context.Background()
+	evmAddress, message, signature := signLoginMessage(t, 0)
+
+	expected := &user.User{EVMAddress: evmAddress, CantonParty: "party::abc"}
+	storeMock := mocks.NewStore(t)
+	storeMock.EXPECT().GetUserByEVMAddress(ctx, evmAddress).Return(expected, nil).Once()
+
+	svc := NewService(storeMock, nil, nil, zap.NewNop(), false, false, nil)
+	got, err := svc.GetUser(ctx, evmAddress, message, signature)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got.EVMAddress != evmAddress {
+		t.Fatalf("expected address %s, got %s", evmAddress, got.EVMAddress)
+	}
+}
+
+func TestGetUser_ExpiredMessage(t *testing.T) {
+	ctx := context.Background()
+	// Timestamp 25 hours in the past — beyond the 24-hour loginMessageMaxAge.
+	evmAddress, message, signature := signLoginMessage(t, -25*time.Hour)
+
+	svc := NewService(nil, nil, nil, zap.NewNop(), false, false, nil)
+	_, err := svc.GetUser(ctx, evmAddress, message, signature)
+	if err == nil {
+		t.Fatal("expected unauthorized error for expired message, got nil")
+	}
+	if !apperrors.Is(err, apperrors.CategoryUnauthorized) {
+		t.Fatalf("expected CategoryUnauthorized, got %v", err)
+	}
+}
+
+func TestGetUser_WrongAddress(t *testing.T) {
+	ctx := context.Background()
+	_, message, signature := signLoginMessage(t, 0)
+	otherAddress := "0x000000000000000000000000000000000000dEaD"
+
+	svc := NewService(nil, nil, nil, zap.NewNop(), false, false, nil)
+	_, err := svc.GetUser(ctx, otherAddress, message, signature)
+	if err == nil {
+		t.Fatal("expected unauthorized error for mismatched address, got nil")
+	}
+	if !apperrors.Is(err, apperrors.CategoryUnauthorized) {
+		t.Fatalf("expected CategoryUnauthorized, got %v", err)
+	}
+}
+
+func TestGetUser_UserNotFound(t *testing.T) {
+	ctx := context.Background()
+	evmAddress, message, signature := signLoginMessage(t, 0)
+
+	storeMock := mocks.NewStore(t)
+	storeMock.EXPECT().GetUserByEVMAddress(ctx, evmAddress).Return(nil, user.ErrUserNotFound).Once()
+
+	svc := NewService(storeMock, nil, nil, zap.NewNop(), false, false, nil)
+	_, err := svc.GetUser(ctx, evmAddress, message, signature)
+	if err == nil {
+		t.Fatal("expected not-found error, got nil")
+	}
+	if !apperrors.Is(err, apperrors.CategoryResourceNotFound) {
+		t.Fatalf("expected CategoryNotFound, got %v", err)
+	}
+}
+
+func TestGetUser_InvalidSignature(t *testing.T) {
+	ctx := context.Background()
+
+	svc := NewService(nil, nil, nil, zap.NewNop(), false, false, nil)
+	_, err := svc.GetUser(ctx, "0xdeadbeef", "some message", "not-a-valid-signature")
+	if err == nil {
+		t.Fatal("expected unauthorized error for invalid signature, got nil")
+	}
+	if !apperrors.Is(err, apperrors.CategoryUnauthorized) {
+		t.Fatalf("expected CategoryUnauthorized, got %v", err)
+	}
+}
+
+func TestGetUser_StoreError(t *testing.T) {
+	ctx := context.Background()
+	evmAddress, message, signature := signLoginMessage(t, 0)
+	storeErr := errors.New("connection refused")
+
+	storeMock := mocks.NewStore(t)
+	storeMock.EXPECT().GetUserByEVMAddress(ctx, evmAddress).Return(nil, storeErr).Once()
+
+	svc := NewService(storeMock, nil, nil, zap.NewNop(), false, false, nil)
+	_, err := svc.GetUser(ctx, evmAddress, message, signature)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, storeErr) {
+		t.Fatalf("expected store error to be wrapped, got %v", err)
 	}
 }

--- a/pkg/user/user.go
+++ b/pkg/user/user.go
@@ -15,15 +15,15 @@ const (
 
 // User represents the domain model for a registered user.
 type User struct {
-	EVMAddress                 string
-	CantonParty                string
-	Fingerprint                string
-	MappingCID                 string
-	CantonPartyID              string
-	CantonKeyCreatedAt         *time.Time
-	CantonPrivateKeyEncrypted  string
-	KeyMode                    string // "custodial" or "external"
-	CantonPublicKeyFingerprint string // For external users: Canton multihash fingerprint
+	EVMAddress                 string     `json:"evm_address"`
+	CantonParty                string     `json:"canton_party"`
+	Fingerprint                string     `json:"fingerprint"`
+	MappingCID                 string     `json:"mapping_cid"`
+	CantonPartyID              string     `json:"-"`
+	CantonKeyCreatedAt         *time.Time `json:"-"`
+	CantonPrivateKeyEncrypted  string     `json:"-"`
+	KeyMode                    string     `json:"key_mode"` // "custodial" or "external"
+	CantonPublicKeyFingerprint string     `json:"-"`        // For external users: Canton multihash fingerprint
 }
 
 // New creates a custodial User from the given parameters.

--- a/pkg/userstore/pg.go
+++ b/pkg/userstore/pg.go
@@ -39,7 +39,7 @@ func (s *pgStore) CreateUser(ctx context.Context, usr *user.User) error {
 
 func (s *pgStore) getUserBy(ctx context.Context, column string, value string) (*user.User, error) {
 	dao := new(UserDao)
-	query := s.db.NewSelect().Model(dao).Where("LOWER("+column+") = LOWER(?)", value)
+	query := s.db.NewSelect().Model(dao).Where("? = ?", bun.Ident(column), value)
 
 	err := query.Scan(ctx)
 	if err != nil {

--- a/pkg/userstore/pg.go
+++ b/pkg/userstore/pg.go
@@ -39,7 +39,7 @@ func (s *pgStore) CreateUser(ctx context.Context, usr *user.User) error {
 
 func (s *pgStore) getUserBy(ctx context.Context, column string, value string) (*user.User, error) {
 	dao := new(UserDao)
-	query := s.db.NewSelect().Model(dao).Where(column+" = ?", value)
+	query := s.db.NewSelect().Model(dao).Where("LOWER("+column+") = LOWER(?)", value)
 
 	err := query.Scan(ctx)
 	if err != nil {


### PR DESCRIPTION
Closes #235

## Summary

- Adds `GET /user?address=0x…` endpoint to `pkg/user/service/http.go` — returns the registered user profile (Canton party ID, fingerprint, mapping CID, key mode) for a connected wallet.
- Adds `GetUser` to the `Service` interface and implements it in `service.go` with EIP-191 signature recovery, address matching, and a 24-hour timestamp replay guard.
- Adds structured `zap` logging for the new method in `log.go`.
- Regenerates `mocks/mock_service.go` and `mocks/mock_store.go` to cover the new `GetUser` and `GetUserByEVMAddress` signatures.
- Full unit-test coverage in `service_test.go` and `http_test.go`: happy path, expired message, wrong address, invalid signature, store error, 404, and 401 cases.

## Test plan

- [x] `go test ./pkg/user/service/...` passes (all `TestGetUser*` and `TestGetUserHTTP*` cases green).
- [x] `GET /user?address=<addr>` with valid `X-Signature` / `X-Message` headers returns `200` with correct profile fields.
- [x] Expired message (> 24 h old timestamp) returns `401`.
- [x] Address not registered returns `404`.
- [x] Signature from a different key returns `401`.