### PR TITLE
chore(config): switch DEMO/USDCx/PROMPT display addresses to synthetic placeholders

### DIFF
--- a/config.e2e-local.yaml
+++ b/config.e2e-local.yaml
@@ -82,7 +82,7 @@ token:
       symbol: "DEMO"
       decimals: 18
       instrument_id: "DEMO"
-    "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48":
+    "0xC1A0000000000000000000000000000000000001":
       name: "USD Coin"
       symbol: "USDCx"
       decimals: 6

--- a/pkg/config/defaults/config.api-server.docker.yaml
+++ b/pkg/config/defaults/config.api-server.docker.yaml
@@ -86,7 +86,7 @@ token:
       symbol: "DEMO"
       decimals: 18
       instrument_id: "DEMO"
-    "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48":
+    "0xC1A0000000000000000000000000000000000001":
       name: "USD Coin"
       symbol: "USDCx"
       decimals: 6

--- a/pkg/config/defaults/config.api-server.local-devnet.yaml
+++ b/pkg/config/defaults/config.api-server.local-devnet.yaml
@@ -79,7 +79,7 @@ token:
       symbol: "DEMO"
       decimals: 18
       instrument_id: "DEMO"
-    "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48":
+    "0xC1A0000000000000000000000000000000000001":
       name: "USD Coin"
       symbol: "USDCx"
       decimals: 6

--- a/pkg/config/defaults/config.api-server.mainnet.yaml
+++ b/pkg/config/defaults/config.api-server.mainnet.yaml
@@ -48,12 +48,21 @@ canton:
 
 token:
   supported_tokens:
+    # Display-only synthetic addresses for MetaMask. The api-server's
+    # eth_call balanceOf facade keys balances by these addresses. They must
+    # NOT collide with well-known mainnet token contracts (e.g. real USDC,
+    # USDT, etc.) or MetaMask flags imports as suspected phishing.
+    "0x9907000000000000000000000000000000000001":
+      name: "PROMPT"
+      symbol: "PROMPT"
+      decimals: 18
+      instrument_id: "PROMPT"
     "0xDE30000000000000000000000000000000000001":
       name: "Demo Token"
       symbol: "DEMO"
       decimals: 18
       instrument_id: "DEMO"
-    "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48":
+    "0xC1A0000000000000000000000000000000000001":
       name: "USD Coin"
       symbol: "USDCx"
       decimals: 6

--- a/pkg/config/tests/env-substitution.api.yaml
+++ b/pkg/config/tests/env-substitution.api.yaml
@@ -31,7 +31,7 @@ token:
       symbol: "PROMPT"
       decimals: 18
       instrument_id: "PROMPT"
-    "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48":
+    "0xC1A0000000000000000000000000000000000001":
       name: "USD Coin"
       symbol: "USDCx"
       decimals: 6

--- a/pkg/config/tests/invalid-database-url.api.yaml
+++ b/pkg/config/tests/invalid-database-url.api.yaml
@@ -31,7 +31,7 @@ token:
       symbol: "PROMPT"
       decimals: 18
       instrument_id: "PROMPT"
-    "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48":
+    "0xC1A0000000000000000000000000000000000001":
       name: "USD Coin"
       symbol: "USDCx"
       decimals: 6

--- a/pkg/config/tests/minimal.api.yaml
+++ b/pkg/config/tests/minimal.api.yaml
@@ -31,7 +31,7 @@ token:
       symbol: "PROMPT"
       decimals: 18
       instrument_id: "PROMPT"
-    "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48":
+    "0xC1A0000000000000000000000000000000000001":
       name: "USD Coin"
       symbol: "USDCx"
       decimals: 6

--- a/pkg/config/tests/missing-env.api.yaml
+++ b/pkg/config/tests/missing-env.api.yaml
@@ -31,7 +31,7 @@ token:
       symbol: "PROMPT"
       decimals: 18
       instrument_id: "PROMPT"
-    "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48":
+    "0xC1A0000000000000000000000000000000000001":
       name: "USD Coin"
       symbol: "USDCx"
       decimals: 6

--- a/tests/e2e/devstack/stack/types.go
+++ b/tests/e2e/devstack/stack/types.go
@@ -23,9 +23,12 @@ const (
 	DemoTokenVirtualAddr = "0xDE30000000000000000000000000000000000001"
 
 	// USDCxTokenVirtualAddr is the well-known virtual EVM address mapped to the
-	// USDCx external token in the api-server configuration.
-	// #nosec G101 -- public deterministic EVM contract address, not a credential.
-	USDCxTokenVirtualAddr = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+	// USDCx external token in the api-server configuration. Synthetic (no real
+	// on-chain meaning) so MetaMask's anti-phishing check — which compares
+	// imported token addresses against its known-mainnet-tokens registry — does
+	// not flag USDCx imports as a possible spoof of real-mainnet USDC.
+	// #nosec G101 -- synthetic placeholder EVM address, not a credential.
+	USDCxTokenVirtualAddr = "0xC1A0000000000000000000000000000000000001"
 )
 
 // CantonHolding is a minimal view of a CIP56Holding contract used by E2E tests.


### PR DESCRIPTION
## Summary

The api-server's `token.supported_tokens` map keys each Canton-supported token by an EVM display address — the value MetaMask sees when rendering the user's Canton-side balance. These are placeholders, not real on-chain contracts:

- **PROMPT** lives at `0x28d38dF637dB75533bD3F71426F3410a82041544` on Ethereum mainnet, but that address is only load-bearing in `ethereum.token_contract` of the **relayer** config (used to watch mainnet for deposit events).
- **USDCx** and **DEMO** are Canton-native and have no Ethereum ERC-20 at all — any address there is purely for MetaMask display.

The previous USDCx placeholder reused real mainnet USDC's address (`0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48`). MetaMask flags that as a phishing risk on import because its anti-phishing check compares any imported token address against the known-mainnet-tokens registry — chain-agnostic, so the warning fires even on our Canton-facade chain. Arun hit this on prod1 yesterday:

> _"While importing USDCx to metamask, I am getting following error: This address matches a known Ethereum Mainnet token address. Recheck the contract address and network for the token you are trying to add."_

## What changed

| Token | Old address | New address |
|---|---|---|
| **PROMPT** | (missing from mainnet template) | `0x9907000000000000000000000000000000000001` |
| **DEMO** | `0xDE30000000000000000000000000000000000001` | unchanged |
| **USDCx** | `0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48` (real mainnet USDC) | `0xC1A0000000000000000000000000000000000001` |

The PROMPT placeholder is also switched defensively, in case PROMPT is ever listed in MM's high-profile registry. **The relayer's `ethereum.token_contract` keeps the real mainnet PROMPT address** — that side actually watches the on-chain contract for deposit events.

## What's intentionally unchanged

- **`pkg/config/defaults/config.api-server.docker.yaml`** keeps `0x5FbDB2…aa3` for PROMPT — that's the anvil-deterministic first-deploy address used by E2E tests, a real ERC-20 deployment.
- **`pkg/config/defaults/config.api-server.local-devnet.yaml`** keeps `0x90cb4f9e…48e` for PROMPT — the deployed Sepolia bridge token used by Sepolia↔devnet flows, also a real ERC-20.
- **Relayer configs** keep all real on-chain addresses (`ethereum.token_contract`, `ethereum.bridge_contract`).
- **`scripts/setup/bootstrap-bridge.go`**, **`contracts/canton-erc20/daml/bridge-wayfinder/src/Wayfinder/Bridge.daml`**, **`docs/WAYFINDER_DEPLOYMENT_REQUIREMENTS.md`**, and the `contracts/*` CHANGELOG/DEPLOYMENT docs all keep the real PROMPT mainnet address — those reference it as the real address it is.

## Files touched

- `pkg/config/defaults/config.api-server.mainnet.yaml` — USDCx swap, **added PROMPT row** with synthetic placeholder
- `pkg/config/defaults/config.api-server.docker.yaml` — USDCx swap
- `pkg/config/defaults/config.api-server.local-devnet.yaml` — USDCx swap
- `config.e2e-local.yaml` — USDCx swap
- `pkg/config/tests/{minimal,missing-env,invalid-database-url,env-substitution}.api.yaml` — USDCx swap (test fixtures)
- `tests/e2e/devstack/stack/types.go` — `USDCxTokenVirtualAddr` constant updated, doc comment expanded

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./pkg/...` — all green (config tests use the updated fixtures)
- [x] `go test -tags e2e -count=0 ./tests/e2e/tests/...` — compiles cleanly (runtime fails only on the expected devstack-not-running discovery step)
- [x] All CLI scripts in `scripts/testing/` that touched these addresses compile

## Heads-up for testers

Anyone with an existing MetaMask import of PROMPT or USDCx on the Canton-facade chain will see "0 balance" after this rolls out, because the api-server's `eth_call balanceOf` lookup keys on the new address. Remove the old token entry in MM and re-import using the new addresses above. Fresh accounts unaffected.

PROMPT bridging on real Ethereum mainnet is unaffected — the relayer continues to use the real `0x28d38d…1544` contract.