### PR TITLE
fix(ethrpc): persist failed transaction receipts as status=0

### DIFF
--- a/pkg/ethrpc/store/model.go
+++ b/pkg/ethrpc/store/model.go
@@ -19,7 +19,7 @@ type EvmTransactionDao struct {
 	Nonce         uint64    `bun:"nonce,notnull"`
 	Input         []byte    `bun:"input,notnull,type:bytea"`
 	ValueWei      string    `bun:"value_wei,notnull,default:'0',type:text"`
-	Status        uint8     `bun:"status,notnull,default:1,type:smallint"`
+	Status        uint8     `bun:"status,notnull,type:smallint"`
 	BlockNumber   uint64    `bun:"block_number,notnull"`
 	BlockHash     []byte    `bun:"block_hash,notnull,type:bytea"`
 	TxIndex       uint      `bun:"tx_index,notnull,default:0"`

--- a/pkg/ethrpc/store/pg_test.go
+++ b/pkg/ethrpc/store/pg_test.go
@@ -324,6 +324,57 @@ func TestPGStore_Transactions(t *testing.T) {
 	}
 }
 
+// TestPGStore_FailedTransactionStatusPersists guards against a column-default
+// regression: the evm_transactions.status column must store status=0 (failed)
+// verbatim. A `default:1` bun tag would make bun emit SQL DEFAULT for the
+// zero value, silently flipping every failed transaction to status=1 (success)
+// while still carrying its revert reason — producing a contradictory receipt.
+// Requires a real Postgres (the bug only manifests against a DB that applies
+// the column default), which setupEVMStore provides via testcontainers.
+func TestPGStore_FailedTransactionStatusPersists(t *testing.T) {
+	ctx := context.Background()
+	store, _ := setupEVMStore(t)
+
+	block, err := store.NewBlock(ctx, testChainID)
+	if err != nil {
+		t.Fatalf("NewBlock failed: %v", err)
+	}
+	failed := &ethrpc.EvmTransaction{
+		TxHash:       []byte{0xfa, 0x11},
+		FromAddress:  "0x1111111111111111111111111111111111111111",
+		ToAddress:    "0x2222222222222222222222222222222222222222",
+		Nonce:        0,
+		Input:        []byte{0xaa},
+		ValueWei:     "0",
+		Status:       0, // failed — the zero value the bug would clobber
+		ErrorMessage: "failed to get recipient: user not found",
+		BlockNumber:  block.Number(),
+		BlockHash:    block.Hash(),
+		TxIndex:      0,
+		GasUsed:      21000,
+	}
+	if err = block.AddEvmTransaction(ctx, failed); err != nil {
+		t.Fatalf("AddEvmTransaction(failed) failed: %v", err)
+	}
+	if err = block.Finalize(ctx); err != nil {
+		t.Fatalf("Finalize failed: %v", err)
+	}
+
+	got, err := store.GetEvmTransaction(ctx, failed.TxHash)
+	if err != nil {
+		t.Fatalf("GetEvmTransaction(failed) failed: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("GetEvmTransaction(failed) returned nil")
+	}
+	if got.Status != 0 {
+		t.Fatalf("failed tx status not persisted: got %d want 0 (a non-zero result means the column default clobbered it)", got.Status)
+	}
+	if got.ErrorMessage != failed.ErrorMessage {
+		t.Fatalf("error message mismatch: got %q want %q", got.ErrorMessage, failed.ErrorMessage)
+	}
+}
+
 func TestPGStore_Logs(t *testing.T) {
 	ctx := context.Background()
 	store, db := setupEVMStore(t)

--- a/pkg/migrations/apidb/14_fix_failed_tx_status.go
+++ b/pkg/migrations/apidb/14_fix_failed_tx_status.go
@@ -14,17 +14,39 @@ import (
 // status (0) is the column's zero value and the column carried a DEFAULT 1,
 // bun emitted SQL DEFAULT on insert and Postgres stored 1 — flipping every
 // failed receipt to status=0x1 (success) while it still carried its revert
-// reason. The struct tag is removed in code; this migration drops the
-// lingering DEFAULT 1 on existing databases (fresh DBs created after the tag
-// removal never had it). With no default, bun now inserts the literal 0/1, so
-// failures persist correctly going forward.
+// reason. The struct tag is removed in code; this migration:
+//
+//  1. Drops the lingering DEFAULT 1 on existing databases (fresh DBs created
+//     after the tag removal never had it). With no default, bun now inserts
+//     the literal 0/1, so failures persist correctly going forward.
+//  2. Backfills already-mined rows. A successful transaction never carries an
+//     error_message (the miner only sets it on the failure branch), so a row
+//     with status=1 AND a non-empty error_message is unambiguously a failure
+//     that was clobbered — safe to flip back to 0.
 func init() {
 	Migrations.MustRegister(func(ctx context.Context, db *bun.DB) error {
 		log.Println("dropping DEFAULT on evm_transactions.status...")
-		_, err := db.ExecContext(ctx,
+		if _, err := db.ExecContext(ctx,
 			`ALTER TABLE evm_transactions ALTER COLUMN status DROP DEFAULT`,
+		); err != nil {
+			return err
+		}
+
+		log.Println("backfilling clobbered failed-transaction statuses (status=1 with an error_message -> 0)...")
+		res, err := db.ExecContext(ctx,
+			`UPDATE evm_transactions
+			    SET status = 0
+			  WHERE status = 1
+			    AND error_message IS NOT NULL
+			    AND error_message <> ''`,
 		)
-		return err
+		if err != nil {
+			return err
+		}
+		if n, aerr := res.RowsAffected(); aerr == nil {
+			log.Printf("repaired %d corrupted failed-transaction receipts", n)
+		}
+		return nil
 	}, func(ctx context.Context, db *bun.DB) error {
 		// The data repair is intentionally irreversible — the original (wrong)
 		// values are indistinguishable from correct ones, so a down migration

--- a/pkg/migrations/apidb/14_fix_failed_tx_status.go
+++ b/pkg/migrations/apidb/14_fix_failed_tx_status.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package apidb
+
+import (
+	"context"
+	"log"
+
+	"github.com/uptrace/bun"
+)
+
+// Migration 14 fixes the evm_transactions.status corruption caused by the
+// `default:1` bun tag on the status column. Because a failed transaction's
+// status (0) is the column's zero value and the column carried a DEFAULT 1,
+// bun emitted SQL DEFAULT on insert and Postgres stored 1 — flipping every
+// failed receipt to status=0x1 (success) while it still carried its revert
+// reason. The struct tag is removed in code; this migration drops the
+// lingering DEFAULT 1 on existing databases (fresh DBs created after the tag
+// removal never had it). With no default, bun now inserts the literal 0/1, so
+// failures persist correctly going forward.
+func init() {
+	Migrations.MustRegister(func(ctx context.Context, db *bun.DB) error {
+		log.Println("dropping DEFAULT on evm_transactions.status...")
+		_, err := db.ExecContext(ctx,
+			`ALTER TABLE evm_transactions ALTER COLUMN status DROP DEFAULT`,
+		)
+		return err
+	}, func(ctx context.Context, db *bun.DB) error {
+		// The data repair is intentionally irreversible — the original (wrong)
+		// values are indistinguishable from correct ones, so a down migration
+		// cannot restore them. Only the schema-level default is reinstated to
+		// mirror the prior column definition.
+		log.Println("restoring DEFAULT 1 on evm_transactions.status...")
+		_, err := db.ExecContext(ctx,
+			`ALTER TABLE evm_transactions ALTER COLUMN status SET DEFAULT 1`,
+		)
+		return err
+	})
+}


### PR DESCRIPTION
## Summary
Failed EVM transfers were returned by `eth_getTransactionReceipt` with `status: "0x1"` (success) **and** a `revertReason` — a contradiction. Wallets showed failed transfers as successful.