### PR TITLE
feat(cantonsdk/token): add TransferInternalByPartyID for internal Canton party transfers

### DIFF
--- a/pkg/cantonsdk/token/client.go
+++ b/pkg/cantonsdk/token/client.go
@@ -70,9 +70,17 @@ type Token interface {
 	// idempotencyKey is used as the Canton CommandId for idempotent submission.
 	TransferByFingerprint(ctx context.Context, idempotencyKey, fromFingerprint, toFingerprint, amount, tokenSymbol string) error
 
-	// TransferByPartyID transfers tokens by party IDs.
+	// TransferByPartyID transfers tokens by party IDs using Interactive Submission.
 	// idempotencyKey is used as the Canton CommandId for idempotent submission.
+	// Requires a KeyResolver configured via WithKeyResolver (external/secp256k1 parties only).
 	TransferByPartyID(ctx context.Context, idempotencyKey, fromParty, toParty, amount, tokenSymbol string) error
+
+	// TransferInternalByPartyID transfers tokens for an internal Canton party using
+	// regular command submission (SubmitAndWaitForTransaction). Unlike TransferByPartyID,
+	// no KeyResolver is required — the Canton node holds the signing key. Use this for
+	// issuer or bridge parties that are not registered with an external secp256k1 key.
+	// idempotencyKey is used as the Canton CommandId for idempotent submission.
+	TransferInternalByPartyID(ctx context.Context, idempotencyKey, fromParty, toParty, amount, tokenSymbol string) error
 
 	// GetTokenTransferEvents returns all active CIP56.Events.TokenTransferEvent contracts visible to relayerParty.
 	GetTokenTransferEvents(ctx context.Context) ([]*TokenTransferEvent, error)
@@ -368,6 +376,60 @@ func (c *Client) GetTotalSupply(ctx context.Context, tokenSymbol string) (string
 	}
 
 	return total, nil
+}
+
+func (c *Client) TransferInternalByPartyID(ctx context.Context, idempotencyKey, fromParty, toParty, amount, tokenSymbol string) error {
+	if idempotencyKey == "" {
+		return fmt.Errorf("idempotencyKey is required")
+	}
+	if fromParty == "" || toParty == "" {
+		return fmt.Errorf("from/to party is required")
+	}
+	if amount == "" {
+		return fmt.Errorf("amount is required")
+	}
+	if tokenSymbol == "" {
+		return fmt.Errorf("token symbol is required")
+	}
+
+	holdings, err := c.GetHoldings(ctx, fromParty, tokenSymbol)
+	if err != nil {
+		return err
+	}
+	selected, err := selectHoldingsForTransfer(holdings, amount)
+	if err != nil {
+		return fmt.Errorf("select holdings for transfer: %w", err)
+	}
+
+	factoryCID, err := c.getTransferFactoryCID(ctx)
+	if err != nil {
+		return err
+	}
+
+	req := &transferFactoryRequest{
+		CommandID:        idempotencyKey,
+		FromPartyID:      fromParty,
+		ToPartyID:        toParty,
+		Amount:           amount,
+		InstrumentAdmin:  selected.InstrumentAdmin,
+		InstrumentID:     selected.InstrumentID,
+		InputHoldingCIDs: selected.CIDs,
+		FactoryCID:       factoryCID,
+	}
+
+	cmd := c.buildTransferCommand(req)
+	authCtx := c.ledger.AuthContext(ctx)
+	_, err = c.ledger.Command().SubmitAndWaitForTransaction(authCtx, &lapiv2.SubmitAndWaitForTransactionRequest{
+		Commands: &lapiv2.Commands{
+			SynchronizerId: c.cfg.DomainID,
+			CommandId:      idempotencyKey,
+			UserId:         c.cfg.UserID,
+			ActAs:          []string{fromParty},
+			ReadAs:         []string{c.cfg.IssuerParty},
+			Commands:       []*lapiv2.Command{cmd},
+		},
+	})
+	return err
 }
 
 func (c *Client) TransferByFingerprint(ctx context.Context, idempotencyKey, fromFingerprint,

--- a/pkg/token/mocks/mock_canton_token.go
+++ b/pkg/token/mocks/mock_canton_token.go
@@ -798,6 +798,57 @@ func (_c *Token_TransferByPartyID_Call) RunAndReturn(run func(context.Context, s
 	return _c
 }
 
+// TransferInternalByPartyID provides a mock function with given fields: ctx, idempotencyKey, fromParty, toParty, amount, tokenSymbol
+func (_m *Token) TransferInternalByPartyID(ctx context.Context, idempotencyKey string, fromParty string, toParty string, amount string, tokenSymbol string) error {
+	ret := _m.Called(ctx, idempotencyKey, fromParty, toParty, amount, tokenSymbol)
+
+	if len(ret) == 0 {
+		panic("no return value specified for TransferInternalByPartyID")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, string) error); ok {
+		r0 = rf(ctx, idempotencyKey, fromParty, toParty, amount, tokenSymbol)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Token_TransferInternalByPartyID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'TransferInternalByPartyID'
+type Token_TransferInternalByPartyID_Call struct {
+	*mock.Call
+}
+
+// TransferInternalByPartyID is a helper method to define mock.On call
+//   - ctx context.Context
+//   - idempotencyKey string
+//   - fromParty string
+//   - toParty string
+//   - amount string
+//   - tokenSymbol string
+func (_e *Token_Expecter) TransferInternalByPartyID(ctx interface{}, idempotencyKey interface{}, fromParty interface{}, toParty interface{}, amount interface{}, tokenSymbol interface{}) *Token_TransferInternalByPartyID_Call {
+	return &Token_TransferInternalByPartyID_Call{Call: _e.mock.On("TransferInternalByPartyID", ctx, idempotencyKey, fromParty, toParty, amount, tokenSymbol)}
+}
+
+func (_c *Token_TransferInternalByPartyID_Call) Run(run func(ctx context.Context, idempotencyKey string, fromParty string, toParty string, amount string, tokenSymbol string)) *Token_TransferInternalByPartyID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].(string), args[5].(string))
+	})
+	return _c
+}
+
+func (_c *Token_TransferInternalByPartyID_Call) Return(_a0 error) *Token_TransferInternalByPartyID_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Token_TransferInternalByPartyID_Call) RunAndReturn(run func(context.Context, string, string, string, string, string) error) *Token_TransferInternalByPartyID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewToken creates a new instance of Token. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewToken(t interface {

--- a/pkg/transfer/mocks/mock_canton_token.go
+++ b/pkg/transfer/mocks/mock_canton_token.go
@@ -798,6 +798,57 @@ func (_c *Token_TransferByPartyID_Call) RunAndReturn(run func(context.Context, s
 	return _c
 }
 
+// TransferInternalByPartyID provides a mock function with given fields: ctx, idempotencyKey, fromParty, toParty, amount, tokenSymbol
+func (_m *Token) TransferInternalByPartyID(ctx context.Context, idempotencyKey string, fromParty string, toParty string, amount string, tokenSymbol string) error {
+	ret := _m.Called(ctx, idempotencyKey, fromParty, toParty, amount, tokenSymbol)
+
+	if len(ret) == 0 {
+		panic("no return value specified for TransferInternalByPartyID")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, string) error); ok {
+		r0 = rf(ctx, idempotencyKey, fromParty, toParty, amount, tokenSymbol)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Token_TransferInternalByPartyID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'TransferInternalByPartyID'
+type Token_TransferInternalByPartyID_Call struct {
+	*mock.Call
+}
+
+// TransferInternalByPartyID is a helper method to define mock.On call
+//   - ctx context.Context
+//   - idempotencyKey string
+//   - fromParty string
+//   - toParty string
+//   - amount string
+//   - tokenSymbol string
+func (_e *Token_Expecter) TransferInternalByPartyID(ctx interface{}, idempotencyKey interface{}, fromParty interface{}, toParty interface{}, amount interface{}, tokenSymbol interface{}) *Token_TransferInternalByPartyID_Call {
+	return &Token_TransferInternalByPartyID_Call{Call: _e.mock.On("TransferInternalByPartyID", ctx, idempotencyKey, fromParty, toParty, amount, tokenSymbol)}
+}
+
+func (_c *Token_TransferInternalByPartyID_Call) Run(run func(ctx context.Context, idempotencyKey string, fromParty string, toParty string, amount string, tokenSymbol string)) *Token_TransferInternalByPartyID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].(string), args[5].(string))
+	})
+	return _c
+}
+
+func (_c *Token_TransferInternalByPartyID_Call) Return(_a0 error) *Token_TransferInternalByPartyID_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Token_TransferInternalByPartyID_Call) RunAndReturn(run func(context.Context, string, string, string, string, string) error) *Token_TransferInternalByPartyID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewToken creates a new instance of Token. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewToken(t interface {


### PR DESCRIPTION
## Summary

- Adds `TransferInternalByPartyID` to the `Token` interface and `*Client` in `pkg/cantonsdk/token`
- Submits `TransferFactory_Transfer` via `SubmitAndWaitForTransaction` (same as `Mint`/`Burn`) — no `KeyResolver` required
- Reuses existing internal helpers: `selectHoldingsForTransfer`, `getTransferFactoryCID`, `buildTransferCommand`
- Regenerates mocks in `pkg/token/mocks/` and `pkg/transfer/mocks/`

Closes #247

## Context

`TransferByPartyID` routes through Interactive Submission and always requires a secp256k1 `KeyResolver`. This works for external (non-custodial) parties but not for internal Canton parties like the P2 USDCx issuer or P1 bridge party, whose keys are managed by the Canton node.

`TransferInternalByPartyID` fills that gap — same contract-level logic, plain JWT-auth submission.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/token/... ./pkg/transfer/...` passes