### PR TITLE
fix: report zero native balance and gas

### DIFF
--- a/config.e2e-local.yaml
+++ b/config.e2e-local.yaml
@@ -87,15 +87,11 @@ token:
       symbol: "USDCx"
       decimals: 6
       instrument_id: "USDCx"
-  native_balance_wei: "1000000000000000000000"
 
 # Ethereum JSON-RPC facade (MetaMask compatibility)
 eth_rpc:
   enabled: true
   chain_id: 31337
-  gas_price_wei: "1000000000"
-  gas_limit: 21000
-  native_balance_wei: "1000000000000000000000"
   request_timeout: "30s"
 
 jwks:

--- a/pkg/app/api/server.go
+++ b/pkg/app/api/server.go
@@ -239,7 +239,7 @@ func initServices(
 	if cfg.EthRPC.Enabled {
 		m := ethrpcminer.New(
 			evmStore,
-			cfg.EthRPC.ChainID, cfg.EthRPC.GasLimit,
+			cfg.EthRPC.ChainID, ethrpc.DefaultGasLimit,
 			cfg.EthRPC.MinerMaxTxsPerBlock, cfg.EthRPC.MinerInterval,
 			ethrpcminer.NewMetrics(reg),
 			logger,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -125,21 +125,8 @@ func TestLoadAPIServer_AppliesDefaults(t *testing.T) {
 		t.Fatalf("auth.expiry_leeway default mismatch: got %s", cfg.Canton.Ledger.Auth.ExpiryLeeway)
 	}
 
-	if cfg.Token.NativeBalanceWei != "1000000000000000000000" {
-		t.Fatalf("token.native_balance_wei default mismatch: got %q", cfg.Token.NativeBalanceWei)
-	}
-
 	if cfg.EthRPC.Enabled {
 		t.Fatal("eth_rpc.enabled default mismatch: expected false")
-	}
-	if cfg.EthRPC.GasPriceWei != "1000000000" {
-		t.Fatalf("eth_rpc.gas_price_wei default mismatch: got %q", cfg.EthRPC.GasPriceWei)
-	}
-	if cfg.EthRPC.GasLimit != 21000 {
-		t.Fatalf("eth_rpc.gas_limit default mismatch: got %d", cfg.EthRPC.GasLimit)
-	}
-	if cfg.EthRPC.NativeBalanceWei != "1000000000000000000000" {
-		t.Fatalf("eth_rpc.native_balance_wei default mismatch: got %q", cfg.EthRPC.NativeBalanceWei)
 	}
 	if cfg.EthRPC.RequestTimeout != 30*time.Second {
 		t.Fatalf("eth_rpc.request_timeout default mismatch: got %s", cfg.EthRPC.RequestTimeout)

--- a/pkg/config/defaults/config.api-server.docker.yaml
+++ b/pkg/config/defaults/config.api-server.docker.yaml
@@ -91,15 +91,11 @@ token:
       symbol: "USDCx"
       decimals: 6
       instrument_id: "USDCx"
-  native_balance_wei: "1000000000000000000000"
 
 # Ethereum JSON-RPC facade (MetaMask compatibility)
 eth_rpc:
   enabled: true
   chain_id: 31337  # Anvil local chain ID
-  gas_price_wei: "1000000000"
-  gas_limit: 21000
-  native_balance_wei: "1000000000000000000000"
   request_timeout: "30s"
 
 # JWKS endpoint for JWT validation (optional - if not using EVM signatures)

--- a/pkg/config/defaults/config.api-server.local-devnet.yaml
+++ b/pkg/config/defaults/config.api-server.local-devnet.yaml
@@ -84,15 +84,11 @@ token:
       symbol: "USDCx"
       decimals: 6
       instrument_id: "USDCx"
-  native_balance_wei: "1000000000000000000000"
 
 # Ethereum JSON-RPC facade (MetaMask compatibility)
 eth_rpc:
   enabled: true
   chain_id: 1155111101  # Custom: Sepolia (11155111) + 01 suffix for Canton local
-  gas_price_wei: "1000000000"
-  gas_limit: 21000
-  native_balance_wei: "1000000000000000000000"
   request_timeout: "60s"
 
 jwks:

--- a/pkg/config/defaults/config.api-server.mainnet.yaml
+++ b/pkg/config/defaults/config.api-server.mainnet.yaml
@@ -67,14 +67,10 @@ token:
       symbol: "USDCx"
       decimals: 6
       instrument_id: "USDCx"
-  native_balance_wei: "1000000000000000000000"
 
 eth_rpc:
   enabled: true
   chain_id: 1337
-  gas_price_wei: "1000000000"
-  gas_limit: 21000
-  native_balance_wei: "1000000000000000000000"
   request_timeout: "60s"
 
 jwks:

--- a/pkg/ethrpc/config.go
+++ b/pkg/ethrpc/config.go
@@ -10,9 +10,6 @@ import (
 type Config struct {
 	Enabled             bool          `yaml:"enabled" default:"false"`
 	ChainID             uint64        `yaml:"chain_id" validate:"required_if=Enabled true"`
-	GasPriceWei         string        `yaml:"gas_price_wei" default:"1000000000"`
-	GasLimit            uint64        `yaml:"gas_limit" default:"21000"`
-	NativeBalanceWei    string        `yaml:"native_balance_wei" default:"1000000000000000000000"`
 	RequestTimeout      time.Duration `yaml:"request_timeout"  default:"30s"`
 	MinerInterval       time.Duration `yaml:"miner_interval"   default:"2s"`
 	MinerMaxTxsPerBlock int           `yaml:"miner_max_txs_per_block" default:"500"`

--- a/pkg/ethrpc/service/service.go
+++ b/pkg/ethrpc/service/service.go
@@ -83,13 +83,14 @@ type ethService struct {
 }
 
 const (
-	decimalStringBase         = 10
-	defaultGasPriceWeiInt64   = int64(1_000_000_000)
-	defaultGasPriceWeiUint64  = uint64(1_000_000_000)
 	functionSelectorSize      = 4
-	topicSizeBytes            = 32
 	confirmationBufferBlocks  = uint64(12)
 	syntheticBlockTimeSeconds = uint64(12)
+	// DefaultGasLimit is the cosmetic gas limit the facade reports (eth_estimateGas,
+	// block gasLimit, tx gas, synthetic block gasUsed). The facade executes
+	// transfers on Canton rather than an EVM, so gas is never metered — and the
+	// gas price is fixed at 0 — making this value purely informational for wallets.
+	DefaultGasLimit = 21_000
 )
 
 // NewService creates a new ethService.
@@ -140,21 +141,24 @@ func (s *ethService) BlockNumber(ctx context.Context) (hexutil.Uint64, error) {
 	return hexutil.Uint64(max(baseBlock, timeBasedBlocks)), nil
 }
 
-func (s *ethService) GasPrice(_ context.Context) (*hexutil.Big, error) {
-	gasPrice := new(big.Int)
-	if _, ok := gasPrice.SetString(s.cfg.GasPriceWei, decimalStringBase); !ok {
-		return nil, apperr.GeneralError(fmt.Errorf("invalid gas price wei: %q", s.cfg.GasPriceWei))
-	}
-
-	return (*hexutil.Big)(gasPrice), nil
+// GasPrice always reports 0, and so do maxPriorityFeePerGas, block
+// baseFeePerGas, and receipt effectiveGasPrice. The facade never charges gas,
+// and MetaMask's client-side pre-flight check is
+// `balance >= value + gasLimit*gasPrice`. Since eth_getBalance reports a zero
+// native balance and this facade only accepts zero-value ERC-20 transfers, the
+// check collapses to `0 >= 0` only while gas is 0 — any non-zero gas price would
+// make MetaMask reject transfers with "insufficient funds for gas". Gas is
+// therefore fixed at 0 in code rather than exposed as config.
+func (*ethService) GasPrice(_ context.Context) (*hexutil.Big, error) {
+	return (*hexutil.Big)(big.NewInt(0)), nil
 }
 
 func (*ethService) MaxPriorityFeePerGas(_ context.Context) (*hexutil.Big, error) {
-	return (*hexutil.Big)(big.NewInt(defaultGasPriceWeiInt64)), nil
+	return (*hexutil.Big)(big.NewInt(0)), nil
 }
 
-func (s *ethService) EstimateGas(_ context.Context, _ *ethrpc.CallArgs) (hexutil.Uint64, error) {
-	return hexutil.Uint64(s.cfg.GasLimit), nil
+func (*ethService) EstimateGas(_ context.Context, _ *ethrpc.CallArgs) (hexutil.Uint64, error) {
+	return hexutil.Uint64(DefaultGasLimit), nil
 }
 
 func (s *ethService) GetBalance(ctx context.Context, address common.Address) (*hexutil.Big, error) {
@@ -328,7 +332,7 @@ func (s *ethService) GetTransactionReceipt(ctx context.Context, hash common.Hash
 		Logs:              logs,
 		LogsBloom:         bloom,
 		Status:            hexutil.Uint64(row.Status),
-		EffectiveGasPrice: hexutil.Uint64(defaultGasPriceWeiUint64),
+		EffectiveGasPrice: hexutil.Uint64(0),
 		Type:              hexutil.Uint64(2),
 		// RevertReason is omitted when empty (omitempty), so successful
 		// receipts keep the standard JSON shape.
@@ -350,7 +354,7 @@ func (s *ethService) GetTransactionByHash(ctx context.Context, hash common.Hash)
 	blockHash := common.BytesToHash(row.BlockHash)
 	blockNum := hexutil.Uint64(row.BlockNumber)
 	txIndex := hexutil.Uint(row.TxIndex)
-	gasPrice := big.NewInt(defaultGasPriceWeiInt64)
+	gasPrice := big.NewInt(0)
 
 	return &ethrpc.RPCTransaction{
 		Hash:             hash,
@@ -362,7 +366,7 @@ func (s *ethService) GetTransactionByHash(ctx context.Context, hash common.Hash)
 		To:               &to,
 		Value:            (*hexutil.Big)(big.NewInt(0)),
 		GasPrice:         (*hexutil.Big)(gasPrice),
-		Gas:              hexutil.Uint64(s.cfg.GasLimit),
+		Gas:              hexutil.Uint64(DefaultGasLimit),
 		Input:            row.Input,
 		Type:             hexutil.Uint64(2),
 		ChainID:          (*hexutil.Big)(new(big.Int).Set(s.chainID)),
@@ -557,12 +561,12 @@ func (s *ethService) GetBlockByNumber(ctx context.Context, block ethrpc.BlockNum
 		TotalDifficulty:  (*hexutil.Big)(big.NewInt(0)),
 		ExtraData:        []byte{},
 		Size:             hexutil.Uint64(0),
-		GasLimit:         hexutil.Uint64(s.cfg.GasLimit),
+		GasLimit:         hexutil.Uint64(DefaultGasLimit),
 		GasUsed:          hexutil.Uint64(0),
 		Timestamp:        hexutil.Uint64(blockNum * syntheticBlockTimeSeconds),
 		Transactions:     []any{},
 		Uncles:           []common.Hash{},
-		BaseFeePerGas:    (*hexutil.Big)(big.NewInt(defaultGasPriceWeiInt64)),
+		BaseFeePerGas:    (*hexutil.Big)(big.NewInt(0)),
 	}, nil
 }
 

--- a/pkg/ethrpc/service/service_test.go
+++ b/pkg/ethrpc/service/service_test.go
@@ -24,11 +24,8 @@ import (
 // defaultCfg returns a minimal EthRPCConfig suitable for unit tests.
 func defaultCfg() *ethrpc.Config {
 	return &ethrpc.Config{
-		ChainID:          31337,
-		GasPriceWei:      "1000000000",
-		GasLimit:         21000,
-		RequestTimeout:   30 * time.Second,
-		NativeBalanceWei: "1000000000000000000000",
+		ChainID:        31337,
+		RequestTimeout: 30 * time.Second,
 	}
 }
 
@@ -73,46 +70,44 @@ func TestService_BlockNumber(t *testing.T) {
 
 // ─── GasPrice ─────────────────────────────────────────────────────────────────
 
+// Gas is fixed at 0 in code (not configurable). See TestService_ZeroGas for the
+// MetaMask-compatibility rationale.
 func TestService_GasPrice(t *testing.T) {
-	t.Run("valid config returns configured price", func(t *testing.T) {
-		svc := newSvc(t, defaultCfg(), nil, nil)
-
-		got, err := svc.GasPrice(context.Background())
-		require.NoError(t, err)
-		assert.Equal(t, big.NewInt(1_000_000_000), got.ToInt())
-	})
-
-	t.Run("non-numeric wei string returns error", func(t *testing.T) {
-		cfg := defaultCfg()
-		cfg.GasPriceWei = "not-a-number"
-		svc := newSvc(t, cfg, nil, nil)
-
-		_, err := svc.GasPrice(context.Background())
-		require.Error(t, err)
-		assert.True(t, apperr.Is(err, apperr.CategoryGeneralError))
-	})
+	got, err := newSvc(t, defaultCfg(), nil, nil).GasPrice(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, big.NewInt(0), got.ToInt())
 }
 
 // ─── MaxPriorityFeePerGas ─────────────────────────────────────────────────────
 
 func TestService_MaxPriorityFeePerGas(t *testing.T) {
-	svc := newSvc(t, defaultCfg(), nil, nil)
-
-	got, err := svc.MaxPriorityFeePerGas(context.Background())
+	got, err := newSvc(t, defaultCfg(), nil, nil).MaxPriorityFeePerGas(context.Background())
 	require.NoError(t, err)
-	assert.Equal(t, big.NewInt(1_000_000_000), got.ToInt())
+	assert.Equal(t, big.NewInt(0), got.ToInt())
+}
+
+// ─── Zero gas (MetaMask compatibility) ────────────────────────────────────────
+
+// TestService_ZeroGas locks in the MetaMask-compatibility contract: gas is fixed
+// at 0 across every fee surface a wallet reads, so a zero native balance
+// satisfies MetaMask's `balance >= value + gas*price` pre-flight check for the
+// zero-value ERC-20 transfers this facade accepts. A non-zero gas price would
+// make MetaMask reject transfers with "insufficient funds for gas".
+func TestService_ZeroGas(t *testing.T) {
+	blockNum := hexutil.Uint64(42)
+	got, err := newSvc(t, defaultCfg(), nil, nil).
+		GetBlockByNumber(context.Background(), ethrpc.BlockNumberOrHash{BlockNumber: &blockNum}, false)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, big.NewInt(0), got.BaseFeePerGas.ToInt())
 }
 
 // ─── EstimateGas ──────────────────────────────────────────────────────────────
 
 func TestService_EstimateGas(t *testing.T) {
-	cfg := defaultCfg()
-	cfg.GasLimit = 50_000
-	svc := newSvc(t, cfg, nil, nil)
-
-	got, err := svc.EstimateGas(context.Background(), nil)
+	got, err := newSvc(t, defaultCfg(), nil, nil).EstimateGas(context.Background(), nil)
 	require.NoError(t, err)
-	assert.Equal(t, hexutil.Uint64(50_000), got)
+	assert.Equal(t, hexutil.Uint64(service.DefaultGasLimit), got)
 }
 
 // ─── GetBalance ───────────────────────────────────────────────────────────────

--- a/pkg/token/config.go
+++ b/pkg/token/config.go
@@ -18,15 +18,13 @@ type ERC20Token struct {
 
 // Config holds token metadata indexed by contract address.
 type Config struct {
-	SupportedTokens  map[common.Address]ERC20Token `yaml:"supported_tokens" validate:"required,min=1"`
-	NativeBalanceWei string                        `yaml:"native_balance_wei" default:"1000000000000000000000"`
+	SupportedTokens map[common.Address]ERC20Token `yaml:"supported_tokens" validate:"required,min=1"`
 }
 
 // NewConfig creates a token Config.
-func NewConfig(nativeBalanceWei string) *Config {
+func NewConfig() *Config {
 	return &Config{
-		NativeBalanceWei: nativeBalanceWei,
-		SupportedTokens:  make(map[common.Address]ERC20Token),
+		SupportedTokens: make(map[common.Address]ERC20Token),
 	}
 }
 

--- a/pkg/token/erc20_test.go
+++ b/pkg/token/erc20_test.go
@@ -30,7 +30,7 @@ var (
 // ─── Shared helpers ───────────────────────────────────────────────────────────
 
 func newCfg() *token.Config {
-	cfg := token.NewConfig("5000000000000000000") // 5 ETH in wei
+	cfg := token.NewConfig()
 	cfg.AddToken(promptAddr, token.ERC20Token{Name: "Prompt Token", Symbol: "PROMPT", Decimals: 18, InstrumentID: "PROMPT"})
 	cfg.AddToken(demoAddr, token.ERC20Token{Name: "Demo Token", Symbol: "DEMO", Decimals: 18, InstrumentID: "DEMO"})
 	return cfg

--- a/pkg/token/native.go
+++ b/pkg/token/native.go
@@ -20,21 +20,19 @@ type nativeImpl struct {
 	svc *Service
 }
 
-const decimalBase = 10
-
 // NewNative creates a Native implementation.
 func NewNative(svc *Service) Native {
 	return &nativeImpl{svc: svc}
 }
 
-func (n *nativeImpl) GetBalance(ctx context.Context, address common.Address) (big.Int, error) {
-	// TODO: This logic is confusing - either return not supported or implement it.
-	isRegistered, err := n.svc.isUserRegistered(ctx, address)
-	if err != nil || !isRegistered {
-		return big.Int{}, err
-	}
-	bal, _ := new(big.Int).SetString(n.svc.cfg.NativeBalanceWei, decimalBase)
-	return *bal, nil
+// GetBalance always reports a zero native balance. The native coin is synthetic
+// — there is no real gas token — so 0 is the honest value and avoids showing a
+// confusing fake balance in MetaMask. Gas is also fixed at 0 (see the ethrpc
+// service), so MetaMask's `balance >= value + gasLimit*gasPrice` pre-flight
+// check still passes as `0 >= 0` for the zero-value ERC-20 transfers this facade
+// supports.
+func (*nativeImpl) GetBalance(_ context.Context, _ common.Address) (big.Int, error) {
+	return big.Int{}, nil
 }
 
 func (*nativeImpl) Transfer(_ context.Context, _, _ common.Address, _ big.Int) error {

--- a/pkg/token/native_test.go
+++ b/pkg/token/native_test.go
@@ -4,13 +4,10 @@ package token_test
 
 import (
 	"context"
-	"errors"
 	"math/big"
 	"testing"
 
 	"github.com/chainsafe/canton-middleware/pkg/token"
-	"github.com/chainsafe/canton-middleware/pkg/token/mocks"
-	"github.com/chainsafe/canton-middleware/pkg/user"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
@@ -23,54 +20,16 @@ func TestNative_GetBalance(t *testing.T) {
 	ctx := context.Background()
 	addr := common.HexToAddress("0xAAAA000000000000000000000000000000000001")
 
-	t.Run("registered user returns configured native balance", func(t *testing.T) {
-		userStore := mocks.NewUserStore(t)
-		userStore.EXPECT().GetUserByEVMAddress(ctx, addr.Hex()).Return(&user.User{}, nil)
-
-		svc := token.NewTokenService(newCfg(), nil, userStore, nil)
-		native := token.NewNative(svc)
-
-		bal, err := native.GetBalance(ctx, addr)
-		require.NoError(t, err)
-		expected, _ := new(big.Int).SetString("5000000000000000000", 10)
-		assert.Equal(t, 0, expected.Cmp(&bal))
-	})
-
-	t.Run("unregistered user (ErrUserNotFound) returns zero and nil error", func(t *testing.T) {
-		userStore := mocks.NewUserStore(t)
-		userStore.EXPECT().GetUserByEVMAddress(ctx, addr.Hex()).Return(nil, user.ErrUserNotFound)
-
-		svc := token.NewTokenService(newCfg(), nil, userStore, nil)
+	// The native coin is synthetic and always reports a zero balance, regardless
+	// of registration — gas is also fixed at 0, so this still passes MetaMask's
+	// pre-flight check for the zero-value ERC-20 transfers this facade supports.
+	t.Run("always returns zero balance", func(t *testing.T) {
+		svc := token.NewTokenService(newCfg(), nil, nil, nil)
 		native := token.NewNative(svc)
 
 		bal, err := native.GetBalance(ctx, addr)
 		require.NoError(t, err)
 		assert.Equal(t, big.Int{}, bal)
-	})
-
-	t.Run("DB error propagates as error", func(t *testing.T) {
-		userStore := mocks.NewUserStore(t)
-		userStore.EXPECT().GetUserByEVMAddress(ctx, addr.Hex()).Return(nil, errors.New("db timeout"))
-
-		svc := token.NewTokenService(newCfg(), nil, userStore, nil)
-		native := token.NewNative(svc)
-
-		_, err := native.GetBalance(ctx, addr)
-		require.Error(t, err)
-	})
-
-	t.Run("invalid NativeBalanceWei panics", func(t *testing.T) {
-		userStore := mocks.NewUserStore(t)
-		userStore.EXPECT().GetUserByEVMAddress(ctx, addr.Hex()).Return(&user.User{}, nil)
-
-		// Override NativeBalanceWei with an unparseable string.
-		cfg := newCfg()
-		cfg.NativeBalanceWei = "not-a-number"
-		svc := token.NewTokenService(cfg, nil, userStore, nil)
-		native := token.NewNative(svc)
-
-		// nil dereference in *bal when SetString returns nil
-		assert.Panics(t, func() { native.GetBalance(ctx, addr) }) //nolint:errcheck // panic assertion intentionally ignores returned error
 	})
 }
 

--- a/pkg/token/service.go
+++ b/pkg/token/service.go
@@ -196,18 +196,6 @@ func (s *Service) getTokenName(_ context.Context, contract common.Address) (stri
 	return tkn.Name, nil
 }
 
-// isUserRegistered checks if an EVM address is registered
-func (s *Service) isUserRegistered(ctx context.Context, address common.Address) (bool, error) {
-	_, err := s.userStore.GetUserByEVMAddress(ctx, address.Hex())
-	if err != nil {
-		if errors.Is(err, user.ErrUserNotFound) {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
-}
-
 // getTokenSymbol returns the token symbol from config
 func (s *Service) getTokenSymbol(_ context.Context, contract common.Address) (string, error) {
 	tkn, err := s.cfg.getToken(contract)


### PR DESCRIPTION
## Problem

The EVM JSON-RPC facade reported a fake **1000-coin native balance** and a **1 gwei gas price** purely to satisfy MetaMask's client-side pre-flight check (`balance >= value + gasLimit*gasPrice`). The fake balance is confusing — a user with no native coin sees 1000 in MetaMask.

## Fix

There is no native gas token, so report **0**. Because the facade only accepts **zero-value ERC-20 transfers**, MetaMask's check collapses to `0 >= 0` — so transfers still go through **as long as gas is also 0**. This requires zeroing *every* fee surface MetaMask reads (gas price, maxPriorityFeePerGas, block baseFeePerGas, receipt effectiveGasPrice), not just `eth_gasPrice`.

Since the gas price and the cosmetic gas limit are fixed values rather than per-deployment knobs, they are hardcoded in code and removed from config:

- **native balance** → always `0` (`token.Native.GetBalance`)
- **gas price** → always `0` across `eth_gasPrice`, `maxPriorityFeePerGas`, block `baseFeePerGas`, receipt `effectiveGasPrice`
- **gas limit** → `service.DefaultGasLimit` (21000), cosmetic only

Removed from config: `eth_rpc.gas_price_wei`, `eth_rpc.gas_limit`, `eth_rpc.native_balance_wei` (the last was a dead field — never read), and `token.native_balance_wei`. Also dropped the now-dead `token.Service.isUserRegistered`.

> The relayer's `ethereum.gas_limit` (real on-chain gas for actual Ethereum txs) is **unaffected** — only the api-server facade's cosmetic values changed.

## Notes

- Verify against a live MetaMask: a zero-gas chain can occasionally surface soft warnings. If that happens, the values can be reintroduced — but the balance/gas coupling must be preserved (both 0, or both non-zero).
- `go build`, `go vet`, and the full test suite pass.