### PR TITLE
feat: dApp/Snap testing utilities and guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ Key Canton-specific fields (auto-detected by bootstrap):
 
 | Document | Description |
 |----------|-------------|
+| [dApp & Snap Testing](docs/DAPP_SNAP_TESTING.md) | Testing with the Wayfinder dApp and MetaMask Snap |
 | [Local Interop Testing](docs/LOCAL_INTEROP_TESTING.md) | Full local bootstrap and 8-step interop test guide |
 | [API Documentation](docs/API_DOCUMENTATION.md) | Endpoint reference (JSON-RPC, Registration, Splice Registry) |
 | [Architecture](docs/ARCHITECTURE.md) | System design and data flows |

--- a/docs/DAPP_SNAP_TESTING.md
+++ b/docs/DAPP_SNAP_TESTING.md
@@ -1,0 +1,66 @@
+# Testing with the Wayfinder dApp and MetaMask Snap
+
+This guide covers the steps to run the Canton Middleware locally and connect it to the dApp and MetaMask Snap 
+for end-to-end testing.
+
+> **Full testing guide:** Complete setup instructions for the Snap and dApp side are maintained in the Canton Snap repository:
+> [github.com/ChainSafe/canton-snap — Testing with Middleware](https://github.com/ChainSafe/canton-snap/blob/main/docs/testing-with-middleware.md)
+
+---
+
+## 1. Start the Middleware
+
+```bash
+make docker-up
+```
+
+This builds and starts the full local stack: Canton node, API server, indexer, relayer, Anvil, and all supporting services. Wait for all containers to report healthy before proceeding.
+
+---
+
+## 2. Whitelist an Address
+
+The API server requires addresses to be whitelisted before registration. Run the interactive utility and enter the EVM address you want to allow:
+
+```bash
+go run scripts/utils/whitelist.go
+```
+
+To whitelist non-interactively:
+
+```bash
+go run scripts/utils/whitelist.go -address 0xYourAddress -note "tester"
+```
+
+---
+
+## 3. Fund an Address
+
+Once the address is registered through the dApp (or Snap), mint DEMO and PROMPT tokens to it:
+
+```bash
+go run scripts/utils/fund-wallet.go
+```
+
+The script connects to the running stack automatically, prompts for the EVM address and amount, and mints to the corresponding Canton party.
+
+---
+
+## 4. Verify on the dApp
+
+With tokens minted, open the dApp and connect MetaMask using the local network:
+
+| Setting | Value |
+|---------|-------|
+| RPC URL | `http://localhost:8081/eth` |
+| Chain ID | `31337` |
+
+Balances and transfers should be visible immediately. Use the Snap to sign Canton transfers and confirm the balance updates reflect on both the dApp and the indexer.
+
+---
+
+## MetaMask Configuration
+
+| Network Name | RPC URL | Chain ID | Currency Symbol |
+|---|---|---|---|
+| Canton Local | `http://localhost:8081/eth` | 31337 | ETH |

--- a/scripts/utils/dockerconfig/config.go
+++ b/scripts/utils/dockerconfig/config.go
@@ -1,0 +1,68 @@
+// Package dockerconfig loads the api-server config from a running Docker stack.
+// Used by developer utility scripts that need database / Canton connectivity
+// without a manually specified config path.
+package dockerconfig
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/chainsafe/canton-middleware/pkg/config"
+)
+
+const (
+	// ContainerName is the api-server container used as the config source.
+	ContainerName = "erc20-api-server"
+
+	resolvedCfg = "/app/state/api-server-config.yaml"
+)
+
+// Load pulls config from the running Docker stack:
+//   - env vars are read from the api-server container via docker inspect and
+//     exported into the current process so ${VAR} placeholders expand correctly
+//   - the bootstrap-resolved YAML is fetched via docker exec cat and docker-
+//     internal hostnames are rewritten to localhost for host-side access
+func Load() (*config.APIServer, error) {
+	// 1. Read env vars from the running container.
+	envOut, err := exec.Command("docker", "inspect", ContainerName,
+		"--format", "{{range .Config.Env}}{{println .}}{{end}}").Output()
+	if err != nil {
+		return nil, fmt.Errorf("docker inspect %s failed: %w\n(is the Docker stack running?)", ContainerName, err)
+	}
+	for line := range strings.SplitSeq(strings.TrimSpace(string(envOut)), "\n") {
+		if idx := strings.IndexByte(line, '='); idx > 0 {
+			os.Setenv(line[:idx], line[idx+1:])
+		}
+	}
+
+	// Fix DATABASE_URL: container uses postgres hostname, host machine uses localhost.
+	if dbURL := os.Getenv("API_SERVER_DATABASE_URL"); dbURL != "" {
+		os.Setenv("API_SERVER_DATABASE_URL", strings.ReplaceAll(dbURL, "@postgres:", "@localhost:"))
+	}
+
+	// 2. Read the bootstrap-resolved config YAML from the shared state volume.
+	yamlOut, err := exec.Command("docker", "exec", ContainerName, "cat", resolvedCfg).Output()
+	if err != nil {
+		return nil, fmt.Errorf("docker exec cat %s failed: %w", resolvedCfg, err)
+	}
+
+	// Rewrite docker-internal service hostnames to localhost for host access.
+	resolved := string(yamlOut)
+	resolved = strings.ReplaceAll(resolved, "canton:5011", "localhost:5011")
+	resolved = strings.ReplaceAll(resolved, "mock-oauth2:8088", "localhost:8088")
+
+	// 3. Write patched YAML to a temp file and load via the standard loader.
+	tmp, err := os.CreateTemp("", "devtool-*.yaml")
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := tmp.WriteString(resolved); err != nil {
+		return nil, err
+	}
+	tmp.Close()
+
+	return config.LoadAPIServer(tmp.Name())
+}

--- a/scripts/utils/dockerconfig/config.go
+++ b/scripts/utils/dockerconfig/config.go
@@ -4,6 +4,7 @@
 package dockerconfig
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -25,8 +26,10 @@ const (
 //   - the bootstrap-resolved YAML is fetched via docker exec cat and docker-
 //     internal hostnames are rewritten to localhost for host-side access
 func Load() (*config.APIServer, error) {
+	ctx := context.Background()
+
 	// 1. Read env vars from the running container.
-	envOut, err := exec.Command("docker", "inspect", ContainerName,
+	envOut, err := exec.CommandContext(ctx, "docker", "inspect", ContainerName,
 		"--format", "{{range .Config.Env}}{{println .}}{{end}}").Output()
 	if err != nil {
 		return nil, fmt.Errorf("docker inspect %s failed: %w\n(is the Docker stack running?)", ContainerName, err)
@@ -43,7 +46,7 @@ func Load() (*config.APIServer, error) {
 	}
 
 	// 2. Read the bootstrap-resolved config YAML from the shared state volume.
-	yamlOut, err := exec.Command("docker", "exec", ContainerName, "cat", resolvedCfg).Output()
+	yamlOut, err := exec.CommandContext(ctx, "docker", "exec", ContainerName, "cat", resolvedCfg).Output()
 	if err != nil {
 		return nil, fmt.Errorf("docker exec cat %s failed: %w", resolvedCfg, err)
 	}

--- a/scripts/utils/fund-wallet.go
+++ b/scripts/utils/fund-wallet.go
@@ -8,7 +8,7 @@
 // Reads all config values automatically from the running Docker stack.
 //
 // Usage:
-//   go run scripts/utils/fund-address.go
+//   go run scripts/utils/fund-wallet.go
 
 package main
 

--- a/scripts/utils/fund-wallet.go
+++ b/scripts/utils/fund-wallet.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 // Fund Address Script
 //
@@ -17,22 +16,16 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/chainsafe/canton-middleware/pkg/auth"
 	canton "github.com/chainsafe/canton-middleware/pkg/cantonsdk/client"
 	cantontoken "github.com/chainsafe/canton-middleware/pkg/cantonsdk/token"
-	"github.com/chainsafe/canton-middleware/pkg/config"
 	"github.com/chainsafe/canton-middleware/pkg/pgutil"
 	"github.com/chainsafe/canton-middleware/pkg/userstore"
+	"github.com/chainsafe/canton-middleware/scripts/utils/dockerconfig"
 	_ "github.com/lib/pq"
 	"go.uber.org/zap"
-)
-
-const (
-	containerName = "erc20-api-server"
-	resolvedCfg   = "/app/state/api-server-config.yaml"
 )
 
 func main() {
@@ -41,7 +34,7 @@ func main() {
 	fmt.Println("══════════════════════════════════════════════════════════════════════")
 	fmt.Println()
 
-	cfg, err := loadConfigFromDocker()
+	cfg, err := dockerconfig.Load()
 	if err != nil {
 		fatalf("failed to load config from Docker: %v", err)
 	}
@@ -157,57 +150,6 @@ func main() {
 	fmt.Println("══════════════════════════════════════════════════════════════════════")
 	fmt.Println("  Done")
 	fmt.Println("══════════════════════════════════════════════════════════════════════")
-}
-
-// loadConfigFromDocker pulls config values from the running Docker stack:
-// - env vars (DATABASE_URL, auth credentials) from the api-server container
-// - resolved YAML (domain_id, issuer_party) from the container's state volume
-// Docker-internal hostnames are rewritten to localhost for host-side access.
-func loadConfigFromDocker() (*config.APIServer, error) {
-	// 1. Read env vars from the running container and set them locally so
-	//    config.LoadAPIServer can expand ${VAR} placeholders via os.ExpandEnv.
-	envOut, err := exec.Command("docker", "inspect", containerName,
-		"--format", "{{range .Config.Env}}{{println .}}{{end}}").Output()
-	if err != nil {
-		return nil, fmt.Errorf("docker inspect %s failed: %w\n(is the Docker stack running?)", containerName, err)
-	}
-	for _, line := range strings.Split(strings.TrimSpace(string(envOut)), "\n") {
-		if idx := strings.IndexByte(line, '='); idx > 0 {
-			os.Setenv(line[:idx], line[idx+1:])
-		}
-	}
-
-	// Fix DATABASE_URL: container uses postgres hostname, host machine uses localhost
-	if dbURL := os.Getenv("API_SERVER_DATABASE_URL"); dbURL != "" {
-		os.Setenv("API_SERVER_DATABASE_URL", strings.ReplaceAll(dbURL, "@postgres:", "@localhost:"))
-	}
-
-	// 2. Read the bootstrap-resolved config YAML from the shared state volume.
-	//    This file already has domain_id and issuer_party substituted by the
-	//    bootstrap script; the remaining ${VAR} placeholders are expanded by
-	//    config.LoadAPIServer via os.ExpandEnv using the env vars set above.
-	yamlOut, err := exec.Command("docker", "exec", containerName, "cat", resolvedCfg).Output()
-	if err != nil {
-		return nil, fmt.Errorf("docker exec cat %s failed: %w", resolvedCfg, err)
-	}
-
-	// Rewrite docker-internal service hostnames to localhost for host access.
-	resolved := string(yamlOut)
-	resolved = strings.ReplaceAll(resolved, "canton:5011", "localhost:5011")
-	resolved = strings.ReplaceAll(resolved, "mock-oauth2:8088", "localhost:8088")
-
-	// 3. Write patched YAML to a temp file and load via the standard loader.
-	tmp, err := os.CreateTemp("", "fund-addr-*.yaml")
-	if err != nil {
-		return nil, err
-	}
-	defer os.Remove(tmp.Name())
-	if _, err := tmp.WriteString(resolved); err != nil {
-		return nil, err
-	}
-	tmp.Close()
-
-	return config.LoadAPIServer(tmp.Name())
 }
 
 func truncate(s string, n int) string {

--- a/scripts/utils/fund-wallet.go
+++ b/scripts/utils/fund-wallet.go
@@ -1,0 +1,223 @@
+//go:build ignore
+// +build ignore
+
+// Fund Address Script
+//
+// Interactively mints DEMO and PROMPT tokens to a registered EVM address.
+// The address must already exist in the database (user must be registered).
+// Reads all config values automatically from the running Docker stack.
+//
+// Usage:
+//   go run scripts/utils/fund-address.go
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/chainsafe/canton-middleware/pkg/auth"
+	canton "github.com/chainsafe/canton-middleware/pkg/cantonsdk/client"
+	cantontoken "github.com/chainsafe/canton-middleware/pkg/cantonsdk/token"
+	"github.com/chainsafe/canton-middleware/pkg/config"
+	"github.com/chainsafe/canton-middleware/pkg/pgutil"
+	"github.com/chainsafe/canton-middleware/pkg/userstore"
+	_ "github.com/lib/pq"
+	"go.uber.org/zap"
+)
+
+const (
+	containerName = "erc20-api-server"
+	resolvedCfg   = "/app/state/api-server-config.yaml"
+)
+
+func main() {
+	fmt.Println("══════════════════════════════════════════════════════════════════════")
+	fmt.Println("  Fund Address — Mint DEMO & PROMPT tokens")
+	fmt.Println("══════════════════════════════════════════════════════════════════════")
+	fmt.Println()
+
+	cfg, err := loadConfigFromDocker()
+	if err != nil {
+		fatalf("failed to load config from Docker: %v", err)
+	}
+
+	logger, _ := zap.NewDevelopment()
+
+	fmt.Println(">>> Connecting to services...")
+	bunDB, err := pgutil.ConnectDB(cfg.Database)
+	if err != nil {
+		fatalf("failed to connect to database: %v", err)
+	}
+	defer bunDB.Close()
+
+	uStore := userstore.NewStore(bunDB)
+	fmt.Println("    Connected to PostgreSQL")
+
+	ctx := context.Background()
+
+	cantonClient, err := canton.New(ctx, cfg.Canton, canton.WithLogger(logger))
+	if err != nil {
+		fatalf("failed to connect to Canton: %v", err)
+	}
+	defer cantonClient.Close()
+	fmt.Println("    Connected to Canton Ledger API")
+	fmt.Println()
+
+	reader := bufio.NewReader(os.Stdin)
+
+	// Prompt for EVM address
+	fmt.Print("Enter EVM address: ")
+	evmAddress, _ := reader.ReadString('\n')
+	evmAddress = auth.NormalizeAddress(strings.TrimSpace(evmAddress))
+	if evmAddress == "" {
+		fatalf("EVM address is required")
+	}
+
+	// Resolve user from database
+	usr, err := uStore.GetUserByEVMAddress(ctx, evmAddress)
+	if err != nil {
+		fatalf("user not found for address %s: %v\n(make sure the user is registered via the API first)", evmAddress, err)
+	}
+
+	partyID := usr.CantonPartyID
+	fmt.Printf("\nResolved Canton party: %s\n\n", truncate(partyID, 60))
+
+	// Fetch current balances and total supply for both tokens
+	tokens := []string{"DEMO", "PROMPT"}
+	balances := make(map[string]string)
+	supplies := make(map[string]string)
+
+	fmt.Println(">>> Fetching current balances and total supply...")
+	for _, sym := range tokens {
+		bal, err := cantonClient.Token.GetBalanceByPartyID(ctx, partyID, sym)
+		if err != nil {
+			fmt.Printf("    WARN: could not fetch %s balance: %v\n", sym, err)
+			bal = "0"
+		}
+		balances[sym] = bal
+
+		sup, err := cantonClient.Token.GetTotalSupply(ctx, sym)
+		if err != nil {
+			fmt.Printf("    WARN: could not fetch %s total supply: %v\n", sym, err)
+			sup = "unknown"
+		}
+		supplies[sym] = sup
+	}
+
+	fmt.Println()
+	fmt.Println("  Current state:")
+	for _, sym := range tokens {
+		fmt.Printf("    %s — balance: %s  |  total supply: %s\n", sym, balances[sym], supplies[sym])
+	}
+	fmt.Println()
+
+	// Prompt for amount
+	fmt.Print("Enter amount to mint (e.g. 500): ")
+	amountStr, _ := reader.ReadString('\n')
+	amountStr = strings.TrimSpace(amountStr)
+	if amountStr == "" {
+		fatalf("amount is required")
+	}
+
+	// Mint both tokens
+	fmt.Println()
+	fmt.Println(">>> Minting tokens...")
+	for _, sym := range tokens {
+		fmt.Printf("    Minting %s %s to %s...\n", amountStr, sym, evmAddress)
+		_, err := cantonClient.Token.Mint(ctx, &cantontoken.MintRequest{
+			RecipientParty: partyID,
+			Amount:         amountStr,
+			TokenSymbol:    sym,
+		})
+		if err != nil {
+			fmt.Printf("    ERROR: failed to mint %s: %v\n", sym, err)
+		} else {
+			fmt.Printf("    Minted %s %s\n", amountStr, sym)
+		}
+	}
+
+	// Show updated balances
+	fmt.Println()
+	fmt.Println(">>> Updated balances:")
+	for _, sym := range tokens {
+		bal, err := cantonClient.Token.GetBalanceByPartyID(ctx, partyID, sym)
+		if err != nil {
+			fmt.Printf("    %s: (could not fetch: %v)\n", sym, err)
+			continue
+		}
+		fmt.Printf("    %s: %s\n", sym, bal)
+	}
+
+	fmt.Println()
+	fmt.Println("══════════════════════════════════════════════════════════════════════")
+	fmt.Println("  Done")
+	fmt.Println("══════════════════════════════════════════════════════════════════════")
+}
+
+// loadConfigFromDocker pulls config values from the running Docker stack:
+// - env vars (DATABASE_URL, auth credentials) from the api-server container
+// - resolved YAML (domain_id, issuer_party) from the container's state volume
+// Docker-internal hostnames are rewritten to localhost for host-side access.
+func loadConfigFromDocker() (*config.APIServer, error) {
+	// 1. Read env vars from the running container and set them locally so
+	//    config.LoadAPIServer can expand ${VAR} placeholders via os.ExpandEnv.
+	envOut, err := exec.Command("docker", "inspect", containerName,
+		"--format", "{{range .Config.Env}}{{println .}}{{end}}").Output()
+	if err != nil {
+		return nil, fmt.Errorf("docker inspect %s failed: %w\n(is the Docker stack running?)", containerName, err)
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(envOut)), "\n") {
+		if idx := strings.IndexByte(line, '='); idx > 0 {
+			os.Setenv(line[:idx], line[idx+1:])
+		}
+	}
+
+	// Fix DATABASE_URL: container uses postgres hostname, host machine uses localhost
+	if dbURL := os.Getenv("API_SERVER_DATABASE_URL"); dbURL != "" {
+		os.Setenv("API_SERVER_DATABASE_URL", strings.ReplaceAll(dbURL, "@postgres:", "@localhost:"))
+	}
+
+	// 2. Read the bootstrap-resolved config YAML from the shared state volume.
+	//    This file already has domain_id and issuer_party substituted by the
+	//    bootstrap script; the remaining ${VAR} placeholders are expanded by
+	//    config.LoadAPIServer via os.ExpandEnv using the env vars set above.
+	yamlOut, err := exec.Command("docker", "exec", containerName, "cat", resolvedCfg).Output()
+	if err != nil {
+		return nil, fmt.Errorf("docker exec cat %s failed: %w", resolvedCfg, err)
+	}
+
+	// Rewrite docker-internal service hostnames to localhost for host access.
+	resolved := string(yamlOut)
+	resolved = strings.ReplaceAll(resolved, "canton:5011", "localhost:5011")
+	resolved = strings.ReplaceAll(resolved, "mock-oauth2:8088", "localhost:8088")
+
+	// 3. Write patched YAML to a temp file and load via the standard loader.
+	tmp, err := os.CreateTemp("", "fund-addr-*.yaml")
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := tmp.WriteString(resolved); err != nil {
+		return nil, err
+	}
+	tmp.Close()
+
+	return config.LoadAPIServer(tmp.Name())
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Printf("ERROR: "+format+"\n", args...)
+	os.Exit(1)
+}

--- a/scripts/utils/whitelist.go
+++ b/scripts/utils/whitelist.go
@@ -2,8 +2,7 @@
 
 // whitelist.go — Interactive EVM address whitelisting utility.
 //
-// Reads all config values automatically from the running Docker stack
-// (same approach as fund-wallet.go). No config flags required.
+// Reads all config values automatically from the running Docker stack.
 //
 // Usage (interactive):
 //
@@ -18,53 +17,32 @@ package main
 import (
 	"bufio"
 	"context"
+	"flag"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/chainsafe/canton-middleware/pkg/auth"
-	"github.com/chainsafe/canton-middleware/pkg/config"
 	"github.com/chainsafe/canton-middleware/pkg/pgutil"
 	"github.com/chainsafe/canton-middleware/pkg/userstore"
+	"github.com/chainsafe/canton-middleware/scripts/utils/dockerconfig"
 	_ "github.com/lib/pq"
 )
 
-const (
-	containerName = "erc20-api-server"
-	resolvedCfg   = "/app/state/api-server-config.yaml"
+var (
+	addrFlag = flag.String("address", "", "EVM address to whitelist (skips interactive prompt)")
+	noteFlag = flag.String("note", "", "Optional note to attach to the whitelist entry")
 )
 
 func main() {
-	// Parse optional flags for non-interactive use.
-	var addrFlag, noteFlag string
-	for i, arg := range os.Args[1:] {
-		switch {
-		case arg == "-address" || arg == "--address":
-			if i+1 < len(os.Args[1:]) {
-				addrFlag = os.Args[i+2]
-			}
-		case strings.HasPrefix(arg, "-address="):
-			addrFlag = strings.TrimPrefix(arg, "-address=")
-		case strings.HasPrefix(arg, "--address="):
-			addrFlag = strings.TrimPrefix(arg, "--address=")
-		case arg == "-note" || arg == "--note":
-			if i+1 < len(os.Args[1:]) {
-				noteFlag = os.Args[i+2]
-			}
-		case strings.HasPrefix(arg, "-note="):
-			noteFlag = strings.TrimPrefix(arg, "-note=")
-		case strings.HasPrefix(arg, "--note="):
-			noteFlag = strings.TrimPrefix(arg, "--note=")
-		}
-	}
+	flag.Parse()
 
 	fmt.Println("════════════════════════════════════════════════════════════════════")
 	fmt.Println("  Whitelist Manager")
 	fmt.Println("════════════════════════════════════════════════════════════════════")
 	fmt.Println()
 
-	cfg, err := loadConfigFromDocker()
+	cfg, err := dockerconfig.Load()
 	if err != nil {
 		fatalf("failed to load config from Docker: %v", err)
 	}
@@ -82,8 +60,8 @@ func main() {
 	ctx := context.Background()
 	reader := bufio.NewReader(os.Stdin)
 
-	rawAddr := strings.TrimSpace(addrFlag)
-	rawNote := strings.TrimSpace(noteFlag)
+	rawAddr := strings.TrimSpace(*addrFlag)
+	rawNote := strings.TrimSpace(*noteFlag)
 
 	if rawAddr == "" {
 		fmt.Print("Enter EVM address to whitelist: ")
@@ -124,57 +102,6 @@ func main() {
 	fmt.Println("════════════════════════════════════════════════════════════════════")
 	fmt.Println("  Done")
 	fmt.Println("════════════════════════════════════════════════════════════════════")
-}
-
-// loadConfigFromDocker pulls config values from the running Docker stack:
-// - env vars (DATABASE_URL, auth credentials) from the api-server container
-// - resolved YAML (domain_id, issuer_party) from the container's state volume
-// Docker-internal hostnames are rewritten to localhost for host-side access.
-func loadConfigFromDocker() (*config.APIServer, error) {
-	// 1. Read env vars from the running container and set them locally so
-	//    config.LoadAPIServer can expand ${VAR} placeholders via os.ExpandEnv.
-	envOut, err := exec.Command("docker", "inspect", containerName,
-		"--format", "{{range .Config.Env}}{{println .}}{{end}}").Output()
-	if err != nil {
-		return nil, fmt.Errorf("docker inspect %s failed: %w\n(is the Docker stack running?)", containerName, err)
-	}
-	for line := range strings.SplitSeq(strings.TrimSpace(string(envOut)), "\n") {
-		if idx := strings.IndexByte(line, '='); idx > 0 {
-			os.Setenv(line[:idx], line[idx+1:])
-		}
-	}
-
-	// Fix DATABASE_URL: container uses postgres hostname, host machine uses localhost.
-	if dbURL := os.Getenv("API_SERVER_DATABASE_URL"); dbURL != "" {
-		os.Setenv("API_SERVER_DATABASE_URL", strings.ReplaceAll(dbURL, "@postgres:", "@localhost:"))
-	}
-
-	// 2. Read the bootstrap-resolved config YAML from the shared state volume.
-	//    This file already has domain_id and issuer_party substituted by the
-	//    bootstrap script; remaining ${VAR} placeholders are expanded by
-	//    config.LoadAPIServer via os.ExpandEnv using the env vars set above.
-	yamlOut, err := exec.Command("docker", "exec", containerName, "cat", resolvedCfg).Output()
-	if err != nil {
-		return nil, fmt.Errorf("docker exec cat %s failed: %w", resolvedCfg, err)
-	}
-
-	// Rewrite docker-internal service hostnames to localhost for host access.
-	resolved := string(yamlOut)
-	resolved = strings.ReplaceAll(resolved, "canton:5011", "localhost:5011")
-	resolved = strings.ReplaceAll(resolved, "mock-oauth2:8088", "localhost:8088")
-
-	// 3. Write patched YAML to a temp file and load via the standard loader.
-	tmp, err := os.CreateTemp("", "whitelist-*.yaml")
-	if err != nil {
-		return nil, err
-	}
-	defer os.Remove(tmp.Name())
-	if _, err := tmp.WriteString(resolved); err != nil {
-		return nil, err
-	}
-	tmp.Close()
-
-	return config.LoadAPIServer(tmp.Name())
 }
 
 func fatalf(format string, args ...any) {

--- a/scripts/utils/whitelist.go
+++ b/scripts/utils/whitelist.go
@@ -1,0 +1,183 @@
+//go:build ignore
+
+// whitelist.go — Interactive EVM address whitelisting utility.
+//
+// Reads all config values automatically from the running Docker stack
+// (same approach as fund-wallet.go). No config flags required.
+//
+// Usage (interactive):
+//
+//	go run scripts/utils/whitelist.go
+//
+// Usage (non-interactive):
+//
+//	go run scripts/utils/whitelist.go -address 0xABCD... -note "operator"
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/chainsafe/canton-middleware/pkg/auth"
+	"github.com/chainsafe/canton-middleware/pkg/config"
+	"github.com/chainsafe/canton-middleware/pkg/pgutil"
+	"github.com/chainsafe/canton-middleware/pkg/userstore"
+	_ "github.com/lib/pq"
+)
+
+const (
+	containerName = "erc20-api-server"
+	resolvedCfg   = "/app/state/api-server-config.yaml"
+)
+
+func main() {
+	// Parse optional flags for non-interactive use.
+	var addrFlag, noteFlag string
+	for i, arg := range os.Args[1:] {
+		switch {
+		case arg == "-address" || arg == "--address":
+			if i+1 < len(os.Args[1:]) {
+				addrFlag = os.Args[i+2]
+			}
+		case strings.HasPrefix(arg, "-address="):
+			addrFlag = strings.TrimPrefix(arg, "-address=")
+		case strings.HasPrefix(arg, "--address="):
+			addrFlag = strings.TrimPrefix(arg, "--address=")
+		case arg == "-note" || arg == "--note":
+			if i+1 < len(os.Args[1:]) {
+				noteFlag = os.Args[i+2]
+			}
+		case strings.HasPrefix(arg, "-note="):
+			noteFlag = strings.TrimPrefix(arg, "-note=")
+		case strings.HasPrefix(arg, "--note="):
+			noteFlag = strings.TrimPrefix(arg, "--note=")
+		}
+	}
+
+	fmt.Println("════════════════════════════════════════════════════════════════════")
+	fmt.Println("  Whitelist Manager")
+	fmt.Println("════════════════════════════════════════════════════════════════════")
+	fmt.Println()
+
+	cfg, err := loadConfigFromDocker()
+	if err != nil {
+		fatalf("failed to load config from Docker: %v", err)
+	}
+
+	fmt.Println(">>> Connecting to database...")
+	bunDB, err := pgutil.ConnectDB(cfg.Database)
+	if err != nil {
+		fatalf("failed to connect to database: %v", err)
+	}
+	defer bunDB.Close()
+	store := userstore.NewStore(bunDB)
+	fmt.Println("    Connected to PostgreSQL")
+	fmt.Println()
+
+	ctx := context.Background()
+	reader := bufio.NewReader(os.Stdin)
+
+	rawAddr := strings.TrimSpace(addrFlag)
+	rawNote := strings.TrimSpace(noteFlag)
+
+	if rawAddr == "" {
+		fmt.Print("Enter EVM address to whitelist: ")
+		line, _ := reader.ReadString('\n')
+		rawAddr = strings.TrimSpace(line)
+	}
+	if rawAddr == "" {
+		fatalf("address is required")
+	}
+
+	normalized := auth.NormalizeAddress(rawAddr)
+	if normalized == "0x0000000000000000000000000000000000000000" {
+		fatalf("invalid EVM address: %q", rawAddr)
+	}
+	if normalized != rawAddr {
+		fmt.Printf("  Normalized: %s\n", normalized)
+	}
+
+	already, err := store.IsWhitelisted(ctx, normalized)
+	if err != nil {
+		fatalf("failed to check whitelist: %v", err)
+	}
+
+	if err := store.AddToWhitelist(ctx, normalized, rawNote); err != nil {
+		fatalf("failed to add to whitelist: %v", err)
+	}
+
+	fmt.Println()
+	if already {
+		fmt.Printf("  Updated:  %s\n", normalized)
+	} else {
+		fmt.Printf("  Added:    %s\n", normalized)
+	}
+	if rawNote != "" {
+		fmt.Printf("  Note:     %s\n", rawNote)
+	}
+	fmt.Println()
+	fmt.Println("════════════════════════════════════════════════════════════════════")
+	fmt.Println("  Done")
+	fmt.Println("════════════════════════════════════════════════════════════════════")
+}
+
+// loadConfigFromDocker pulls config values from the running Docker stack:
+// - env vars (DATABASE_URL, auth credentials) from the api-server container
+// - resolved YAML (domain_id, issuer_party) from the container's state volume
+// Docker-internal hostnames are rewritten to localhost for host-side access.
+func loadConfigFromDocker() (*config.APIServer, error) {
+	// 1. Read env vars from the running container and set them locally so
+	//    config.LoadAPIServer can expand ${VAR} placeholders via os.ExpandEnv.
+	envOut, err := exec.Command("docker", "inspect", containerName,
+		"--format", "{{range .Config.Env}}{{println .}}{{end}}").Output()
+	if err != nil {
+		return nil, fmt.Errorf("docker inspect %s failed: %w\n(is the Docker stack running?)", containerName, err)
+	}
+	for line := range strings.SplitSeq(strings.TrimSpace(string(envOut)), "\n") {
+		if idx := strings.IndexByte(line, '='); idx > 0 {
+			os.Setenv(line[:idx], line[idx+1:])
+		}
+	}
+
+	// Fix DATABASE_URL: container uses postgres hostname, host machine uses localhost.
+	if dbURL := os.Getenv("API_SERVER_DATABASE_URL"); dbURL != "" {
+		os.Setenv("API_SERVER_DATABASE_URL", strings.ReplaceAll(dbURL, "@postgres:", "@localhost:"))
+	}
+
+	// 2. Read the bootstrap-resolved config YAML from the shared state volume.
+	//    This file already has domain_id and issuer_party substituted by the
+	//    bootstrap script; remaining ${VAR} placeholders are expanded by
+	//    config.LoadAPIServer via os.ExpandEnv using the env vars set above.
+	yamlOut, err := exec.Command("docker", "exec", containerName, "cat", resolvedCfg).Output()
+	if err != nil {
+		return nil, fmt.Errorf("docker exec cat %s failed: %w", resolvedCfg, err)
+	}
+
+	// Rewrite docker-internal service hostnames to localhost for host access.
+	resolved := string(yamlOut)
+	resolved = strings.ReplaceAll(resolved, "canton:5011", "localhost:5011")
+	resolved = strings.ReplaceAll(resolved, "mock-oauth2:8088", "localhost:8088")
+
+	// 3. Write patched YAML to a temp file and load via the standard loader.
+	tmp, err := os.CreateTemp("", "whitelist-*.yaml")
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := tmp.WriteString(resolved); err != nil {
+		return nil, err
+	}
+	tmp.Close()
+
+	return config.LoadAPIServer(tmp.Name())
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Printf("ERROR: "+format+"\n", args...)
+	os.Exit(1)
+}


### PR DESCRIPTION
## Summary

- Adds `scripts/utils/whitelist.go` — interactive utility to whitelist an EVM address in the api-server database; reads config automatically from the running Docker stack via `docker inspect`/`docker exec`, supports `-address` and `-note` flags for non-interactive use
- Adds `scripts/utils/fund-wallet.go` — interactive utility to mint DEMO and PROMPT tokens to a registered EVM address, also auto-configured from the Docker stack
- Adds `docs/DAPP_SNAP_TESTING.md` — short guide covering the four steps to test the middleware end-to-end with the Wayfinder dApp and MetaMask Snap; links to the full Snap-side guide in the Canton Snap repo
- Updates `README.md` to link the new guide in the documentation table

## Test plan

- [ ] `make docker-up` starts the full stack
- [ ] `go run scripts/utils/whitelist.go` prompts for address and inserts it into the whitelist table
- [ ] `go run scripts/utils/whitelist.go -address 0x... -note "tester"` runs non-interactively
- [ ] `go run scripts/utils/fund-wallet.go` prompts for address and amount, mints DEMO and PROMPT
- [ ] Whitelisted and funded address can register and see balances on the dApp