### PR TITLE
fix(relayer): chunk eth log queries and honor configured start block

### DIFF
--- a/pkg/ethereum/client.go
+++ b/pkg/ethereum/client.go
@@ -293,9 +293,9 @@ func (c *Client) WatchDepositEvents(ctx context.Context, fromBlock uint64, handl
 }
 
 // scanDepositRange filters DepositToCanton events for a single inclusive block
-// range and dispatches each to handler. A filter or iterator error is returned
-// so the caller can stop advancing scan progress and retry the range on the
-// next tick. Handler errors are logged but do not abort the range.
+// range and dispatches each to handler. A filter, iterator, or handler error is
+// returned so the caller can stop advancing scan progress and retry the range
+// on the next tick.
 func (c *Client) scanDepositRange(ctx context.Context, r blockRange, handler func(*DepositEvent) error) error {
 	opts := &bind.FilterOpts{
 		Start:   r.start,

--- a/pkg/ethereum/client.go
+++ b/pkg/ethereum/client.go
@@ -331,9 +331,11 @@ func (c *Client) scanDepositRange(ctx context.Context, r blockRange, handler fun
 		}
 
 		if err := handler(depositEvent); err != nil {
-			c.logger.Error("Failed to handle deposit event",
-				zap.Error(err),
-				zap.String("tx_hash", event.Raw.TxHash.Hex()))
+			// The handler only fails on context cancellation (shutdown). Abort
+			// the slice without advancing scan progress so the unhandled events
+			// are re-scanned on the next tick or restart; downstream inserts are
+			// idempotent (ON CONFLICT DO NOTHING), so re-delivery is safe.
+			return fmt.Errorf("handle deposit event %s: %w", event.Raw.TxHash.Hex(), err)
 		}
 	}
 

--- a/pkg/ethereum/client.go
+++ b/pkg/ethereum/client.go
@@ -275,55 +275,74 @@ func (c *Client) WatchDepositEvents(ctx context.Context, fromBlock uint64, handl
 					return
 				}
 
-				// Query for events from currentBlock+1 to latestBlock
-				opts := &bind.FilterOpts{
-					Start:   currentBlock + 1,
-					End:     &latestBlock,
-					Context: ctx,
-				}
-
-				filterStart := time.Now()
-				iter, err := c.bridge.FilterDepositToCanton(opts, nil, nil, nil)
-				c.observeRPC("filter_deposit_events", filterStart, err)
-				if err != nil {
-					c.metrics.EventPollFailuresTotal.WithLabelValues("filter_events").Inc()
-					c.logger.Warn("Failed to filter deposit events", zap.Error(err))
-					return
-				}
-
-				for iter.Next() {
-					c.metrics.EventsFetchedTotal.Inc()
-					event := iter.Event
-					depositEvent := &DepositEvent{
-						Token:           event.Token,
-						Sender:          event.Sender,
-						CantonRecipient: event.CantonRecipient,
-						Amount:          event.Amount,
-						Nonce:           event.Nonce,
-						BlockNumber:     event.Raw.BlockNumber,
-						TxHash:          event.Raw.TxHash,
-						LogIndex:        event.Raw.Index,
+				// Walk [currentBlock+1, latestBlock] in slices of at most
+				// MaxBlockRange blocks so each eth_getLogs request stays under
+				// the provider's per-call range cap. Progress advances only
+				// through the last successful slice; a failing slice (and
+				// everything after it) is retried on the next tick.
+				for _, r := range chunkRange(currentBlock+1, latestBlock, c.config.MaxBlockRange) {
+					if err := c.scanDepositRange(ctx, r, handler); err != nil {
+						return
 					}
-
-					if err := handler(depositEvent); err != nil {
-						c.logger.Error("Failed to handle deposit event",
-							zap.Error(err),
-							zap.String("tx_hash", event.Raw.TxHash.Hex()))
-					}
+					currentBlock = r.end
+					c.setLastScannedBlock(currentBlock)
 				}
-
-				if err := iter.Error(); err != nil {
-					c.metrics.EventPollFailuresTotal.WithLabelValues("iterator").Inc()
-					c.logger.Warn("Iterator error", zap.Error(err))
-				}
-				iter.Close()
-
-				// Update scan progress even if there were no events
-				currentBlock = latestBlock
-				c.setLastScannedBlock(currentBlock)
 			}()
 		}
 	}
+}
+
+// scanDepositRange filters DepositToCanton events for a single inclusive block
+// range and dispatches each to handler. A filter or iterator error is returned
+// so the caller can stop advancing scan progress and retry the range on the
+// next tick. Handler errors are logged but do not abort the range.
+func (c *Client) scanDepositRange(ctx context.Context, r blockRange, handler func(*DepositEvent) error) error {
+	opts := &bind.FilterOpts{
+		Start:   r.start,
+		End:     &r.end,
+		Context: ctx,
+	}
+
+	filterStart := time.Now()
+	iter, err := c.bridge.FilterDepositToCanton(opts, nil, nil, nil)
+	c.observeRPC("filter_deposit_events", filterStart, err)
+	if err != nil {
+		c.metrics.EventPollFailuresTotal.WithLabelValues("filter_events").Inc()
+		c.logger.Warn("Failed to filter deposit events",
+			zap.Uint64("from_block", r.start),
+			zap.Uint64("to_block", r.end),
+			zap.Error(err))
+		return err
+	}
+	defer iter.Close()
+
+	for iter.Next() {
+		c.metrics.EventsFetchedTotal.Inc()
+		event := iter.Event
+		depositEvent := &DepositEvent{
+			Token:           event.Token,
+			Sender:          event.Sender,
+			CantonRecipient: event.CantonRecipient,
+			Amount:          event.Amount,
+			Nonce:           event.Nonce,
+			BlockNumber:     event.Raw.BlockNumber,
+			TxHash:          event.Raw.TxHash,
+			LogIndex:        event.Raw.Index,
+		}
+
+		if err := handler(depositEvent); err != nil {
+			c.logger.Error("Failed to handle deposit event",
+				zap.Error(err),
+				zap.String("tx_hash", event.Raw.TxHash.Hex()))
+		}
+	}
+
+	if err := iter.Error(); err != nil {
+		c.metrics.EventPollFailuresTotal.WithLabelValues("iterator").Inc()
+		c.logger.Warn("Iterator error", zap.Error(err))
+		return err
+	}
+	return nil
 }
 
 // WithdrawFromCanton submits a withdrawal transaction

--- a/pkg/relayer/engine/engine.go
+++ b/pkg/relayer/engine/engine.go
@@ -365,6 +365,15 @@ func (e *Engine) loadEthereumOffset(ctx context.Context) error {
 
 	if state != nil {
 		e.ethLastBlock = state.LastBlock
+		// Honor a configured start_block that is ahead of the stored progress so
+		// operators can fast-forward past a problematic range without editing the
+		// DB. The later of the two always wins; config never rewinds the relayer.
+		if e.config.EthStartBlock > e.ethLastBlock {
+			e.logger.Info("Configured start_block is ahead of stored block, fast-forwarding",
+				zap.Uint64("stored_block", e.ethLastBlock),
+				zap.Uint64("configured_start_block", e.config.EthStartBlock))
+			e.ethLastBlock = e.config.EthStartBlock
+		}
 		e.logger.Info("Loaded Ethereum last block", zap.Uint64("block", e.ethLastBlock))
 		return nil
 	}


### PR DESCRIPTION
## Problem

The relayer was stuck logging `Block range limit exceeded` on every poll tick and ignoring the `eth_start_block` set in config (loading the old block from the DB instead). Two compounding bugs:

1. **`loadEthereumOffset` ignored config once any progress was persisted.** When a `chain_state` row existed, the stored block won unconditionally and `eth_start_block` was dead. The only way to fast-forward was hand-editing the DB.

2. **`WatchDepositEvents` never chunked its log queries.** It issued a single `eth_getLogs` spanning `currentBlock+1 .. head`. With a large catch-up gap that exceeds the provider's range cap, so the call failed and — since `currentBlock` only advances on success — it retried the identical oversized range forever. The documented `MaxBlockRange` chunking (`chunkRange`) existed but was never wired into the request path, which is why lowering `max_block_range` had no effect.

## Fix

- **`pkg/ethereum/client.go`** — walk `[currentBlock+1, head]` in `MaxBlockRange` slices via a new `scanDepositRange` helper, advancing scan progress only through the last successful slice. A failing slice (and everything after) retries on the next tick. `max_block_range` is now an effective lever.
- **`pkg/relayer/engine/engine.go`** — `loadEthereumOffset` now takes the later of the stored block and `eth_start_block`. Config can fast-forward past a stuck range but never rewinds the relayer.

## Notes

- Fix 2 alone recovers the current deployment: it'll chunk forward from the stored block instead of failing on the full range. Bumping `eth_start_block` just skips the catch-up.
- `chunkRange` slicing math is covered by `TestChunkRange`. End-to-end coverage of the loop would require a bridge interface refactor or simulated backend (`c.bridge` is a concrete abigen binding) — flagged as a possible follow-up.

## Testing

- `go build ./...`, `go vet`, and `go test ./pkg/ethereum/... ./pkg/relayer/...` pass.