### PR TITLE
feat: non-custodial incoming transfer accept API

### DIFF
--- a/pkg/cantonsdk/token/client.go
+++ b/pkg/cantonsdk/token/client.go
@@ -1186,6 +1186,7 @@ func (c *Client) PrepareAcceptTransfer(
 		PreparedTransaction:  prepResp.PreparedTransaction,
 		HashingSchemeVersion: prepResp.HashingSchemeVersion,
 		PartyID:              partyID,
+		ExpiresAt:            time.Now().Add(defaultTransferValidity),
 	}
 
 	c.logger.Info("prepared non-custodial accept",

--- a/pkg/cantonsdk/token/client.go
+++ b/pkg/cantonsdk/token/client.go
@@ -120,6 +120,13 @@ type Token interface {
 	// Calls the registrar's accept choice-context endpoint (keyed by instrumentAdmin), encodes
 	// the AnyValue choiceContext, and exercises TransferInstruction_Accept via SubmitAndWait.
 	AcceptTransferInstruction(ctx context.Context, partyID, instructionCID, instrumentAdmin string) error
+
+	// PrepareAcceptTransfer builds a Canton transaction for accepting a pending inbound
+	// transfer instruction and returns the hash that the client must sign externally.
+	// Use ExecuteTransfer to complete the accept once the client has signed.
+	PrepareAcceptTransfer(
+		ctx context.Context, partyID, instructionCID, instrumentAdmin string,
+	) (*PreparedTransfer, error)
 }
 
 // Client implements CIP-56 token operations.
@@ -1095,6 +1102,99 @@ func (c *Client) AcceptTransferInstruction(ctx context.Context, partyID, instruc
 		return fmt.Errorf("accept transfer instruction: %w", err)
 	}
 	return nil
+}
+
+func (c *Client) PrepareAcceptTransfer(
+	ctx context.Context, partyID, instructionCID, instrumentAdmin string,
+) (*PreparedTransfer, error) {
+	if partyID == "" || instructionCID == "" || instrumentAdmin == "" {
+		return nil, fmt.Errorf("partyID, instructionCID, and instrumentAdmin are required")
+	}
+	if c.registryClient == nil {
+		return nil, fmt.Errorf("no registry client configured for accept")
+	}
+	extCfg, ok := c.cfg.ExternalTokens[instrumentAdmin]
+	if !ok {
+		return nil, fmt.Errorf("unsupported external token issuer: %s", instrumentAdmin)
+	}
+
+	acceptResp, err := c.registryClient.GetAcceptChoiceContext(ctx, extCfg.RegistryURL, instrumentAdmin, instructionCID)
+	if err != nil {
+		return nil, fmt.Errorf("get accept choice context: %w", err)
+	}
+
+	ctxValue, err := encodeChoiceContextRecord(acceptResp.ChoiceContextData)
+	if err != nil {
+		return nil, fmt.Errorf("encode choice context: %w", err)
+	}
+
+	extraArgs := &lapiv2.Value{
+		Sum: &lapiv2.Value_Record{
+			Record: &lapiv2.Record{
+				Fields: []*lapiv2.RecordField{
+					{Label: "context", Value: ctxValue},
+					{Label: "meta", Value: values.EmptyMetadata()},
+				},
+			},
+		},
+	}
+
+	disclosed, err := convertDisclosedContractSlice(acceptResp.DisclosedContracts, c.cfg.DomainID)
+	if err != nil {
+		return nil, fmt.Errorf("convert disclosed contracts: %w", err)
+	}
+
+	cmd := &lapiv2.Command{
+		Command: &lapiv2.Command_Exercise{
+			Exercise: &lapiv2.ExerciseCommand{
+				TemplateId: &lapiv2.Identifier{
+					PackageId:  c.cfg.SpliceTransferPackageID,
+					ModuleName: spliceTransferModule,
+					EntityName: transferInstrEntity,
+				},
+				ContractId: instructionCID,
+				Choice:     acceptChoice,
+				ChoiceArgument: &lapiv2.Value{
+					Sum: &lapiv2.Value_Record{
+						Record: &lapiv2.Record{
+							Fields: []*lapiv2.RecordField{
+								{Label: "extraArgs", Value: extraArgs},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	authCtx := c.ledger.AuthContext(ctx)
+	prepResp, err := c.ledger.Interactive().PrepareSubmission(authCtx, &interactivev2.PrepareSubmissionRequest{
+		UserId:             c.cfg.UserID,
+		CommandId:          uuid.NewString(),
+		Commands:           []*lapiv2.Command{cmd},
+		ActAs:              []string{partyID},
+		SynchronizerId:     c.cfg.DomainID,
+		DisclosedContracts: disclosed,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("prepare accept submission: %w", err)
+	}
+
+	pt := &PreparedTransfer{
+		TransferID:           uuid.NewString(),
+		TransactionHash:      prepResp.PreparedTransactionHash,
+		PreparedTransaction:  prepResp.PreparedTransaction,
+		HashingSchemeVersion: prepResp.HashingSchemeVersion,
+		PartyID:              partyID,
+	}
+
+	c.logger.Info("prepared non-custodial accept",
+		zap.String("transfer_id", pt.TransferID),
+		zap.String("party_id", partyID),
+		zap.String("contract_id", instructionCID),
+	)
+
+	return pt, nil
 }
 
 func (c *Client) GetTokenTransferEvents(ctx context.Context) ([]*TokenTransferEvent, error) {

--- a/pkg/token/mocks/mock_canton_token.go
+++ b/pkg/token/mocks/mock_canton_token.go
@@ -22,6 +22,55 @@ func (_m *Token) EXPECT() *Token_Expecter {
 	return &Token_Expecter{mock: &_m.Mock}
 }
 
+// AcceptTransferInstruction provides a mock function with given fields: ctx, partyID, instructionCID, instrumentAdmin
+func (_m *Token) AcceptTransferInstruction(ctx context.Context, partyID string, instructionCID string, instrumentAdmin string) error {
+	ret := _m.Called(ctx, partyID, instructionCID, instrumentAdmin)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AcceptTransferInstruction")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) error); ok {
+		r0 = rf(ctx, partyID, instructionCID, instrumentAdmin)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Token_AcceptTransferInstruction_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AcceptTransferInstruction'
+type Token_AcceptTransferInstruction_Call struct {
+	*mock.Call
+}
+
+// AcceptTransferInstruction is a helper method to define mock.On call
+//   - ctx context.Context
+//   - partyID string
+//   - instructionCID string
+//   - instrumentAdmin string
+func (_e *Token_Expecter) AcceptTransferInstruction(ctx interface{}, partyID interface{}, instructionCID interface{}, instrumentAdmin interface{}) *Token_AcceptTransferInstruction_Call {
+	return &Token_AcceptTransferInstruction_Call{Call: _e.mock.On("AcceptTransferInstruction", ctx, partyID, instructionCID, instrumentAdmin)}
+}
+
+func (_c *Token_AcceptTransferInstruction_Call) Run(run func(ctx context.Context, partyID string, instructionCID string, instrumentAdmin string)) *Token_AcceptTransferInstruction_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string))
+	})
+	return _c
+}
+
+func (_c *Token_AcceptTransferInstruction_Call) Return(_a0 error) *Token_AcceptTransferInstruction_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Token_AcceptTransferInstruction_Call) RunAndReturn(run func(context.Context, string, string, string) error) *Token_AcceptTransferInstruction_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Burn provides a mock function with given fields: ctx, req
 func (_m *Token) Burn(ctx context.Context, req *token.BurnRequest) error {
 	ret := _m.Called(ctx, req)
@@ -112,6 +161,65 @@ func (_c *Token_ExecuteTransfer_Call) Return(_a0 error) *Token_ExecuteTransfer_C
 }
 
 func (_c *Token_ExecuteTransfer_Call) RunAndReturn(run func(context.Context, *token.ExecuteTransferRequest) error) *Token_ExecuteTransfer_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// FindPendingInboundTransferInstructions provides a mock function with given fields: ctx, partyID
+func (_m *Token) FindPendingInboundTransferInstructions(ctx context.Context, partyID string) ([]string, error) {
+	ret := _m.Called(ctx, partyID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FindPendingInboundTransferInstructions")
+	}
+
+	var r0 []string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) ([]string, error)); ok {
+		return rf(ctx, partyID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) []string); ok {
+		r0 = rf(ctx, partyID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, partyID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Token_FindPendingInboundTransferInstructions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FindPendingInboundTransferInstructions'
+type Token_FindPendingInboundTransferInstructions_Call struct {
+	*mock.Call
+}
+
+// FindPendingInboundTransferInstructions is a helper method to define mock.On call
+//   - ctx context.Context
+//   - partyID string
+func (_e *Token_Expecter) FindPendingInboundTransferInstructions(ctx interface{}, partyID interface{}) *Token_FindPendingInboundTransferInstructions_Call {
+	return &Token_FindPendingInboundTransferInstructions_Call{Call: _e.mock.On("FindPendingInboundTransferInstructions", ctx, partyID)}
+}
+
+func (_c *Token_FindPendingInboundTransferInstructions_Call) Run(run func(ctx context.Context, partyID string)) *Token_FindPendingInboundTransferInstructions_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *Token_FindPendingInboundTransferInstructions_Call) Return(_a0 []string, _a1 error) *Token_FindPendingInboundTransferInstructions_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Token_FindPendingInboundTransferInstructions_Call) RunAndReturn(run func(context.Context, string) ([]string, error)) *Token_FindPendingInboundTransferInstructions_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -697,6 +805,67 @@ func (_c *Token_Mint_Call) RunAndReturn(run func(context.Context, *token.MintReq
 	return _c
 }
 
+// PrepareAcceptTransfer provides a mock function with given fields: ctx, partyID, instructionCID, instrumentAdmin
+func (_m *Token) PrepareAcceptTransfer(ctx context.Context, partyID string, instructionCID string, instrumentAdmin string) (*token.PreparedTransfer, error) {
+	ret := _m.Called(ctx, partyID, instructionCID, instrumentAdmin)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PrepareAcceptTransfer")
+	}
+
+	var r0 *token.PreparedTransfer
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) (*token.PreparedTransfer, error)); ok {
+		return rf(ctx, partyID, instructionCID, instrumentAdmin)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) *token.PreparedTransfer); ok {
+		r0 = rf(ctx, partyID, instructionCID, instrumentAdmin)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*token.PreparedTransfer)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
+		r1 = rf(ctx, partyID, instructionCID, instrumentAdmin)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Token_PrepareAcceptTransfer_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PrepareAcceptTransfer'
+type Token_PrepareAcceptTransfer_Call struct {
+	*mock.Call
+}
+
+// PrepareAcceptTransfer is a helper method to define mock.On call
+//   - ctx context.Context
+//   - partyID string
+//   - instructionCID string
+//   - instrumentAdmin string
+func (_e *Token_Expecter) PrepareAcceptTransfer(ctx interface{}, partyID interface{}, instructionCID interface{}, instrumentAdmin interface{}) *Token_PrepareAcceptTransfer_Call {
+	return &Token_PrepareAcceptTransfer_Call{Call: _e.mock.On("PrepareAcceptTransfer", ctx, partyID, instructionCID, instrumentAdmin)}
+}
+
+func (_c *Token_PrepareAcceptTransfer_Call) Run(run func(ctx context.Context, partyID string, instructionCID string, instrumentAdmin string)) *Token_PrepareAcceptTransfer_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string))
+	})
+	return _c
+}
+
+func (_c *Token_PrepareAcceptTransfer_Call) Return(_a0 *token.PreparedTransfer, _a1 error) *Token_PrepareAcceptTransfer_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Token_PrepareAcceptTransfer_Call) RunAndReturn(run func(context.Context, string, string, string) (*token.PreparedTransfer, error)) *Token_PrepareAcceptTransfer_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // PrepareTransfer provides a mock function with given fields: ctx, req
 func (_m *Token) PrepareTransfer(ctx context.Context, req *token.PrepareTransferRequest) (*token.PreparedTransfer, error) {
 	ret := _m.Called(ctx, req)
@@ -905,114 +1074,6 @@ func (_c *Token_TransferInternalByPartyID_Call) Return(_a0 error) *Token_Transfe
 }
 
 func (_c *Token_TransferInternalByPartyID_Call) RunAndReturn(run func(context.Context, string, string, string, string, string) error) *Token_TransferInternalByPartyID_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// AcceptTransferInstruction provides a mock function with given fields: ctx, partyID, instructionCID, instrumentAdmin
-func (_m *Token) AcceptTransferInstruction(ctx context.Context, partyID string, instructionCID string, instrumentAdmin string) error {
-	ret := _m.Called(ctx, partyID, instructionCID, instrumentAdmin)
-
-	if len(ret) == 0 {
-		panic("no return value specified for AcceptTransferInstruction")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) error); ok {
-		r0 = rf(ctx, partyID, instructionCID, instrumentAdmin)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// Token_AcceptTransferInstruction_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AcceptTransferInstruction'
-type Token_AcceptTransferInstruction_Call struct {
-	*mock.Call
-}
-
-// AcceptTransferInstruction is a helper method to define mock.On call
-//   - ctx context.Context
-//   - partyID string
-//   - instructionCID string
-//   - instrumentAdmin string
-func (_e *Token_Expecter) AcceptTransferInstruction(ctx interface{}, partyID interface{}, instructionCID interface{}, instrumentAdmin interface{}) *Token_AcceptTransferInstruction_Call {
-	return &Token_AcceptTransferInstruction_Call{Call: _e.mock.On("AcceptTransferInstruction", ctx, partyID, instructionCID, instrumentAdmin)}
-}
-
-func (_c *Token_AcceptTransferInstruction_Call) Run(run func(ctx context.Context, partyID string, instructionCID string, instrumentAdmin string)) *Token_AcceptTransferInstruction_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string))
-	})
-	return _c
-}
-
-func (_c *Token_AcceptTransferInstruction_Call) Return(_a0 error) *Token_AcceptTransferInstruction_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *Token_AcceptTransferInstruction_Call) RunAndReturn(run func(context.Context, string, string, string) error) *Token_AcceptTransferInstruction_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// FindPendingInboundTransferInstructions provides a mock function with given fields: ctx, partyID
-func (_m *Token) FindPendingInboundTransferInstructions(ctx context.Context, partyID string) ([]string, error) {
-	ret := _m.Called(ctx, partyID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for FindPendingInboundTransferInstructions")
-	}
-
-	var r0 []string
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) ([]string, error)); ok {
-		return rf(ctx, partyID)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) []string); ok {
-		r0 = rf(ctx, partyID)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]string)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, partyID)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// Token_FindPendingInboundTransferInstructions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FindPendingInboundTransferInstructions'
-type Token_FindPendingInboundTransferInstructions_Call struct {
-	*mock.Call
-}
-
-// FindPendingInboundTransferInstructions is a helper method to define mock.On call
-//   - ctx context.Context
-//   - partyID string
-func (_e *Token_Expecter) FindPendingInboundTransferInstructions(ctx interface{}, partyID interface{}) *Token_FindPendingInboundTransferInstructions_Call {
-	return &Token_FindPendingInboundTransferInstructions_Call{Call: _e.mock.On("FindPendingInboundTransferInstructions", ctx, partyID)}
-}
-
-func (_c *Token_FindPendingInboundTransferInstructions_Call) Run(run func(ctx context.Context, partyID string)) *Token_FindPendingInboundTransferInstructions_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
-	})
-	return _c
-}
-
-func (_c *Token_FindPendingInboundTransferInstructions_Call) Return(_a0 []string, _a1 error) *Token_FindPendingInboundTransferInstructions_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *Token_FindPendingInboundTransferInstructions_Call) RunAndReturn(run func(context.Context, string) ([]string, error)) *Token_FindPendingInboundTransferInstructions_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/transfer/http.go
+++ b/pkg/transfer/http.go
@@ -31,6 +31,10 @@ func RegisterRoutes(r chi.Router, svc Service, logger *zap.Logger) {
 
 	r.Post("/api/v2/transfer/prepare", apphttp.HandleError(h.prepare))
 	r.Post("/api/v2/transfer/execute", apphttp.HandleError(h.execute))
+
+	r.Get("/api/v2/transfer/incoming", apphttp.HandleError(h.listIncoming))
+	r.Post("/api/v2/transfer/incoming/{contractID}/prepare", apphttp.HandleError(h.prepareAccept))
+	r.Post("/api/v2/transfer/incoming/{contractID}/execute", apphttp.HandleError(h.executeAccept))
 }
 
 func (h *httpHandler) prepare(w http.ResponseWriter, r *http.Request) error {
@@ -60,7 +64,7 @@ func (h *httpHandler) prepare(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
-	h.writeJSON(w, http.StatusOK, resp)
+	h.writeJSON(w, resp)
 	return nil
 }
 
@@ -84,7 +88,73 @@ func (h *httpHandler) execute(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
-	h.writeJSON(w, http.StatusOK, resp)
+	h.writeJSON(w, resp)
+	return nil
+}
+
+func (h *httpHandler) listIncoming(w http.ResponseWriter, r *http.Request) error {
+	evmAddr, err := authenticateEVM(r)
+	if err != nil {
+		return err
+	}
+
+	resp, err := h.svc.ListIncoming(r.Context(), evmAddr)
+	if err != nil {
+		return err
+	}
+
+	h.writeJSON(w, resp)
+	return nil
+}
+
+func (h *httpHandler) prepareAccept(w http.ResponseWriter, r *http.Request) error {
+	evmAddr, err := authenticateEVM(r)
+	if err != nil {
+		return err
+	}
+
+	contractID := chi.URLParam(r, "contractID")
+	if contractID == "" {
+		return apperrors.BadRequestError(nil, "contractID path parameter is required")
+	}
+
+	var req PrepareAcceptRequest
+	if jsonErr := readJSON(r, &req); jsonErr != nil {
+		return jsonErr
+	}
+	if req.InstrumentAdmin == "" {
+		return apperrors.BadRequestError(nil, "instrument_admin is required")
+	}
+
+	resp, err := h.svc.PrepareAccept(r.Context(), evmAddr, contractID, &req)
+	if err != nil {
+		return err
+	}
+
+	h.writeJSON(w, resp)
+	return nil
+}
+
+func (h *httpHandler) executeAccept(w http.ResponseWriter, r *http.Request) error {
+	evmAddr, err := authenticateEVM(r)
+	if err != nil {
+		return err
+	}
+
+	var req ExecuteRequest
+	if jsonErr := readJSON(r, &req); jsonErr != nil {
+		return jsonErr
+	}
+	if req.TransferID == "" || req.Signature == "" || req.SignedBy == "" {
+		return apperrors.BadRequestError(nil, "transfer_id, signature, and signed_by are required")
+	}
+
+	resp, err := h.svc.ExecuteAccept(r.Context(), evmAddr, &req)
+	if err != nil {
+		return err
+	}
+
+	h.writeJSON(w, resp)
 	return nil
 }
 
@@ -119,9 +189,9 @@ func readJSON(r *http.Request, dst any) error {
 	return nil
 }
 
-func (h *httpHandler) writeJSON(w http.ResponseWriter, status int, data any) {
+func (h *httpHandler) writeJSON(w http.ResponseWriter, data any) {
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
+	w.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(w).Encode(data); err != nil {
 		h.logger.Error("failed to write JSON response", zap.Error(err))
 	}

--- a/pkg/transfer/log.go
+++ b/pkg/transfer/log.go
@@ -116,6 +116,106 @@ func (ls *logService) Execute(
 	return ls.svc.Execute(ctx, senderEVMAddr, req)
 }
 
+// ListIncoming wraps the service method with logging.
+func (ls *logService) ListIncoming(ctx context.Context, evmAddr string) (resp *ListIncomingResponse, err error) {
+	start := time.Now()
+	ls.logger.Info("ListIncoming started",
+		zap.String("service", transferServiceName),
+		zap.String("method", "ListIncoming"),
+		zap.String("evm_addr", evmAddr),
+	)
+	defer func() {
+		duration := time.Since(start)
+		if err != nil {
+			ls.logger.Error("ListIncoming failed",
+				zap.String("service", transferServiceName),
+				zap.String("method", "ListIncoming"),
+				zap.Duration("duration", duration),
+				zap.Error(err),
+			)
+		} else {
+			ls.logger.Info("ListIncoming completed",
+				zap.String("service", transferServiceName),
+				zap.String("method", "ListIncoming"),
+				zap.Int("total", resp.Total),
+				zap.Duration("duration", duration),
+			)
+		}
+	}()
+	return ls.svc.ListIncoming(ctx, evmAddr)
+}
+
+// PrepareAccept wraps the service method with logging.
+func (ls *logService) PrepareAccept(
+	ctx context.Context, evmAddr, contractID string, req *PrepareAcceptRequest,
+) (resp *PrepareResponse, err error) {
+	start := time.Now()
+	ls.logger.Info("PrepareAccept started",
+		zap.String("service", transferServiceName),
+		zap.String("method", "PrepareAccept"),
+		zap.String("evm_addr", evmAddr),
+		zap.String("contract_id", contractID),
+		zap.String("instrument_admin", req.InstrumentAdmin),
+	)
+	defer func() {
+		duration := time.Since(start)
+		if err != nil {
+			ls.logger.Error("PrepareAccept failed",
+				zap.String("service", transferServiceName),
+				zap.String("method", "PrepareAccept"),
+				zap.String("contract_id", contractID),
+				zap.Duration("duration", duration),
+				zap.Error(err),
+			)
+		} else {
+			ls.logger.Info("PrepareAccept completed",
+				zap.String("service", transferServiceName),
+				zap.String("method", "PrepareAccept"),
+				zap.String("transfer_id", resp.TransferID),
+				zap.String("party_id", resp.PartyID),
+				zap.Duration("duration", duration),
+			)
+		}
+	}()
+	return ls.svc.PrepareAccept(ctx, evmAddr, contractID, req)
+}
+
+// ExecuteAccept wraps the service method with logging.
+func (ls *logService) ExecuteAccept(
+	ctx context.Context, evmAddr string, req *ExecuteRequest,
+) (resp *ExecuteResponse, err error) {
+	start := time.Now()
+	ls.logger.Info("ExecuteAccept started",
+		zap.String("service", transferServiceName),
+		zap.String("method", "ExecuteAccept"),
+		zap.String("evm_addr", evmAddr),
+		zap.String("transfer_id", req.TransferID),
+		zap.String("signature", redactSignature(req.Signature)),
+		zap.String("signed_by", req.SignedBy),
+	)
+	defer func() {
+		duration := time.Since(start)
+		if err != nil {
+			ls.logger.Error("ExecuteAccept failed",
+				zap.String("service", transferServiceName),
+				zap.String("method", "ExecuteAccept"),
+				zap.String("transfer_id", req.TransferID),
+				zap.Duration("duration", duration),
+				zap.Error(err),
+			)
+		} else {
+			ls.logger.Info("ExecuteAccept completed",
+				zap.String("service", transferServiceName),
+				zap.String("method", "ExecuteAccept"),
+				zap.String("transfer_id", req.TransferID),
+				zap.String("status", resp.Status),
+				zap.Duration("duration", duration),
+			)
+		}
+	}()
+	return ls.svc.ExecuteAccept(ctx, evmAddr, req)
+}
+
 // redactSignature redacts signature data to show only metadata.
 // Signatures are sensitive and should not be logged in full.
 func redactSignature(sig string) string {

--- a/pkg/transfer/mocks/mock_canton_token.go
+++ b/pkg/transfer/mocks/mock_canton_token.go
@@ -22,6 +22,55 @@ func (_m *Token) EXPECT() *Token_Expecter {
 	return &Token_Expecter{mock: &_m.Mock}
 }
 
+// AcceptTransferInstruction provides a mock function with given fields: ctx, partyID, instructionCID, instrumentAdmin
+func (_m *Token) AcceptTransferInstruction(ctx context.Context, partyID string, instructionCID string, instrumentAdmin string) error {
+	ret := _m.Called(ctx, partyID, instructionCID, instrumentAdmin)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AcceptTransferInstruction")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) error); ok {
+		r0 = rf(ctx, partyID, instructionCID, instrumentAdmin)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Token_AcceptTransferInstruction_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AcceptTransferInstruction'
+type Token_AcceptTransferInstruction_Call struct {
+	*mock.Call
+}
+
+// AcceptTransferInstruction is a helper method to define mock.On call
+//   - ctx context.Context
+//   - partyID string
+//   - instructionCID string
+//   - instrumentAdmin string
+func (_e *Token_Expecter) AcceptTransferInstruction(ctx interface{}, partyID interface{}, instructionCID interface{}, instrumentAdmin interface{}) *Token_AcceptTransferInstruction_Call {
+	return &Token_AcceptTransferInstruction_Call{Call: _e.mock.On("AcceptTransferInstruction", ctx, partyID, instructionCID, instrumentAdmin)}
+}
+
+func (_c *Token_AcceptTransferInstruction_Call) Run(run func(ctx context.Context, partyID string, instructionCID string, instrumentAdmin string)) *Token_AcceptTransferInstruction_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string))
+	})
+	return _c
+}
+
+func (_c *Token_AcceptTransferInstruction_Call) Return(_a0 error) *Token_AcceptTransferInstruction_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Token_AcceptTransferInstruction_Call) RunAndReturn(run func(context.Context, string, string, string) error) *Token_AcceptTransferInstruction_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Burn provides a mock function with given fields: ctx, req
 func (_m *Token) Burn(ctx context.Context, req *token.BurnRequest) error {
 	ret := _m.Called(ctx, req)
@@ -112,6 +161,65 @@ func (_c *Token_ExecuteTransfer_Call) Return(_a0 error) *Token_ExecuteTransfer_C
 }
 
 func (_c *Token_ExecuteTransfer_Call) RunAndReturn(run func(context.Context, *token.ExecuteTransferRequest) error) *Token_ExecuteTransfer_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// FindPendingInboundTransferInstructions provides a mock function with given fields: ctx, partyID
+func (_m *Token) FindPendingInboundTransferInstructions(ctx context.Context, partyID string) ([]string, error) {
+	ret := _m.Called(ctx, partyID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FindPendingInboundTransferInstructions")
+	}
+
+	var r0 []string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) ([]string, error)); ok {
+		return rf(ctx, partyID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) []string); ok {
+		r0 = rf(ctx, partyID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, partyID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Token_FindPendingInboundTransferInstructions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FindPendingInboundTransferInstructions'
+type Token_FindPendingInboundTransferInstructions_Call struct {
+	*mock.Call
+}
+
+// FindPendingInboundTransferInstructions is a helper method to define mock.On call
+//   - ctx context.Context
+//   - partyID string
+func (_e *Token_Expecter) FindPendingInboundTransferInstructions(ctx interface{}, partyID interface{}) *Token_FindPendingInboundTransferInstructions_Call {
+	return &Token_FindPendingInboundTransferInstructions_Call{Call: _e.mock.On("FindPendingInboundTransferInstructions", ctx, partyID)}
+}
+
+func (_c *Token_FindPendingInboundTransferInstructions_Call) Run(run func(ctx context.Context, partyID string)) *Token_FindPendingInboundTransferInstructions_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *Token_FindPendingInboundTransferInstructions_Call) Return(_a0 []string, _a1 error) *Token_FindPendingInboundTransferInstructions_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Token_FindPendingInboundTransferInstructions_Call) RunAndReturn(run func(context.Context, string) ([]string, error)) *Token_FindPendingInboundTransferInstructions_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -697,6 +805,67 @@ func (_c *Token_Mint_Call) RunAndReturn(run func(context.Context, *token.MintReq
 	return _c
 }
 
+// PrepareAcceptTransfer provides a mock function with given fields: ctx, partyID, instructionCID, instrumentAdmin
+func (_m *Token) PrepareAcceptTransfer(ctx context.Context, partyID string, instructionCID string, instrumentAdmin string) (*token.PreparedTransfer, error) {
+	ret := _m.Called(ctx, partyID, instructionCID, instrumentAdmin)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PrepareAcceptTransfer")
+	}
+
+	var r0 *token.PreparedTransfer
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) (*token.PreparedTransfer, error)); ok {
+		return rf(ctx, partyID, instructionCID, instrumentAdmin)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) *token.PreparedTransfer); ok {
+		r0 = rf(ctx, partyID, instructionCID, instrumentAdmin)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*token.PreparedTransfer)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
+		r1 = rf(ctx, partyID, instructionCID, instrumentAdmin)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Token_PrepareAcceptTransfer_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PrepareAcceptTransfer'
+type Token_PrepareAcceptTransfer_Call struct {
+	*mock.Call
+}
+
+// PrepareAcceptTransfer is a helper method to define mock.On call
+//   - ctx context.Context
+//   - partyID string
+//   - instructionCID string
+//   - instrumentAdmin string
+func (_e *Token_Expecter) PrepareAcceptTransfer(ctx interface{}, partyID interface{}, instructionCID interface{}, instrumentAdmin interface{}) *Token_PrepareAcceptTransfer_Call {
+	return &Token_PrepareAcceptTransfer_Call{Call: _e.mock.On("PrepareAcceptTransfer", ctx, partyID, instructionCID, instrumentAdmin)}
+}
+
+func (_c *Token_PrepareAcceptTransfer_Call) Run(run func(ctx context.Context, partyID string, instructionCID string, instrumentAdmin string)) *Token_PrepareAcceptTransfer_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string))
+	})
+	return _c
+}
+
+func (_c *Token_PrepareAcceptTransfer_Call) Return(_a0 *token.PreparedTransfer, _a1 error) *Token_PrepareAcceptTransfer_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Token_PrepareAcceptTransfer_Call) RunAndReturn(run func(context.Context, string, string, string) (*token.PreparedTransfer, error)) *Token_PrepareAcceptTransfer_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // PrepareTransfer provides a mock function with given fields: ctx, req
 func (_m *Token) PrepareTransfer(ctx context.Context, req *token.PrepareTransferRequest) (*token.PreparedTransfer, error) {
 	ret := _m.Called(ctx, req)
@@ -905,114 +1074,6 @@ func (_c *Token_TransferInternalByPartyID_Call) Return(_a0 error) *Token_Transfe
 }
 
 func (_c *Token_TransferInternalByPartyID_Call) RunAndReturn(run func(context.Context, string, string, string, string, string) error) *Token_TransferInternalByPartyID_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// AcceptTransferInstruction provides a mock function with given fields: ctx, partyID, instructionCID, instrumentAdmin
-func (_m *Token) AcceptTransferInstruction(ctx context.Context, partyID string, instructionCID string, instrumentAdmin string) error {
-	ret := _m.Called(ctx, partyID, instructionCID, instrumentAdmin)
-
-	if len(ret) == 0 {
-		panic("no return value specified for AcceptTransferInstruction")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) error); ok {
-		r0 = rf(ctx, partyID, instructionCID, instrumentAdmin)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// Token_AcceptTransferInstruction_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AcceptTransferInstruction'
-type Token_AcceptTransferInstruction_Call struct {
-	*mock.Call
-}
-
-// AcceptTransferInstruction is a helper method to define mock.On call
-//   - ctx context.Context
-//   - partyID string
-//   - instructionCID string
-//   - instrumentAdmin string
-func (_e *Token_Expecter) AcceptTransferInstruction(ctx interface{}, partyID interface{}, instructionCID interface{}, instrumentAdmin interface{}) *Token_AcceptTransferInstruction_Call {
-	return &Token_AcceptTransferInstruction_Call{Call: _e.mock.On("AcceptTransferInstruction", ctx, partyID, instructionCID, instrumentAdmin)}
-}
-
-func (_c *Token_AcceptTransferInstruction_Call) Run(run func(ctx context.Context, partyID string, instructionCID string, instrumentAdmin string)) *Token_AcceptTransferInstruction_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string))
-	})
-	return _c
-}
-
-func (_c *Token_AcceptTransferInstruction_Call) Return(_a0 error) *Token_AcceptTransferInstruction_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *Token_AcceptTransferInstruction_Call) RunAndReturn(run func(context.Context, string, string, string) error) *Token_AcceptTransferInstruction_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// FindPendingInboundTransferInstructions provides a mock function with given fields: ctx, partyID
-func (_m *Token) FindPendingInboundTransferInstructions(ctx context.Context, partyID string) ([]string, error) {
-	ret := _m.Called(ctx, partyID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for FindPendingInboundTransferInstructions")
-	}
-
-	var r0 []string
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) ([]string, error)); ok {
-		return rf(ctx, partyID)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) []string); ok {
-		r0 = rf(ctx, partyID)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]string)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, partyID)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// Token_FindPendingInboundTransferInstructions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FindPendingInboundTransferInstructions'
-type Token_FindPendingInboundTransferInstructions_Call struct {
-	*mock.Call
-}
-
-// FindPendingInboundTransferInstructions is a helper method to define mock.On call
-//   - ctx context.Context
-//   - partyID string
-func (_e *Token_Expecter) FindPendingInboundTransferInstructions(ctx interface{}, partyID interface{}) *Token_FindPendingInboundTransferInstructions_Call {
-	return &Token_FindPendingInboundTransferInstructions_Call{Call: _e.mock.On("FindPendingInboundTransferInstructions", ctx, partyID)}
-}
-
-func (_c *Token_FindPendingInboundTransferInstructions_Call) Run(run func(ctx context.Context, partyID string)) *Token_FindPendingInboundTransferInstructions_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
-	})
-	return _c
-}
-
-func (_c *Token_FindPendingInboundTransferInstructions_Call) Return(_a0 []string, _a1 error) *Token_FindPendingInboundTransferInstructions_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *Token_FindPendingInboundTransferInstructions_Call) RunAndReturn(run func(context.Context, string) ([]string, error)) *Token_FindPendingInboundTransferInstructions_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/transfer/service.go
+++ b/pkg/transfer/service.go
@@ -35,6 +35,15 @@ type TransferCache interface {
 type Service interface {
 	Prepare(ctx context.Context, senderEVMAddr string, req *PrepareRequest) (*PrepareResponse, error)
 	Execute(ctx context.Context, senderEVMAddr string, req *ExecuteRequest) (*ExecuteResponse, error)
+
+	// ListIncoming returns pending inbound TransferOffer contract IDs for the authenticated user.
+	ListIncoming(ctx context.Context, evmAddr string) (*ListIncomingResponse, error)
+	// PrepareAccept builds a Canton transaction for accepting an inbound offer.
+	PrepareAccept(
+		ctx context.Context, evmAddr, contractID string, req *PrepareAcceptRequest,
+	) (*PrepareResponse, error)
+	// ExecuteAccept completes a previously prepared accept using the client's DER signature.
+	ExecuteAccept(ctx context.Context, evmAddr string, req *ExecuteRequest) (*ExecuteResponse, error)
 }
 
 // TransferService implements the non-custodial prepare/execute transfer flow.
@@ -155,4 +164,66 @@ func (s *TransferService) Execute(ctx context.Context, senderEVMAddr string, req
 	}
 
 	return &ExecuteResponse{Status: "completed"}, nil
+}
+
+// ListIncoming returns pending inbound TransferOffer contract IDs for the authenticated user.
+func (s *TransferService) ListIncoming(ctx context.Context, evmAddr string) (*ListIncomingResponse, error) {
+	u, err := s.userStore.GetUserByEVMAddress(ctx, evmAddr)
+	if err != nil {
+		if errors.Is(err, user.ErrUserNotFound) {
+			return nil, apperrors.UnAuthorizedError(err, "user not found")
+		}
+		return nil, fmt.Errorf("lookup user: %w", err)
+	}
+	if u.KeyMode != user.KeyModeExternal {
+		return nil, apperrors.BadRequestError(nil, "incoming transfer API requires key_mode=external")
+	}
+
+	contractIDs, err := s.cantonToken.FindPendingInboundTransferInstructions(ctx, u.CantonPartyID)
+	if err != nil {
+		return nil, fmt.Errorf("find pending inbound transfers: %w", err)
+	}
+
+	items := make([]IncomingTransfer, len(contractIDs))
+	for i, cid := range contractIDs {
+		items[i] = IncomingTransfer{ContractID: cid}
+	}
+	return &ListIncomingResponse{Items: items, Total: len(items)}, nil
+}
+
+// PrepareAccept builds a Canton transaction for accepting an inbound offer.
+func (s *TransferService) PrepareAccept(
+	ctx context.Context, evmAddr, contractID string, req *PrepareAcceptRequest,
+) (*PrepareResponse, error) {
+	u, err := s.userStore.GetUserByEVMAddress(ctx, evmAddr)
+	if err != nil {
+		if errors.Is(err, user.ErrUserNotFound) {
+			return nil, apperrors.UnAuthorizedError(err, "user not found")
+		}
+		return nil, fmt.Errorf("lookup user: %w", err)
+	}
+	if u.KeyMode != user.KeyModeExternal {
+		return nil, apperrors.BadRequestError(nil, "incoming transfer API requires key_mode=external")
+	}
+
+	pt, err := s.cantonToken.PrepareAcceptTransfer(ctx, u.CantonPartyID, contractID, req.InstrumentAdmin)
+	if err != nil {
+		return nil, fmt.Errorf("prepare accept: %w", err)
+	}
+
+	if err := s.cache.Put(pt); err != nil {
+		return nil, apperrors.GeneralError(fmt.Errorf("too many pending transfers: %w", err))
+	}
+
+	return &PrepareResponse{
+		TransferID:      pt.TransferID,
+		TransactionHash: "0x" + hex.EncodeToString(pt.TransactionHash),
+		PartyID:         pt.PartyID,
+		ExpiresAt:       pt.ExpiresAt.Format(time.RFC3339),
+	}, nil
+}
+
+// ExecuteAccept completes a previously prepared accept using the client's DER signature.
+func (s *TransferService) ExecuteAccept(ctx context.Context, evmAddr string, req *ExecuteRequest) (*ExecuteResponse, error) {
+	return s.Execute(ctx, evmAddr, req)
 }

--- a/pkg/transfer/service_test.go
+++ b/pkg/transfer/service_test.go
@@ -240,3 +240,154 @@ func TestTransferService_Execute_InvalidSignature_ReturnsForbidden(t *testing.T)
 	})
 	assertServiceErrorCategory(t, err, apperrors.CategoryForbidden)
 }
+
+// --- ListIncoming tests ---
+
+func TestTransferService_ListIncoming_Success(t *testing.T) {
+	ctx := context.Background()
+	sender := senderUser()
+
+	store := mocks.NewUserStore(t)
+	store.EXPECT().GetUserByEVMAddress(ctx, sender.EVMAddress).Return(sender, nil).Once()
+
+	tok := mocks.NewToken(t)
+	tok.EXPECT().FindPendingInboundTransferInstructions(ctx, sender.CantonPartyID).
+		Return([]string{"cid-1", "cid-2"}, nil).Once()
+
+	svc := newTestService(tok, store, mocks.NewTransferCache(t))
+
+	resp, err := svc.ListIncoming(ctx, sender.EVMAddress)
+	require.NoError(t, err)
+	assert.Equal(t, 2, resp.Total)
+	assert.Equal(t, "cid-1", resp.Items[0].ContractID)
+	assert.Equal(t, "cid-2", resp.Items[1].ContractID)
+}
+
+func TestTransferService_ListIncoming_UserNotFound(t *testing.T) {
+	ctx := context.Background()
+
+	store := mocks.NewUserStore(t)
+	store.EXPECT().GetUserByEVMAddress(ctx, senderUser().EVMAddress).Return(nil, user.ErrUserNotFound).Once()
+
+	svc := newTestService(mocks.NewToken(t), store, mocks.NewTransferCache(t))
+
+	_, err := svc.ListIncoming(ctx, senderUser().EVMAddress)
+	assertServiceErrorCategory(t, err, apperrors.CategoryUnauthorized)
+}
+
+func TestTransferService_ListIncoming_CustodialUserRejected(t *testing.T) {
+	ctx := context.Background()
+	sender := senderUser()
+	sender.KeyMode = user.KeyModeCustodial
+
+	store := mocks.NewUserStore(t)
+	store.EXPECT().GetUserByEVMAddress(ctx, sender.EVMAddress).Return(sender, nil).Once()
+
+	svc := newTestService(mocks.NewToken(t), store, mocks.NewTransferCache(t))
+
+	_, err := svc.ListIncoming(ctx, sender.EVMAddress)
+	assertServiceErrorCategory(t, err, apperrors.CategoryDataError)
+}
+
+// --- PrepareAccept tests ---
+
+func TestTransferService_PrepareAccept_Success(t *testing.T) {
+	ctx := context.Background()
+	sender := senderUser()
+	const contractID = "offer-contract-1"
+	const instrumentAdmin = "admin::zzz"
+
+	store := mocks.NewUserStore(t)
+	store.EXPECT().GetUserByEVMAddress(ctx, sender.EVMAddress).Return(sender, nil).Once()
+
+	pt := &token.PreparedTransfer{
+		TransferID:      "accept-txn-1",
+		TransactionHash: []byte{0xab, 0xcd},
+		PartyID:         sender.CantonPartyID,
+		ExpiresAt:       time.Now().Add(2 * time.Minute),
+	}
+
+	tok := mocks.NewToken(t)
+	tok.EXPECT().PrepareAcceptTransfer(ctx, sender.CantonPartyID, contractID, instrumentAdmin).
+		Return(pt, nil).Once()
+
+	cache := mocks.NewTransferCache(t)
+	cache.EXPECT().Put(pt).Return(nil).Once()
+
+	svc := newTestService(tok, store, cache)
+
+	resp, err := svc.PrepareAccept(ctx, sender.EVMAddress, contractID, &PrepareAcceptRequest{
+		InstrumentAdmin: instrumentAdmin,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "accept-txn-1", resp.TransferID)
+	assert.Equal(t, "0xabcd", resp.TransactionHash)
+	assert.Equal(t, sender.CantonPartyID, resp.PartyID)
+}
+
+func TestTransferService_PrepareAccept_UserNotFound(t *testing.T) {
+	ctx := context.Background()
+
+	store := mocks.NewUserStore(t)
+	store.EXPECT().GetUserByEVMAddress(ctx, senderUser().EVMAddress).Return(nil, user.ErrUserNotFound).Once()
+
+	svc := newTestService(mocks.NewToken(t), store, mocks.NewTransferCache(t))
+
+	_, err := svc.PrepareAccept(ctx, senderUser().EVMAddress, "cid-1", &PrepareAcceptRequest{
+		InstrumentAdmin: "admin::zzz",
+	})
+	assertServiceErrorCategory(t, err, apperrors.CategoryUnauthorized)
+}
+
+func TestTransferService_PrepareAccept_CustodialUserRejected(t *testing.T) {
+	ctx := context.Background()
+	sender := senderUser()
+	sender.KeyMode = user.KeyModeCustodial
+
+	store := mocks.NewUserStore(t)
+	store.EXPECT().GetUserByEVMAddress(ctx, sender.EVMAddress).Return(sender, nil).Once()
+
+	svc := newTestService(mocks.NewToken(t), store, mocks.NewTransferCache(t))
+
+	_, err := svc.PrepareAccept(ctx, sender.EVMAddress, "cid-1", &PrepareAcceptRequest{
+		InstrumentAdmin: "admin::zzz",
+	})
+	assertServiceErrorCategory(t, err, apperrors.CategoryDataError)
+}
+
+// --- ExecuteAccept tests ---
+
+func TestTransferService_ExecuteAccept_DelegatesToExecute(t *testing.T) {
+	ctx := context.Background()
+	sender := senderUser()
+
+	store := mocks.NewUserStore(t)
+	store.EXPECT().GetUserByEVMAddress(ctx, sender.EVMAddress).Return(sender, nil).Once()
+
+	pt := &token.PreparedTransfer{
+		TransferID:      "accept-exec-1",
+		TransactionHash: []byte{0xff},
+		PartyID:         sender.CantonPartyID,
+		ExpiresAt:       time.Now().Add(2 * time.Minute),
+	}
+
+	cache := mocks.NewTransferCache(t)
+	cache.EXPECT().GetAndDelete("accept-exec-1").Return(pt, nil).Once()
+
+	tok := mocks.NewToken(t)
+	tok.EXPECT().ExecuteTransfer(ctx, mock.MatchedBy(func(req *token.ExecuteTransferRequest) bool {
+		return req.PreparedTransfer == pt && req.SignedBy == sender.CantonPublicKeyFingerprint
+	})).Return(nil).Once()
+
+	svc := newTestService(tok, store, cache)
+
+	resp, err := svc.ExecuteAccept(ctx, sender.EVMAddress, &ExecuteRequest{
+		TransferID: "accept-exec-1",
+		Signature:  "0xdeadbeef",
+		SignedBy:   sender.CantonPublicKeyFingerprint,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "completed", resp.Status)
+}

--- a/pkg/transfer/types.go
+++ b/pkg/transfer/types.go
@@ -27,3 +27,19 @@ type ExecuteRequest struct {
 type ExecuteResponse struct {
 	Status string `json:"status"` // "completed"
 }
+
+// IncomingTransfer represents a single pending inbound transfer offer.
+type IncomingTransfer struct {
+	ContractID string `json:"contract_id"`
+}
+
+// ListIncomingResponse is the HTTP response body for GET /transfer/incoming.
+type ListIncomingResponse struct {
+	Items []IncomingTransfer `json:"items"`
+	Total int                `json:"total"`
+}
+
+// PrepareAcceptRequest is the HTTP request body for preparing a non-custodial accept.
+type PrepareAcceptRequest struct {
+	InstrumentAdmin string `json:"instrument_admin"` // Canton party ID of the instrument admin
+}


### PR DESCRIPTION
## Summary
- Adds `GET /api/v2/transfer/incoming` — lists pending inbound `TransferOffer` contract IDs for the authenticated external-key user (via Canton ACS scan)
- Adds `POST /api/v2/transfer/incoming/{contractID}/prepare` — builds an accept transaction for external signing, returns `transfer_id` + `transaction_hash`
- Adds `POST /api/v2/transfer/incoming/{contractID}/execute` — completes the accept using the client's DER signature
- Adds `PrepareAcceptTransfer` to the Canton `Token` interface + `Client` implementation
- All endpoints require EIP-191 authentication (`X-Signature`/`X-Message` headers) and reject custodial users

## Test plan
- [ ] `TestTransferService_ListIncoming_Success` — returns contract IDs
- [ ] `TestTransferService_ListIncoming_UserNotFound` — 401
- [ ] `TestTransferService_ListIncoming_CustodialUserRejected` — 400
- [ ] `TestTransferService_PrepareAccept_Success` — returns transaction hash for signing
- [ ] `TestTransferService_PrepareAccept_UserNotFound` — 401
- [ ] `TestTransferService_PrepareAccept_CustodialUserRejected` — 400
- [ ] `TestTransferService_ExecuteAccept_DelegatesToExecute` — complete accept flow