### PR TITLE
fix: stop running balance reconciler in the API server

### DIFF
--- a/config.e2e-local.yaml
+++ b/config.e2e-local.yaml
@@ -110,10 +110,6 @@ logging:
   format: "json"
   output_path: "stdout"
 
-reconciliation:
-  initial_timeout: "2m"
-  interval: "10s"
-
 key_management:
   master_key_env: "CANTON_MASTER_KEY"
   key_derivation: "generate"

--- a/pkg/app/api/server.go
+++ b/pkg/app/api/server.go
@@ -26,8 +26,6 @@ import (
 	"github.com/chainsafe/canton-middleware/pkg/keys"
 	"github.com/chainsafe/canton-middleware/pkg/log"
 	"github.com/chainsafe/canton-middleware/pkg/pgutil"
-	"github.com/chainsafe/canton-middleware/pkg/reconciler"
-	reconcilerstore "github.com/chainsafe/canton-middleware/pkg/reconciler/store"
 	"github.com/chainsafe/canton-middleware/pkg/registry"
 	"github.com/chainsafe/canton-middleware/pkg/token"
 	tokenprovider "github.com/chainsafe/canton-middleware/pkg/token/provider"
@@ -124,15 +122,6 @@ func (s *Server) Run() error {
 		return err
 	}
 
-	recStore := reconcilerstore.NewStore(dbBun)
-	rec := reconciler.New(recStore, userStore, cantonClient.Token, logger)
-	s.runInitialReconcile(ctx, rec, logger)
-
-	stopReconcile := s.startPeriodicReconcile(rec, logger)
-	// We will call stopReconcile explicitly after ServeAndWait returns for deterministic shutdown order.
-	// Keep this defer as a safety net.
-	defer stopReconcile()
-
 	svcs, err := initServices(ctx, cfg, dbBun, userStore, cantonClient, indexerClient, cipher, reg, logger)
 	if err != nil {
 		return err
@@ -155,12 +144,7 @@ func (s *Server) Run() error {
 
 	router := s.setupRouter(svcs.evmStore, cantonClient, svcs.tokenService, svcs.regSvc, svcs.transferSvc, metrics, logger)
 
-	err = s.serveAll(ctx, router, logger)
-
-	// Stop background work before deferred DB/client closes kick in.
-	stopReconcile()
-
-	return err
+	return s.serveAll(ctx, router, logger)
 }
 
 // buildIndexerClient creates the single indexer HTTP client used by every
@@ -334,45 +318,6 @@ func (s *Server) openCantonClient(
 		return nil, fmt.Errorf("create canton client: %w", err)
 	}
 	return client, nil
-}
-
-func (s *Server) runInitialReconcile(
-	ctx context.Context,
-	reconciler *reconciler.Reconciler,
-	logger *zap.Logger,
-) {
-	if s.cfg.Reconciliation.InitialTimeout <= 0 {
-		return
-	}
-
-	logger.Info("Running initial balance reconciliation",
-		zap.Duration("timeout", s.cfg.Reconciliation.InitialTimeout),
-	)
-
-	startupCtx, cancel := context.WithTimeout(ctx, s.cfg.Reconciliation.InitialTimeout)
-	defer cancel()
-
-	if err := reconciler.ReconcileAll(startupCtx); err != nil {
-		logger.Warn("Initial reconciliation failed (will retry periodically)", zap.Error(err))
-		return
-	}
-
-	logger.Info("Initial balance reconciliation completed")
-}
-
-func (s *Server) startPeriodicReconcile(
-	reconciler *reconciler.Reconciler,
-	logger *zap.Logger,
-) func() {
-	if s.cfg.Reconciliation.Interval <= 0 {
-		return func() {}
-	}
-
-	logger.Info("Starting periodic reconciliation", zap.Duration("interval", s.cfg.Reconciliation.Interval))
-	reconciler.StartPeriodicReconciliation(s.cfg.Reconciliation.Interval)
-
-	// Return stopper for deterministic shutdown ordering.
-	return func() { reconciler.Stop() }
 }
 
 // serveAll runs the main HTTP server and, when monitoring is enabled,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,7 +18,6 @@ import (
 	"github.com/chainsafe/canton-middleware/pkg/indexer"
 	"github.com/chainsafe/canton-middleware/pkg/log"
 	pgdb "github.com/chainsafe/canton-middleware/pkg/pgutil"
-	"github.com/chainsafe/canton-middleware/pkg/reconciler"
 	"github.com/chainsafe/canton-middleware/pkg/relayer"
 	"github.com/chainsafe/canton-middleware/pkg/token"
 
@@ -79,7 +78,6 @@ type APIServer struct {
 	AcceptWorker        *custodial.AcceptWorkerConfig `yaml:"accept_worker" default:"-"` // nil disables the worker
 	Monitoring          *Monitoring                   `yaml:"monitoring" validate:"required"`
 	Logging             *log.Config                   `yaml:"logging" validate:"required"`
-	Reconciliation      *reconciler.Config            `yaml:"reconciliation" validate:"required"`
 	KeyManagement       *KeyManagement                `yaml:"key_management" validate:"required"`
 	SkipCantonSigVerify bool                          `yaml:"skip_canton_sig_verify" default:"false"`
 	SkipWhitelistCheck  bool                          `yaml:"skip_whitelist_check" default:"false"`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -148,12 +148,6 @@ func TestLoadAPIServer_AppliesDefaults(t *testing.T) {
 	if cfg.Logging.OutputPath != "stdout" {
 		t.Fatalf("logging.output_path default mismatch: got %q", cfg.Logging.OutputPath)
 	}
-	if cfg.Reconciliation.InitialTimeout != 2*time.Minute {
-		t.Fatalf("reconciliation.initial_timeout default mismatch: got %s", cfg.Reconciliation.InitialTimeout)
-	}
-	if cfg.Reconciliation.Interval != 5*time.Minute {
-		t.Fatalf("reconciliation.interval default mismatch: got %s", cfg.Reconciliation.Interval)
-	}
 
 	if cfg.KeyManagement.MasterKeyEnv != "CANTON_MASTER_KEY" {
 		t.Fatalf("key_management.master_key_env default mismatch: got %q", cfg.KeyManagement.MasterKeyEnv)

--- a/pkg/config/defaults/config.api-server.docker.yaml
+++ b/pkg/config/defaults/config.api-server.docker.yaml
@@ -123,11 +123,6 @@ logging:
   format: "json"
   output_path: "stdout"
 
-# Reconciliation settings
-reconciliation:
-  initial_timeout: "2m"
-  interval: "10s"  # Faster reconciliation for testing
-
 # Auto-accepts pending TransferOffer contracts for custodial users by polling
 # the indexer and exercising TransferInstruction_Accept on the api-server's
 # behalf. Required for the e2e USDCx cross-participant test where the receiver

--- a/pkg/config/defaults/config.api-server.local-devnet.yaml
+++ b/pkg/config/defaults/config.api-server.local-devnet.yaml
@@ -99,10 +99,6 @@ jwks:
   url: ""
   issuer: ""
 
-reconciliation:
-  initial_timeout: "2m"
-  interval: "1m"
-
 monitoring:
   enabled: true
   server:

--- a/pkg/config/defaults/config.api-server.mainnet.yaml
+++ b/pkg/config/defaults/config.api-server.mainnet.yaml
@@ -97,10 +97,6 @@ logging:
   format: "json"
   output_path: "stdout"
 
-reconciliation:
-  initial_timeout: "2m"
-  interval: "1m"
-
 key_management:
   master_key_env: "CANTON_MASTER_KEY"
   key_derivation: "generate"

--- a/pkg/config/tests/env-substitution.api.yaml
+++ b/pkg/config/tests/env-substitution.api.yaml
@@ -44,7 +44,6 @@ logging:
   level: "info"
   format: "json"
 
-reconciliation: {}
 key_management: {}
 monitoring:
   enabled: false

--- a/pkg/config/tests/invalid-database-url.api.yaml
+++ b/pkg/config/tests/invalid-database-url.api.yaml
@@ -44,5 +44,4 @@ logging:
   level: "info"
   format: "json"
 
-reconciliation: {}
 key_management: {}

--- a/pkg/config/tests/minimal.api.yaml
+++ b/pkg/config/tests/minimal.api.yaml
@@ -44,7 +44,6 @@ logging:
   level: "info"
   format: "json"
 
-reconciliation: {}
 key_management: {}
 monitoring:
   enabled: false

--- a/pkg/config/tests/missing-env.api.yaml
+++ b/pkg/config/tests/missing-env.api.yaml
@@ -44,5 +44,4 @@ logging:
   level: "info"
   format: "json"
 
-reconciliation: {}
 key_management: {}


### PR DESCRIPTION
## What

Stops the balance reconciler from running inside the API server, and removes the now-dead `reconciliation` config.

## Why

The reconciler ran on every API-server boot plus a periodic loop writing balances into `user_token_balances`, total supply, and `reconciliation_state`. But nothing in the serving path reads that data back:

- Token balance endpoint → `token.Service.GetBalance` → token provider (live
  Canton gRPC or the indexer)
- `eth_getBalance` → `tokenService.Native().GetBalance` → same provider path
