### PR TITLE
fix: USDCx registry — match DA hosted token-standard API shape

### DIFF
--- a/pkg/cantonsdk/token/client.go
+++ b/pkg/cantonsdk/token/client.go
@@ -595,6 +595,8 @@ type transferFactoryRequest struct {
 	// TransferFactory_Transfer choice arguments. The AllocationFactory choice
 	// asserts requestedAt < ledger-time < executeBefore, so they must be stable
 	// across the registry call and the choice exercise.
+	// Note: registry sees second-precision and ledger sees nanosecond 
+	// where both representations are derived from the same time.Time.
 	RequestedAt   time.Time
 	ExecuteBefore time.Time
 }

--- a/pkg/cantonsdk/token/client.go
+++ b/pkg/cantonsdk/token/client.go
@@ -595,7 +595,7 @@ type transferFactoryRequest struct {
 	// TransferFactory_Transfer choice arguments. The AllocationFactory choice
 	// asserts requestedAt < ledger-time < executeBefore, so they must be stable
 	// across the registry call and the choice exercise.
-	// Note: registry sees second-precision and ledger sees nanosecond 
+	// Note: registry sees second-precision and ledger sees nanosecond
 	// where both representations are derived from the same time.Time.
 	RequestedAt   time.Time
 	ExecuteBefore time.Time

--- a/pkg/cantonsdk/token/client.go
+++ b/pkg/cantonsdk/token/client.go
@@ -590,6 +590,13 @@ type transferFactoryRequest struct {
 	AnyValueContext    AcceptChoiceContext
 	DisclosedContracts []*lapiv2.DisclosedContract
 	IsExternal         bool
+	// RequestedAt / ExecuteBefore are computed once in resolveTransferFactory so
+	// the timestamps sent to the registry match the ones used in the on-ledger
+	// TransferFactory_Transfer choice arguments. The AllocationFactory choice
+	// asserts requestedAt < ledger-time < executeBefore, so they must be stable
+	// across the registry call and the choice exercise.
+	RequestedAt   time.Time
+	ExecuteBefore time.Time
 }
 
 func (c *Client) transferViaFactory(ctx context.Context, req *transferFactoryRequest) error {
@@ -629,12 +636,17 @@ func (c *Client) transferViaFactory(ctx context.Context, req *transferFactoryReq
 // Shared between custodial (transferViaFactory) and non-custodial (PrepareTransfer) paths.
 // Returns an error only when AnyValueContext encoding fails (invalid AnyValue tags).
 func (c *Client) buildTransferCommand(req *transferFactoryRequest) (*lapiv2.Command, error) {
-	// Backdate requestedAt by a few seconds: the AllocationFactory choice asserts
-	// `requestedAt < ledger time`, and Canton's ledger time can lag wall-clock by
-	// up to ~mediator-reaction-timeout on busy stacks. A 5s skew is safely within
-	// defaultTransferValidity (1h) and avoids spurious "requestedAt must be in
-	// the past" rejections.
-	now := time.Now().UTC().Add(-5 * time.Second)
+	// requestedAt / executeBefore are populated by resolveTransferFactory so the
+	// registry call and the on-ledger choice see identical timestamps. Fall back
+	// to computing them here for callers that bypass resolveTransferFactory.
+	requestedAt := req.RequestedAt
+	executeBefore := req.ExecuteBefore
+	if requestedAt.IsZero() {
+		requestedAt = time.Now().UTC().Add(-5 * time.Second)
+	}
+	if executeBefore.IsZero() {
+		executeBefore = requestedAt.Add(defaultTransferValidity)
+	}
 
 	// For AllocationFactory tokens the choice context must be encoded as TextMap AnyValue.
 	// For CIP56TransferFactory tokens (empty context) the standard TextMap Text encoding is used.
@@ -677,8 +689,8 @@ func (c *Client) buildTransferCommand(req *transferFactoryRequest) (*lapiv2.Comm
 							req.Amount,
 							req.InstrumentAdmin,
 							req.InstrumentID,
-							now,
-							now.Add(defaultTransferValidity),
+							requestedAt,
+							executeBefore,
 							req.InputHoldingCIDs,
 							extraArgsValue,
 						),
@@ -870,6 +882,12 @@ func (c *Client) queryFactoryContracts(ctx context.Context, filter *lapiv2.Cumul
 // For our tokens (InstrumentAdmin == IssuerParty): uses local ACS query.
 // For external tokens: calls the Transfer Factory Registry API.
 func (c *Client) resolveTransferFactory(ctx context.Context, req *transferFactoryRequest) error {
+	// Backdate requestedAt by a few seconds: the AllocationFactory choice asserts
+	// `requestedAt < ledger time`, and Canton's ledger time can lag wall-clock by
+	// up to ~mediator-reaction-timeout on busy stacks.
+	req.RequestedAt = time.Now().UTC().Add(-5 * time.Second)
+	req.ExecuteBefore = req.RequestedAt.Add(defaultTransferValidity)
+
 	if req.InstrumentAdmin == c.cfg.IssuerParty {
 		cid, err := c.getTransferFactoryCID(ctx)
 		if err != nil {
@@ -888,14 +906,23 @@ func (c *Client) resolveTransferFactory(ctx context.Context, req *transferFactor
 		return fmt.Errorf("unsupported external token issuer: %s", req.InstrumentAdmin)
 	}
 
-	regResp, err := c.registryClient.GetTransferFactory(ctx, extCfg.RegistryURL, &RegistryRequest{
-		ExpectedAdmin: req.InstrumentAdmin,
-		Transfer: RegistryTransferDetail{
-			Sender:           req.FromPartyID,
-			Receiver:         req.ToPartyID,
-			Amount:           req.Amount,
-			InstrumentID:     req.InstrumentID,
-			InputHoldingCIDs: req.InputHoldingCIDs,
+	regResp, err := c.registryClient.GetTransferFactory(ctx, extCfg.RegistryURL, req.InstrumentAdmin, &RegistryRequest{
+		ChoiceArguments: ChoiceArguments{
+			ExpectedAdmin: req.InstrumentAdmin,
+			Transfer: RegistryTransferDetail{
+				Sender:           req.FromPartyID,
+				Receiver:         req.ToPartyID,
+				Amount:           req.Amount,
+				InstrumentID:     InstrumentRef{Admin: req.InstrumentAdmin, ID: req.InstrumentID},
+				InputHoldingCIDs: req.InputHoldingCIDs,
+				Meta:             AnyValueMap{Values: map[string]any{}},
+				RequestedAt:      req.RequestedAt.Format(time.RFC3339),
+				ExecuteBefore:    req.ExecuteBefore.Format(time.RFC3339),
+			},
+			ExtraArgs: ExtraArgs{
+				Context: AnyValueMap{Values: map[string]any{}},
+				Meta:    AnyValueMap{Values: map[string]any{}},
+			},
 		},
 	})
 	if err != nil {

--- a/pkg/cantonsdk/token/registry_client.go
+++ b/pkg/cantonsdk/token/registry_client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	lapiv2 "github.com/chainsafe/canton-middleware/pkg/cantonsdk/lapi/v2"
@@ -83,11 +84,30 @@ type InstrumentRef struct {
 	ID    string `json:"id"`
 }
 
-// RegistryResponse is the response from the Transfer Factory Registry API.
+// RegistryResponse is the registry response as consumed by the SDK.
+// `ChoiceContext` holds the AnyValue map (i.e. `choiceContext.choiceContextData`
+// from the wire shape) and `DisclosedContracts` holds the array — both lifted
+// out of the wire envelope by GetTransferFactory so the downstream converters
+// (ConvertAnyValueChoiceContext / ConvertDisclosedContracts) can consume them
+// directly.
 type RegistryResponse struct {
 	FactoryID          string          `json:"factoryId"`
 	TransferKind       string          `json:"transferKind"`
 	ChoiceContext      json.RawMessage `json:"choiceContext"`
+	DisclosedContracts json.RawMessage `json:"disclosedContracts"`
+}
+
+// registryWireResponse mirrors DA's hosted token-standard registry response,
+// where the AnyValue choice context and the disclosed contracts are both
+// nested inside `choiceContext` (matching the receiver-side AcceptContextResponse).
+type registryWireResponse struct {
+	FactoryID     string          `json:"factoryId"`
+	TransferKind  string          `json:"transferKind"`
+	ChoiceContext json.RawMessage `json:"choiceContext"`
+}
+
+type registryWireChoiceContext struct {
+	ChoiceContextData  json.RawMessage `json:"choiceContextData"`
 	DisclosedContracts json.RawMessage `json:"disclosedContracts"`
 }
 
@@ -112,8 +132,8 @@ func (rc *RegistryClient) GetTransferFactory(
 		return nil, fmt.Errorf("marshal registry request: %w", err)
 	}
 
-	url := strings.TrimRight(registryBaseURL, "/") + fmt.Sprintf(registryPathFmt, registrarParty)
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	reqURL := strings.TrimRight(registryBaseURL, "/") + fmt.Sprintf(registryPathFmt, url.PathEscape(registrarParty))
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("create registry request: %w", err)
 	}
@@ -135,12 +155,28 @@ func (rc *RegistryClient) GetTransferFactory(
 		return nil, fmt.Errorf("registry returned %d: %s", resp.StatusCode, string(respBody))
 	}
 
-	var result RegistryResponse
-	if err := json.Unmarshal(respBody, &result); err != nil {
+	var wire registryWireResponse
+	if err := json.Unmarshal(respBody, &wire); err != nil {
 		return nil, fmt.Errorf("parse registry response: %w", err)
 	}
 
-	return &result, nil
+	// DA's hosted registry wraps `choiceContextData` and `disclosedContracts`
+	// inside `choiceContext` — lift them out so callers see the legacy flat
+	// shape the SDK's converters already understand. A null/absent
+	// choiceContext leaves both fields empty, which the converters short-circuit.
+	var inner registryWireChoiceContext
+	if len(wire.ChoiceContext) > 0 && string(wire.ChoiceContext) != jsonNull {
+		if err := json.Unmarshal(wire.ChoiceContext, &inner); err != nil {
+			return nil, fmt.Errorf("parse choiceContext wrapper: %w", err)
+		}
+	}
+
+	return &RegistryResponse{
+		FactoryID:          wire.FactoryID,
+		TransferKind:       wire.TransferKind,
+		ChoiceContext:      inner.ChoiceContextData,
+		DisclosedContracts: inner.DisclosedContracts,
+	}, nil
 }
 
 // ConvertDisclosedContracts parses the registry's disclosed contracts JSON into proto messages.

--- a/pkg/cantonsdk/token/registry_client.go
+++ b/pkg/cantonsdk/token/registry_client.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	registryPath         = "/registry/transfer-instruction/v1/transfer-factory"
+	registryPathFmt      = "/api/token-standard/v0/registrars/%s/registry/transfer-instruction/v1/transfer-factory"
 	acceptContextPathFmt = "/api/token-standard/v0/registrars/%s/registry/transfer-instruction/v1/%s/choice-contexts/accept"
 )
 
@@ -33,19 +33,54 @@ func NewRegistryClient(httpClient *http.Client) *RegistryClient {
 }
 
 // RegistryRequest is the POST body for the Transfer Factory Registry API.
+// Shape matches the Splice token-standard spec as hosted by DA's utilities API
+// (e.g. api.utilities.digitalasset-dev.com): choice arguments are wrapped in
+// `choiceArguments`, with a sibling `excludeDebugFields` flag.
 type RegistryRequest struct {
+	ChoiceArguments    ChoiceArguments `json:"choiceArguments"`
+	ExcludeDebugFields bool            `json:"excludeDebugFields"`
+}
+
+// ChoiceArguments wraps the on-ledger TransferFactory_Transfer choice arguments
+// alongside the off-ledger extraArgs (context + meta) consumed by the registry.
+type ChoiceArguments struct {
 	ExpectedAdmin string                 `json:"expectedAdmin"`
 	Transfer      RegistryTransferDetail `json:"transfer"`
-	ExtraArgs     map[string]any         `json:"extraArgs,omitempty"`
+	ExtraArgs     ExtraArgs              `json:"extraArgs"`
+}
+
+// ExtraArgs carries the off-ledger context and meta AnyValue maps required
+// by the AllocationFactory's TransferFactory_Transfer choice.
+type ExtraArgs struct {
+	Context AnyValueMap `json:"context"`
+	Meta    AnyValueMap `json:"meta"`
+}
+
+// AnyValueMap models the `{"values": {...}}` AnyValue container that wraps
+// metadata and context maps in the Splice token-standard JSON.
+type AnyValueMap struct {
+	Values map[string]any `json:"values"`
 }
 
 // RegistryTransferDetail contains the transfer parameters for registry lookup.
+// `executeBefore` and `requestedAt` are RFC3339 timestamps; the registry uses
+// them to assert the transfer falls within the issuer's validity window.
 type RegistryTransferDetail struct {
-	Sender           string   `json:"sender"`
-	Receiver         string   `json:"receiver"`
-	Amount           string   `json:"amount"`
-	InstrumentID     string   `json:"instrumentId"`
-	InputHoldingCIDs []string `json:"inputHoldingCids"`
+	Sender           string        `json:"sender"`
+	Receiver         string        `json:"receiver"`
+	Amount           string        `json:"amount"`
+	InstrumentID     InstrumentRef `json:"instrumentId"`
+	InputHoldingCIDs []string      `json:"inputHoldingCids"`
+	Meta             AnyValueMap   `json:"meta"`
+	ExecuteBefore    string        `json:"executeBefore"`
+	RequestedAt      string        `json:"requestedAt"`
+}
+
+// InstrumentRef is the structured instrument identifier the registry expects:
+// the issuer admin party plus the instrument id within that issuer's namespace.
+type InstrumentRef struct {
+	Admin string `json:"admin"`
+	ID    string `json:"id"`
 }
 
 // RegistryResponse is the response from the Transfer Factory Registry API.
@@ -67,13 +102,17 @@ type registryDisclosedContract struct {
 }
 
 // GetTransferFactory calls the registry to discover the transfer factory for an external token.
-func (rc *RegistryClient) GetTransferFactory(ctx context.Context, registryBaseURL string, req *RegistryRequest) (*RegistryResponse, error) {
+// registrarParty is the issuer's party ID under whose namespace the registry is mounted
+// (DA's hosted multi-registrar API multiplexes registrars by URL path).
+func (rc *RegistryClient) GetTransferFactory(
+	ctx context.Context, registryBaseURL, registrarParty string, req *RegistryRequest,
+) (*RegistryResponse, error) {
 	body, err := json.Marshal(req)
 	if err != nil {
 		return nil, fmt.Errorf("marshal registry request: %w", err)
 	}
 
-	url := strings.TrimRight(registryBaseURL, "/") + registryPath
+	url := strings.TrimRight(registryBaseURL, "/") + fmt.Sprintf(registryPathFmt, registrarParty)
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("create registry request: %w", err)

--- a/scripts/setup/usdcx-registry.go
+++ b/scripts/setup/usdcx-registry.go
@@ -126,12 +126,20 @@ type InstrumentRef struct {
 	ID    string `json:"id"`
 }
 
-// RegistryResponse is the response body parsed by RegistryClient.GetTransferFactory.
+// RegistryResponse is the wire response, matching DA's hosted token-standard
+// registry shape: the AnyValue choice context and the disclosed contracts are
+// both nested inside `choiceContext` (the same envelope used by the
+// receiver-side AcceptContextResponse).
 type RegistryResponse struct {
-	FactoryID          string              `json:"factoryId"`
-	TransferKind       string              `json:"transferKind"`
-	ChoiceContext      any                 `json:"choiceContext"`
-	DisclosedContracts []DisclosedContract `json:"disclosedContracts"`
+	FactoryID     string              `json:"factoryId"`
+	TransferKind  string              `json:"transferKind"`
+	ChoiceContext registryChoiceCtxResp `json:"choiceContext"`
+}
+
+// registryChoiceCtxResp is the nested envelope returned inside `choiceContext`.
+type registryChoiceCtxResp struct {
+	ChoiceContextData  acceptChoiceContextData `json:"choiceContextData"`
+	DisclosedContracts []DisclosedContract     `json:"disclosedContracts"`
 }
 
 // DisclosedContract matches the registryDisclosedContract shape in registry_client.go.
@@ -411,28 +419,30 @@ func (s *server) queryFactory(ctx context.Context) (*RegistryResponse, error) {
 	return &RegistryResponse{
 		FactoryID:    factoryCID,
 		TransferKind: "transfer",
-		ChoiceContext: map[string]any{
-			"values": map[string]any{
-				"utility.digitalasset.com/instrument-configuration": map[string]string{
-					"tag": "AV_ContractId", "value": configCID,
-				},
-				"utility.digitalasset.com/sender-credentials": map[string]any{
-					"tag": "AV_List", "value": []any{},
+		ChoiceContext: registryChoiceCtxResp{
+			ChoiceContextData: acceptChoiceContextData{
+				Values: map[string]any{
+					"utility.digitalasset.com/instrument-configuration": map[string]string{
+						"tag": "AV_ContractId", "value": configCID,
+					},
+					"utility.digitalasset.com/sender-credentials": map[string]any{
+						"tag": "AV_List", "value": []any{},
+					},
 				},
 			},
-		},
-		DisclosedContracts: []DisclosedContract{
-			{
-				ContractID:       factoryCID,
-				CreatedEventBlob: base64.StdEncoding.EncodeToString(factoryBlob),
-				TemplateID:       templateIDStr(factoryTID),
-				SynchronizerID:   s.domain,
-			},
-			{
-				ContractID:       configCID,
-				CreatedEventBlob: base64.StdEncoding.EncodeToString(configBlob),
-				TemplateID:       templateIDStr(instrumentConfigTID),
-				SynchronizerID:   s.domain,
+			DisclosedContracts: []DisclosedContract{
+				{
+					ContractID:       factoryCID,
+					CreatedEventBlob: base64.StdEncoding.EncodeToString(factoryBlob),
+					TemplateID:       templateIDStr(factoryTID),
+					SynchronizerID:   s.domain,
+				},
+				{
+					ContractID:       configCID,
+					CreatedEventBlob: base64.StdEncoding.EncodeToString(configBlob),
+					TemplateID:       templateIDStr(instrumentConfigTID),
+					SynchronizerID:   s.domain,
+				},
 			},
 		},
 	}, nil

--- a/scripts/setup/usdcx-registry.go
+++ b/scripts/setup/usdcx-registry.go
@@ -10,10 +10,14 @@
 // are required.
 //
 // Sender-side endpoint:
-//   POST /registry/transfer-instruction/v1/transfer-factory
+//   POST /api/token-standard/v0/registrars/{registrar}/registry/transfer-instruction/v1/transfer-factory
 //
 //   Request body (RegistryRequest):
-//     { "expectedAdmin": "<party>", "transfer": { "sender": "...", ... } }
+//     { "choiceArguments": { "expectedAdmin": "<party>",
+//                            "transfer": { "sender": "...",
+//                                          "instrumentId": {"admin":"...","id":"USDCx"}, ... },
+//                            "extraArgs": {"context":{"values":{}},"meta":{"values":{}}} },
+//       "excludeDebugFields": false }
 //
 //   Response body (RegistryResponse):
 //     { "factoryId": "...", "transferKind": "transfer",
@@ -77,18 +81,49 @@ var (
 // These must match the JSON shapes in pkg/cantonsdk/token/registry_client.go.
 
 // RegistryRequest is the POST body sent by RegistryClient.GetTransferFactory.
+// Mirrors the Splice token-standard shape DA's hosted registry expects: the
+// on-ledger choice arguments live under `choiceArguments`.
 type RegistryRequest struct {
+	ChoiceArguments    ChoiceArguments `json:"choiceArguments"`
+	ExcludeDebugFields bool            `json:"excludeDebugFields"`
+}
+
+// ChoiceArguments wraps the TransferFactory_Transfer arguments plus the
+// off-ledger extraArgs the registry uses to build the choice context.
+type ChoiceArguments struct {
 	ExpectedAdmin string         `json:"expectedAdmin"`
 	Transfer      TransferDetail `json:"transfer"`
+	ExtraArgs     ExtraArgs      `json:"extraArgs"`
+}
+
+// ExtraArgs is the off-ledger context/meta envelope. Both maps are empty for
+// the local devstack — the registry derives the real context from P2's ACS.
+type ExtraArgs struct {
+	Context AnyValueMap `json:"context"`
+	Meta    AnyValueMap `json:"meta"`
+}
+
+// AnyValueMap models the Splice `{"values":{...}}` AnyValue container.
+type AnyValueMap struct {
+	Values map[string]any `json:"values"`
 }
 
 // TransferDetail carries the transfer parameters sent by the caller.
 type TransferDetail struct {
-	Sender           string   `json:"sender"`
-	Receiver         string   `json:"receiver"`
-	Amount           string   `json:"amount"`
-	InstrumentID     string   `json:"instrumentId"`
-	InputHoldingCIDs []string `json:"inputHoldingCids"`
+	Sender           string        `json:"sender"`
+	Receiver         string        `json:"receiver"`
+	Amount           string        `json:"amount"`
+	InstrumentID     InstrumentRef `json:"instrumentId"`
+	InputHoldingCIDs []string      `json:"inputHoldingCids"`
+	Meta             AnyValueMap   `json:"meta"`
+	ExecuteBefore    string        `json:"executeBefore"`
+	RequestedAt      string        `json:"requestedAt"`
+}
+
+// InstrumentRef is the structured instrument identifier {admin, id}.
+type InstrumentRef struct {
+	Admin string `json:"admin"`
+	ID    string `json:"id"`
 }
 
 // RegistryResponse is the response body parsed by RegistryClient.GetTransferFactory.
@@ -239,9 +274,9 @@ func main() {
 	}
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/registry/transfer-instruction/v1/transfer-factory", srv.handleTransferFactory)
-	// Receiver-side accept context endpoint — matches DA's registrar URL pattern.
-	mux.HandleFunc("/api/token-standard/v0/registrars/", srv.handleAcceptContext)
+	// Both registry endpoints are mounted per-registrar under the same prefix,
+	// matching DA's hosted registry URL scheme. Dispatch by suffix below.
+	mux.HandleFunc("/api/token-standard/v0/registrars/", srv.routeRegistrar)
 	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("OK"))
@@ -254,9 +289,45 @@ func main() {
 	}
 }
 
+// ─── Router ──────────────────────────────────────────────────────────────────
+
+// routeRegistrar dispatches requests under /api/token-standard/v0/registrars/
+// to the sender-side or receiver-side handler based on the URL suffix, after
+// validating that the registrar in the path matches our discovered issuer.
+func (s *server) routeRegistrar(w http.ResponseWriter, r *http.Request) {
+	// Strip the registered prefix; remainder is:
+	//   {registrar}/registry/transfer-instruction/v1/transfer-factory
+	//   {registrar}/registry/transfer-instruction/v1/{cid}/choice-contexts/accept
+	remainder := strings.TrimPrefix(r.URL.Path, "/api/token-standard/v0/registrars/")
+	parts := strings.SplitN(remainder, "/", 8)
+	if len(parts) < 5 || parts[1] != "registry" || parts[2] != "transfer-instruction" || parts[3] != "v1" {
+		writeJSON(w, http.StatusNotFound, errorBody{Error: "not found"})
+		return
+	}
+	registrar := parts[0]
+	if registrar != s.issuer {
+		writeJSON(w, http.StatusBadRequest, errorBody{
+			Error: fmt.Sprintf("registrar %q not managed by this registry", registrar),
+		})
+		return
+	}
+
+	switch {
+	case len(parts) == 5 && parts[4] == "transfer-factory":
+		s.handleTransferFactory(w, r)
+	case len(parts) == 7 && parts[5] == "choice-contexts" && parts[6] == "accept":
+		s.handleAcceptContext(w, r)
+	default:
+		writeJSON(w, http.StatusNotFound, errorBody{Error: "not found"})
+	}
+}
+
 // ─── Sender-side handler ──────────────────────────────────────────────────────
 
-// handleTransferFactory implements POST /registry/transfer-instruction/v1/transfer-factory.
+// handleTransferFactory implements POST
+// /api/token-standard/v0/registrars/{registrar}/registry/transfer-instruction/v1/transfer-factory.
+// Registrar match is enforced by routeRegistrar; this handler only validates
+// the choiceArguments.expectedAdmin matches.
 func (s *server) handleTransferFactory(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		writeJSON(w, http.StatusMethodNotAllowed, errorBody{Error: "method not allowed"})
@@ -270,9 +341,9 @@ func (s *server) handleTransferFactory(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.ExpectedAdmin != s.issuer {
+	if req.ChoiceArguments.ExpectedAdmin != s.issuer {
 		writeJSON(w, http.StatusBadRequest, errorBody{
-			Error: fmt.Sprintf("expectedAdmin %q does not match issuer", req.ExpectedAdmin),
+			Error: fmt.Sprintf("expectedAdmin %q does not match issuer", req.ChoiceArguments.ExpectedAdmin),
 		})
 		return
 	}
@@ -375,31 +446,12 @@ func (s *server) queryFactory(ctx context.Context) (*RegistryResponse, error) {
 //
 // Returns the choiceContextData (TransferRule + InstrumentConfiguration contract IDs as
 // AV_ContractId AnyValues) and their createdEventBlobs as disclosedContracts.
-// The {cid} path parameter is accepted but not used — context is instrument-level,
-// not per-offer, for the local devstack with a single instrument.
+// Path validation and registrar match are handled by routeRegistrar.
+// The {cid} path parameter is ignored — context is instrument-level, not
+// per-offer, for the local devstack with a single instrument.
 func (s *server) handleAcceptContext(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		writeJSON(w, http.StatusMethodNotAllowed, errorBody{Error: "method not allowed"})
-		return
-	}
-
-	// Path: /api/token-standard/v0/registrars/{registrar}/registry/transfer-instruction/v1/{cid}/choice-contexts/accept
-	// After stripping the registered prefix "/api/token-standard/v0/registrars/" the remainder is:
-	// {registrar}/registry/transfer-instruction/v1/{cid}/choice-contexts/accept
-	remainder := strings.TrimPrefix(r.URL.Path, "/api/token-standard/v0/registrars/")
-	parts := strings.SplitN(remainder, "/", 8)
-	// parts[0]=registrar, [1]=registry, [2]=transfer-instruction, [3]=v1, [4]=cid,
-	// [5]=choice-contexts, [6]=accept
-	if len(parts) < 7 || parts[1] != "registry" || parts[5] != "choice-contexts" || parts[6] != "accept" {
-		writeJSON(w, http.StatusNotFound, errorBody{Error: "not found"})
-		return
-	}
-	registrar := parts[0]
-
-	if registrar != s.issuer {
-		writeJSON(w, http.StatusBadRequest, errorBody{
-			Error: fmt.Sprintf("registrar %q not managed by this registry", registrar),
-		})
 		return
 	}
 


### PR DESCRIPTION
## Summary
- Fixes USDCx custodial transfers on deployed devnet, which failed with `registry returned 404` from nginx.
- The Splice transfer-factory endpoint hosted by DA's utilities API (e.g. `api.utilities.digitalasset-dev.com`) mounts the registry per-registrar at `/api/token-standard/v0/registrars/{registrar}/registry/transfer-instruction/v1/transfer-factory` and expects the on-ledger choice arguments wrapped in `choiceArguments` with structured `instrumentId`, plus `executeBefore`/`requestedAt`/`extraArgs` fields. The SDK was sending the legacy unprefixed path with a flat body, which the local devstack happened to accept but DA's API rejects.
- Updates both the SDK registry client and the local `usdcx-registry` devstack sidecar to the spec-conformant shape, and reuses the registry call's `requestedAt`/`executeBefore` in the on-ledger `TransferFactory_Transfer` choice so the timestamps stay consistent.

## Symptom
```
MetaMask - RPC Error: RPC submit: canton transfer failed:
  registry lookup for decentralized-usdc-interchain-rep::1220d420…:
  registry returned 404: <html>… nginx/1.28.1 …</html>
```

## Verification against DA's dev API
Direct probes against `api.utilities.digitalasset-dev.com`:
| Request | Response |
| --- | --- |
| Old SDK URL `/registry/transfer-instruction/v1/transfer-factory` | `404` nginx (matches user-reported error) |
| New URL `/api/token-standard/v0/registrars/<party>/registry/transfer-instruction/v1/transfer-factory` with flat body | `422 "Missing required field: DownField(choiceArguments)"` |
| Wrapped body with structured `instrumentId` + `extraArgs` + `executeBefore`/`requestedAt` | `400 "No holdings provided"` (real handler, schema accepted, only blocked by probe's empty CIDs) |

## What changed
- `pkg/cantonsdk/token/registry_client.go`
  - Replaced `registryPath` constant with `registryPathFmt` mirroring `acceptContextPathFmt`.
  - `RegistryRequest` now wraps everything in `ChoiceArguments` + `ExcludeDebugFields`; `RegistryTransferDetail.InstrumentID` is now a structured `InstrumentRef{Admin,ID}`; added `Meta`, `ExecuteBefore`, `RequestedAt`, and `ExtraArgs{Context,Meta}` fields with `AnyValueMap` envelopes.
  - `GetTransferFactory` now takes the registrar party and formats it into the URL.
- `pkg/cantonsdk/token/client.go`
  - `transferFactoryRequest` carries `RequestedAt` / `ExecuteBefore`. `resolveTransferFactory` populates them before the registry call; `buildTransferCommand` reuses them so the registry and the on-ledger choice see identical timestamps (falling back to recomputation for any path that bypasses resolve).
- `scripts/setup/usdcx-registry.go` (local devstack sidecar)
  - Mirrored the new request shape.
  - Replaced the two separate path registrations with a single `routeRegistrar` prefix handler that validates the registrar in the URL path and dispatches to the transfer-factory or accept-context handler by suffix.

## Test plan
- [x] `go build ./...`
- [x] `go build scripts/setup/usdcx-registry.go`
- [x] `go test ./...` (21 packages, all green)
- [x] `./bin/golangci-lint run`
- [x] `./bin/golangci-lint run --build-tags e2e ./tests/e2e/...`
- [x] Verified SDK now produces a request DA's API parses (probe past schema validation; only blocked downstream on probe's fake holding CID)
- [ ] Confirm end-to-end USDCx transfer succeeds on deployed devnet after this is rolled out
- [ ] Re-run `make test-e2e-api` against local devstack to confirm the sidecar still serves USDCx flows on the new per-registrar URL