### PR TITLE
chore(ci): use GraphQL createCommitOnBranch for signed commits

### DIFF
--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -155,7 +155,7 @@ jobs:
           # skip if nothing changed (re-run for same tag)
           git diff --cached --quiet && echo "No changes, skipping PR" && exit 0
           git commit -m "chore: bump canton-middleware-api to ${VERSION} on devnet"
-          git push --force-with-lease origin "$BRANCH"
+          git push -u origin "$BRANCH"
           gh pr create \
             --repo ChainSafe/infra-kubernetes \
             --title "chore: bump canton-middleware-api to ${VERSION} on devnet" \

--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -142,25 +142,66 @@ jobs:
           yq e '.["canton-middleware-api"].image.tag = env(VERSION)' -i \
             definitions/canton/validator-dev1/canton-middleware-api-values.yml
 
-      - name: Open PR
+      - name: Create signed commit and open PR
         env:
           VERSION: ${{ steps.version.outputs.version }}
           GH_TOKEN: ${{ secrets.INFRA_GH_TOKEN }}
+          FILE_PATH: definitions/canton/validator-dev1/canton-middleware-api-values.yml
+          REPO: ChainSafe/infra-kubernetes
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           BRANCH="chore/bump-canton-middleware-api-${VERSION}"
-          git checkout -b "$BRANCH"
-          git add definitions/canton/validator-dev1/canton-middleware-api-values.yml
-          # skip if nothing changed (re-run for same tag)
-          git diff --cached --quiet && echo "No changes, skipping PR" && exit 0
-          git commit -m "chore: bump canton-middleware-api to ${VERSION} on devnet"
-          git push -u origin "$BRANCH"
+          COMMIT_MSG="chore: bump canton-middleware-api to ${VERSION} on devnet"
+
+          # Get current HEAD SHA of main
+          HEAD_SHA=$(gh api repos/${REPO}/git/ref/heads/main --jq '.object.sha')
+
+          # Create branch pointing at main HEAD (no-op if already exists)
+          gh api repos/${REPO}/git/refs \
+            --method POST \
+            --field ref="refs/heads/${BRANCH}" \
+            --field sha="${HEAD_SHA}" > /dev/null 2>&1 || true
+
+          # Get current branch HEAD SHA
+          BRANCH_SHA=$(gh api repos/${REPO}/git/ref/heads/${BRANCH} --jq '.object.sha')
+
+          # Skip if branch already has this version (idempotent re-run)
+          BRANCH_TAG=$(gh api "repos/${REPO}/contents/${FILE_PATH}?ref=${BRANCH}" \
+            -H "Accept: application/vnd.github.raw" 2>/dev/null \
+            | yq e '.["canton-middleware-api"].image.tag' - 2>/dev/null || echo "")
+          if [ "$BRANCH_TAG" = "$VERSION" ]; then
+            echo "Branch already has tag ${VERSION}, ensuring auto-merge"
+            gh pr merge --auto --squash --repo "${REPO}" "${BRANCH}" 2>/dev/null || true
+            exit 0
+          fi
+
+          # Base64-encode the updated file (no line wrapping, Linux base64)
+          FILE_CONTENTS=$(base64 -w0 "${FILE_PATH}")
+
+          # Create signed commit via GitHub GraphQL API
+          gh api graphql -f query='
+            mutation($repo: String!, $branch: String!, $oid: GitObjectID!, $msg: String!, $path: String!, $contents: Base64String!) {
+              createCommitOnBranch(input: {
+                branch: { repositoryNameWithOwner: $repo, branchName: $branch }
+                message: { headline: $msg }
+                fileChanges: { additions: [{ path: $path, contents: $contents }] }
+                expectedHeadOid: $oid
+              }) {
+                commit { url }
+              }
+            }' \
+            -f repo="${REPO}" \
+            -f branch="${BRANCH}" \
+            -f oid="${BRANCH_SHA}" \
+            -f msg="${COMMIT_MSG}" \
+            -f path="${FILE_PATH}" \
+            -f contents="${FILE_CONTENTS}"
+
+          # Open PR and enable auto-merge
           gh pr create \
-            --repo ChainSafe/infra-kubernetes \
-            --title "chore: bump canton-middleware-api to ${VERSION} on devnet" \
+            --repo "${REPO}" \
+            --title "${COMMIT_MSG}" \
             --body "Automated PR: bump \`canton-middleware-api\` image tag to \`${VERSION}\` on \`validator-dev1\`." \
             --base main \
-            --head "$BRANCH" \
+            --head "${BRANCH}" \
           || { echo "PR already exists for this branch, skipping"; exit 0; }
-          gh pr merge --auto --squash --repo ChainSafe/infra-kubernetes "$BRANCH"
+          gh pr merge --auto --squash --repo "${REPO}" "${BRANCH}"

--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -111,3 +111,55 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
+
+  open-devnet-pr:
+    name: Open devnet deploy PR
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Compute version
+        id: version
+        env:
+          REF: ${{ github.ref_name }}
+          INPUT: ${{ github.event.inputs.tag }}
+        run: |
+          VERSION="${INPUT:-$REF}"
+          [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]] || { echo "Invalid version: $VERSION"; exit 1; }
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Checkout infra-kubernetes
+        uses: actions/checkout@v4
+        with:
+          repository: ChainSafe/infra-kubernetes
+          token: ${{ secrets.INFRA_GH_TOKEN }}
+          ref: main
+
+      - name: Update canton-middleware-api image tag
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          yq e '.["canton-middleware-api"].image.tag = env(VERSION)' -i \
+            definitions/canton/validator-dev1/canton-middleware-api-values.yml
+
+      - name: Open PR
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          GH_TOKEN: ${{ secrets.INFRA_GH_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          BRANCH="chore/bump-canton-middleware-api-${VERSION}"
+          git checkout -b "$BRANCH"
+          git add definitions/canton/validator-dev1/canton-middleware-api-values.yml
+          # skip if nothing changed (re-run for same tag)
+          git diff --cached --quiet && echo "No changes, skipping PR" && exit 0
+          git commit -m "chore: bump canton-middleware-api to ${VERSION} on devnet"
+          git push --force-with-lease origin "$BRANCH"
+          gh pr create \
+            --repo ChainSafe/infra-kubernetes \
+            --title "chore: bump canton-middleware-api to ${VERSION} on devnet" \
+            --body "Automated PR: bump \`canton-middleware-api\` image tag to \`${VERSION}\` on \`validator-dev1\`." \
+            --base main \
+            --head "$BRANCH" \
+          || echo "PR already exists for this branch"

--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -162,4 +162,5 @@ jobs:
             --body "Automated PR: bump \`canton-middleware-api\` image tag to \`${VERSION}\` on \`validator-dev1\`." \
             --base main \
             --head "$BRANCH" \
-          || echo "PR already exists for this branch"
+          || { echo "PR already exists for this branch, skipping"; exit 0; }
+          gh pr merge --auto --squash --repo ChainSafe/infra-kubernetes "$BRANCH"


### PR DESCRIPTION
## Summary

Replaces `git commit + git push` with the GitHub GraphQL `createCommitOnBranch` mutation.

**Why:** The `required_signatures` ruleset on `ChainSafe/infra-kubernetes` requires all commits on `main` to be signed. Commits created via `git push` from CI are unsigned and block auto-merge. Commits created via the GitHub GraphQL API are automatically signed by GitHub and show as **Verified** — no bypass actor or GPG key needed.

**Changes in `open-devnet-pr` job:**
- Fetch raw file content via `Accept: application/vnd.github.raw` (no base64 decode)
- Idempotency check now compares the branch (not main) to avoid re-committing on reruns
- Branch creation via REST API, commit via GraphQL `createCommitOnBranch`
- `git commit` / `git push` / `git config` blocks removed entirely

Refs ChainSafe/infrastructure-general#1246

🤖 Generated with [Claude Code](https://claude.com/claude-code)