### PR TITLE
feat(api): transfer to external party via party id

### DIFF
--- a/pkg/transfer/http.go
+++ b/pkg/transfer/http.go
@@ -44,6 +44,10 @@ func RegisterRoutes(r chi.Router, svc Service, logger *zap.Logger) {
 	r.Post("/api/v2/transfer/prepare", apphttp.HandleError(h.prepare))
 	r.Post("/api/v2/transfer/execute", apphttp.HandleError(h.execute))
 
+	// Custodial single-call transfer to an arbitrary recipient party id. The
+	// middleware holds the custodial user's Canton key and signs server-side.
+	r.Post("/api/v2/transfer/custodial", apphttp.HandleError(h.sendCustodial))
+
 	r.Get("/api/v2/transfer/incoming", apphttp.HandleError(h.listIncoming))
 	r.Post("/api/v2/transfer/incoming/{contractID}/prepare", apphttp.HandleError(h.prepareAccept))
 	r.Post("/api/v2/transfer/incoming/{contractID}/execute", apphttp.HandleError(h.executeAccept))
@@ -60,10 +64,14 @@ func (h *httpHandler) prepare(w http.ResponseWriter, r *http.Request) error {
 		return jsonErr
 	}
 
-	if req.To == "" || req.Amount == "" || req.Token == "" {
-		return apperrors.BadRequestError(nil, "to, amount, and token are required")
+	if req.Amount == "" || req.Token == "" {
+		return apperrors.BadRequestError(nil, "amount and token are required")
 	}
-	if !auth.ValidateEVMAddress(req.To) {
+	// Exactly one recipient form: a registered user's EVM address, or a raw party id.
+	if (req.To == "") == (req.ToPartyID == "") {
+		return apperrors.BadRequestError(nil, "exactly one of to or to_party_id is required")
+	}
+	if req.To != "" && !auth.ValidateEVMAddress(req.To) {
 		return apperrors.BadRequestError(nil, "invalid recipient address: must be a 0x-prefixed 40-hex-char EVM address")
 	}
 	amt, parseErr := decimal.NewFromString(req.Amount)
@@ -72,6 +80,34 @@ func (h *httpHandler) prepare(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	resp, err := h.svc.Prepare(r.Context(), evmAddr, &req)
+	if err != nil {
+		return err
+	}
+
+	h.writeJSON(w, resp)
+	return nil
+}
+
+func (h *httpHandler) sendCustodial(w http.ResponseWriter, r *http.Request) error {
+	evmAddr, err := authenticateEVM(r)
+	if err != nil {
+		return err
+	}
+
+	var req CustodialTransferRequest
+	if jsonErr := readJSON(r, &req); jsonErr != nil {
+		return jsonErr
+	}
+
+	if req.ToPartyID == "" || req.Amount == "" || req.Token == "" {
+		return apperrors.BadRequestError(nil, "to_party_id, amount, and token are required")
+	}
+	amt, parseErr := decimal.NewFromString(req.Amount)
+	if parseErr != nil || !amt.IsPositive() {
+		return apperrors.BadRequestError(nil, "invalid amount: must be a positive decimal number")
+	}
+
+	resp, err := h.svc.SendCustodial(r.Context(), evmAddr, &req)
 	if err != nil {
 		return err
 	}

--- a/pkg/transfer/log.go
+++ b/pkg/transfer/log.go
@@ -224,6 +224,48 @@ func (ls *logService) ExecuteAccept(
 	return ls.svc.ExecuteAccept(ctx, evmAddr, req)
 }
 
+// SendCustodial wraps the service method with logging.
+func (ls *logService) SendCustodial(
+	ctx context.Context,
+	senderEVMAddr string,
+	req *CustodialTransferRequest,
+) (resp *ExecuteResponse, err error) {
+	start := time.Now()
+
+	ls.logger.Info("SendCustodial started",
+		zap.String("service", transferServiceName),
+		zap.String("method", "SendCustodial"),
+		zap.String("sender", senderEVMAddr),
+		zap.String("to_party_id", req.ToPartyID),
+		zap.String("amount", req.Amount),
+		zap.String("token", req.Token),
+	)
+
+	defer func() {
+		duration := time.Since(start)
+
+		if err != nil {
+			ls.logger.Error("SendCustodial failed",
+				zap.String("service", transferServiceName),
+				zap.String("method", "SendCustodial"),
+				zap.String("sender", senderEVMAddr),
+				zap.Duration("duration", duration),
+				zap.Error(err),
+			)
+		} else {
+			ls.logger.Info("SendCustodial completed",
+				zap.String("service", transferServiceName),
+				zap.String("method", "SendCustodial"),
+				zap.String("sender", senderEVMAddr),
+				zap.String("status", resp.Status),
+				zap.Duration("duration", duration),
+			)
+		}
+	}()
+
+	return ls.svc.SendCustodial(ctx, senderEVMAddr, req)
+}
+
 // redactSignature redacts signature data to show only metadata.
 // Signatures are sensitive and should not be logged in full.
 func redactSignature(sig string) string {

--- a/pkg/transfer/service.go
+++ b/pkg/transfer/service.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -52,6 +53,11 @@ type PendingOfferLister interface {
 type Service interface {
 	Prepare(ctx context.Context, senderEVMAddr string, req *PrepareRequest) (*PrepareResponse, error)
 	Execute(ctx context.Context, senderEVMAddr string, req *ExecuteRequest) (*ExecuteResponse, error)
+
+	// SendCustodial performs a single-call, server-signed transfer for a custodial
+	// user to an arbitrary recipient party id (the middleware holds the user's
+	// Canton key, so there is no client prepare/execute round-trip).
+	SendCustodial(ctx context.Context, senderEVMAddr string, req *CustodialTransferRequest) (*ExecuteResponse, error)
 
 	// ListIncoming returns one page of pending inbound TransferOffer details for the
 	// user with the given EVM address. This call is unauthenticated — anyone can
@@ -145,17 +151,30 @@ func (s *TransferService) Prepare(ctx context.Context, senderEVMAddr string, req
 		return nil, apperrors.BadRequestError(nil, "prepare/execute API requires key_mode=external")
 	}
 
-	recipient, err := s.userStore.GetUserByEVMAddress(ctx, req.To)
-	if err != nil {
-		if errors.Is(err, user.ErrUserNotFound) {
-			return nil, apperrors.BadRequestError(err, "recipient not found")
+	// Resolve the recipient party id. When the caller supplies a raw party id we
+	// use it directly (it may be a party not registered in the middleware, e.g.
+	// hosted on an external participant node); otherwise we look up the EVM
+	// address of a registered user.
+	toPartyID := req.ToPartyID
+	if toPartyID == "" {
+		recipient, lookupErr := s.userStore.GetUserByEVMAddress(ctx, req.To)
+		if lookupErr != nil {
+			if errors.Is(lookupErr, user.ErrUserNotFound) {
+				return nil, apperrors.BadRequestError(lookupErr, "recipient not found")
+			}
+			return nil, fmt.Errorf("lookup recipient: %w", lookupErr)
 		}
-		return nil, fmt.Errorf("lookup recipient: %w", err)
+		toPartyID = recipient.CantonPartyID
+	} else if vErr := validatePartyID(toPartyID); vErr != nil {
+		return nil, apperrors.BadRequestError(vErr, "invalid recipient party id")
+	}
+	if toPartyID == sender.CantonPartyID {
+		return nil, apperrors.BadRequestError(nil, "cannot transfer to self")
 	}
 
 	pt, err := s.cantonToken.PrepareTransfer(ctx, &token.PrepareTransferRequest{
 		FromPartyID: sender.CantonPartyID,
-		ToPartyID:   recipient.CantonPartyID,
+		ToPartyID:   toPartyID,
 		Amount:      req.Amount,
 		TokenSymbol: req.Token,
 	})
@@ -176,6 +195,64 @@ func (s *TransferService) Prepare(ctx context.Context, senderEVMAddr string, req
 		PartyID:         pt.PartyID,
 		ExpiresAt:       pt.ExpiresAt.Format(time.RFC3339),
 	}, nil
+}
+
+// SendCustodial performs a single-call, server-signed transfer for a custodial
+// user to an arbitrary recipient party id. The middleware holds the custodial
+// user's Canton key, so it both prepares and executes the transfer (no client
+// round-trip). The recipient must accept the resulting TransferOffer on their
+// own participant node; this call only creates and submits the offer.
+func (s *TransferService) SendCustodial(
+	ctx context.Context, senderEVMAddr string, req *CustodialTransferRequest,
+) (*ExecuteResponse, error) {
+	if !s.allowedTokenSymbols[req.Token] {
+		return nil, apperrors.BadRequestError(nil, "unsupported token")
+	}
+
+	if err := validatePartyID(req.ToPartyID); err != nil {
+		return nil, apperrors.BadRequestError(err, "invalid recipient party id")
+	}
+
+	sender, err := s.userStore.GetUserByEVMAddress(ctx, senderEVMAddr)
+	if err != nil {
+		if errors.Is(err, user.ErrUserNotFound) {
+			return nil, apperrors.UnAuthorizedError(err, "user not found")
+		}
+		return nil, fmt.Errorf("lookup sender: %w", err)
+	}
+	if sender.KeyMode != user.KeyModeCustodial {
+		return nil, apperrors.BadRequestError(nil, "this endpoint requires key_mode=custodial")
+	}
+	if req.ToPartyID == sender.CantonPartyID {
+		return nil, apperrors.BadRequestError(nil, "cannot transfer to self")
+	}
+
+	// The middleware signs server-side, so prepare+execute happen in one call.
+	// A fresh idempotency key is used as the Canton command id per request.
+	err = s.cantonToken.TransferByPartyID(ctx, uuid.NewString(), sender.CantonPartyID, req.ToPartyID, req.Amount, req.Token)
+	if err != nil {
+		if errors.Is(err, token.ErrInsufficientBalance) {
+			return nil, apperrors.BadRequestError(err, "insufficient balance")
+		}
+		return nil, fmt.Errorf("transfer: %w", err)
+	}
+
+	return &ExecuteResponse{Status: "submitted"}, nil
+}
+
+// validatePartyID does a lightweight syntactic check of a Canton party id, which
+// has the form "<hint>::<fingerprint>" where the fingerprint is a hex-encoded
+// multihash. It rejects obvious garbage (e.g. an EVM address pasted by mistake);
+// an id that is well-formed but unroutable is surfaced by Canton at submission.
+func validatePartyID(partyID string) error {
+	hint, fingerprint, ok := strings.Cut(partyID, "::")
+	if !ok || hint == "" || fingerprint == "" {
+		return fmt.Errorf("party id must be of the form <hint>::<fingerprint>")
+	}
+	if _, err := hex.DecodeString(fingerprint); err != nil {
+		return fmt.Errorf("party id fingerprint must be hex-encoded")
+	}
+	return nil
 }
 
 // Execute completes a previously prepared transfer using the client's DER signature.

--- a/pkg/transfer/service.go
+++ b/pkg/transfer/service.go
@@ -151,6 +151,13 @@ func (s *TransferService) Prepare(ctx context.Context, senderEVMAddr string, req
 		return nil, apperrors.BadRequestError(nil, "prepare/execute API requires key_mode=external")
 	}
 
+	// Exactly one recipient form is allowed; reject an ambiguous request rather
+	// than silently preferring one (the HTTP handler enforces this too, but the
+	// service must not resolve an ambiguous request when called directly).
+	if (req.To == "") == (req.ToPartyID == "") {
+		return nil, apperrors.BadRequestError(nil, "exactly one of to or to_party_id is required")
+	}
+
 	// Resolve the recipient party id. When the caller supplies a raw party id we
 	// use it directly (it may be a party not registered in the middleware, e.g.
 	// hosted on an external participant node); otherwise we look up the EVM

--- a/pkg/transfer/service_test.go
+++ b/pkg/transfer/service_test.go
@@ -165,6 +165,203 @@ func TestTransferService_Prepare_UnsupportedToken(t *testing.T) {
 	assertServiceErrorCategory(t, err, apperrors.CategoryDataError)
 }
 
+// validExternalPartyID is a syntactically valid Canton party id (hint::hex)
+// for a party not registered in the middleware.
+const validExternalPartyID = "alice::1220abcdef0123456789"
+
+func TestTransferService_Prepare_ToPartyID_Success(t *testing.T) {
+	ctx := context.Background()
+	sender := senderUser()
+
+	// Only the sender is looked up; the recipient party id is used directly,
+	// so there is no second GetUserByEVMAddress call.
+	store := mocks.NewUserStore(t)
+	store.EXPECT().GetUserByEVMAddress(ctx, sender.EVMAddress).Return(sender, nil).Once()
+
+	prepared := &token.PreparedTransfer{
+		TransferID:      "txn-ext-1",
+		TransactionHash: []byte{0xbe, 0xef},
+		PartyID:         sender.CantonPartyID,
+		ExpiresAt:       time.Now().Add(2 * time.Minute),
+	}
+
+	tok := mocks.NewToken(t)
+	tok.EXPECT().PrepareTransfer(ctx, &token.PrepareTransferRequest{
+		FromPartyID: sender.CantonPartyID,
+		ToPartyID:   validExternalPartyID,
+		Amount:      "10",
+		TokenSymbol: "DEMO",
+	}).Return(prepared, nil).Once()
+
+	cache := mocks.NewTransferCache(t)
+	cache.EXPECT().Put(prepared).Return(nil).Once()
+
+	svc := newTestService(t, tok, store, cache)
+	resp, err := svc.Prepare(ctx, sender.EVMAddress, &PrepareRequest{
+		ToPartyID: validExternalPartyID,
+		Amount:    "10",
+		Token:     "DEMO",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "txn-ext-1", resp.TransferID)
+	assert.Equal(t, sender.CantonPartyID, resp.PartyID)
+}
+
+func TestTransferService_Prepare_ToPartyID_Invalid(t *testing.T) {
+	ctx := context.Background()
+	sender := senderUser()
+
+	store := mocks.NewUserStore(t)
+	store.EXPECT().GetUserByEVMAddress(ctx, sender.EVMAddress).Return(sender, nil).Once()
+
+	svc := newTestService(t, mocks.NewToken(t), store, mocks.NewTransferCache(t))
+	_, err := svc.Prepare(ctx, sender.EVMAddress, &PrepareRequest{
+		ToPartyID: "not-a-party-id",
+		Amount:    "10",
+		Token:     "DEMO",
+	})
+	assertServiceErrorCategory(t, err, apperrors.CategoryDataError)
+}
+
+func TestTransferService_Prepare_ToPartyID_Self(t *testing.T) {
+	ctx := context.Background()
+	sender := senderUser()
+	sender.CantonPartyID = "sender::1220deadbeef" // valid hex so it passes party-id validation
+
+	store := mocks.NewUserStore(t)
+	store.EXPECT().GetUserByEVMAddress(ctx, sender.EVMAddress).Return(sender, nil).Once()
+
+	svc := newTestService(t, mocks.NewToken(t), store, mocks.NewTransferCache(t))
+	_, err := svc.Prepare(ctx, sender.EVMAddress, &PrepareRequest{
+		ToPartyID: sender.CantonPartyID,
+		Amount:    "10",
+		Token:     "DEMO",
+	})
+	assertServiceErrorCategory(t, err, apperrors.CategoryDataError)
+}
+
+// --- SendCustodial tests ---
+
+func custodialSender() *user.User {
+	return &user.User{
+		EVMAddress:    "0xcccccccccccccccccccccccccccccccccccccccc",
+		CantonPartyID: "sender::1220deadbeef",
+		KeyMode:       user.KeyModeCustodial,
+	}
+}
+
+func TestTransferService_SendCustodial_Success(t *testing.T) {
+	ctx := context.Background()
+	sender := custodialSender()
+
+	store := mocks.NewUserStore(t)
+	store.EXPECT().GetUserByEVMAddress(ctx, sender.EVMAddress).Return(sender, nil).Once()
+
+	tok := mocks.NewToken(t)
+	// idempotencyKey is a freshly generated UUID, so match any string there.
+	tok.EXPECT().TransferByPartyID(ctx, mock.Anything, sender.CantonPartyID, validExternalPartyID, "10", "DEMO").
+		Return(nil).Once()
+
+	svc := newTestService(t, tok, store, mocks.NewTransferCache(t))
+	resp, err := svc.SendCustodial(ctx, sender.EVMAddress, &CustodialTransferRequest{
+		ToPartyID: validExternalPartyID,
+		Amount:    "10",
+		Token:     "DEMO",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "submitted", resp.Status)
+}
+
+func TestTransferService_SendCustodial_RequiresCustodial(t *testing.T) {
+	ctx := context.Background()
+	sender := senderUser() // key_mode=external
+
+	store := mocks.NewUserStore(t)
+	store.EXPECT().GetUserByEVMAddress(ctx, sender.EVMAddress).Return(sender, nil).Once()
+
+	svc := newTestService(t, mocks.NewToken(t), store, mocks.NewTransferCache(t))
+	_, err := svc.SendCustodial(ctx, sender.EVMAddress, &CustodialTransferRequest{
+		ToPartyID: validExternalPartyID,
+		Amount:    "10",
+		Token:     "DEMO",
+	})
+	assertServiceErrorCategory(t, err, apperrors.CategoryDataError)
+}
+
+func TestTransferService_SendCustodial_InvalidPartyID(t *testing.T) {
+	// Party-id validation happens before any store lookup, so no user mock is needed.
+	svc := newTestService(t, mocks.NewToken(t), mocks.NewUserStore(t), mocks.NewTransferCache(t))
+	_, err := svc.SendCustodial(context.Background(), custodialSender().EVMAddress, &CustodialTransferRequest{
+		ToPartyID: "0xdeadbeef", // missing hint::fingerprint form
+		Amount:    "10",
+		Token:     "DEMO",
+	})
+	assertServiceErrorCategory(t, err, apperrors.CategoryDataError)
+}
+
+func TestTransferService_SendCustodial_UserNotFound(t *testing.T) {
+	ctx := context.Background()
+	sender := custodialSender()
+
+	store := mocks.NewUserStore(t)
+	store.EXPECT().GetUserByEVMAddress(ctx, sender.EVMAddress).Return(nil, user.ErrUserNotFound).Once()
+
+	svc := newTestService(t, mocks.NewToken(t), store, mocks.NewTransferCache(t))
+	_, err := svc.SendCustodial(ctx, sender.EVMAddress, &CustodialTransferRequest{
+		ToPartyID: validExternalPartyID,
+		Amount:    "10",
+		Token:     "DEMO",
+	})
+	assertServiceErrorCategory(t, err, apperrors.CategoryUnauthorized)
+}
+
+func TestTransferService_SendCustodial_InsufficientBalance(t *testing.T) {
+	ctx := context.Background()
+	sender := custodialSender()
+
+	store := mocks.NewUserStore(t)
+	store.EXPECT().GetUserByEVMAddress(ctx, sender.EVMAddress).Return(sender, nil).Once()
+
+	tok := mocks.NewToken(t)
+	tok.EXPECT().TransferByPartyID(ctx, mock.Anything, sender.CantonPartyID, validExternalPartyID, "10", "DEMO").
+		Return(token.ErrInsufficientBalance).Once()
+
+	svc := newTestService(t, tok, store, mocks.NewTransferCache(t))
+	_, err := svc.SendCustodial(ctx, sender.EVMAddress, &CustodialTransferRequest{
+		ToPartyID: validExternalPartyID,
+		Amount:    "10",
+		Token:     "DEMO",
+	})
+	assertServiceErrorCategory(t, err, apperrors.CategoryDataError)
+}
+
+func TestValidatePartyID(t *testing.T) {
+	cases := []struct {
+		name    string
+		partyID string
+		wantErr bool
+	}{
+		{"valid", "alice::1220abcdef0123456789", false},
+		{"no separator", "alice1220abcdef", true},
+		{"empty hint", "::1220abcdef", true},
+		{"empty fingerprint", "alice::", true},
+		{"non-hex fingerprint", "alice::nothex", true},
+		{"evm address", "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validatePartyID(tc.partyID)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 // --- Execute tests ---
 
 func TestTransferService_Execute_Success(t *testing.T) {

--- a/pkg/transfer/service_test.go
+++ b/pkg/transfer/service_test.go
@@ -241,6 +241,38 @@ func TestTransferService_Prepare_ToPartyID_Self(t *testing.T) {
 	assertServiceErrorCategory(t, err, apperrors.CategoryDataError)
 }
 
+func TestTransferService_Prepare_BothRecipientForms_Rejected(t *testing.T) {
+	ctx := context.Background()
+	sender := senderUser()
+
+	store := mocks.NewUserStore(t)
+	store.EXPECT().GetUserByEVMAddress(ctx, sender.EVMAddress).Return(sender, nil).Once()
+
+	svc := newTestService(t, mocks.NewToken(t), store, mocks.NewTransferCache(t))
+	_, err := svc.Prepare(ctx, sender.EVMAddress, &PrepareRequest{
+		To:        recipientUser().EVMAddress,
+		ToPartyID: validExternalPartyID,
+		Amount:    "10",
+		Token:     "DEMO",
+	})
+	assertServiceErrorCategory(t, err, apperrors.CategoryDataError)
+}
+
+func TestTransferService_Prepare_NoRecipient_Rejected(t *testing.T) {
+	ctx := context.Background()
+	sender := senderUser()
+
+	store := mocks.NewUserStore(t)
+	store.EXPECT().GetUserByEVMAddress(ctx, sender.EVMAddress).Return(sender, nil).Once()
+
+	svc := newTestService(t, mocks.NewToken(t), store, mocks.NewTransferCache(t))
+	_, err := svc.Prepare(ctx, sender.EVMAddress, &PrepareRequest{
+		Amount: "10",
+		Token:  "DEMO",
+	})
+	assertServiceErrorCategory(t, err, apperrors.CategoryDataError)
+}
+
 // --- SendCustodial tests ---
 
 func custodialSender() *user.User {

--- a/pkg/transfer/types.go
+++ b/pkg/transfer/types.go
@@ -4,10 +4,22 @@
 package transfer
 
 // PrepareRequest is the HTTP request body for preparing a non-custodial transfer.
+// Exactly one of To (a registered user's EVM address) or ToPartyID (an arbitrary
+// Canton party id, e.g. a party on an external participant node) must be set.
 type PrepareRequest struct {
-	To     string `json:"to"`     // Recipient EVM address (0x...)
-	Amount string `json:"amount"` // Token amount (decimal string)
-	Token  string `json:"token"`  // "DEMO" or "PROMPT"
+	To        string `json:"to,omitempty"`          // Recipient EVM address (0x...) of a registered user
+	ToPartyID string `json:"to_party_id,omitempty"` // Recipient Canton party id (<hint>::<fingerprint>)
+	Amount    string `json:"amount"`                // Token amount (decimal string)
+	Token     string `json:"token"`                 // "DEMO" or "PROMPT"
+}
+
+// CustodialTransferRequest is the HTTP request body for the custodial transfer
+// endpoint, which sends a token to an arbitrary recipient party id in a single
+// server-signed call (the middleware holds the custodial user's Canton key).
+type CustodialTransferRequest struct {
+	ToPartyID string `json:"to_party_id"` // Recipient Canton party id (<hint>::<fingerprint>)
+	Amount    string `json:"amount"`      // Token amount (decimal string)
+	Token     string `json:"token"`       // Token symbol
 }
 
 // PrepareResponse is the HTTP response body for a prepared transfer.


### PR DESCRIPTION
Closes #316.

Enables transferring a token to a Canton party that is **not registered in the middleware** (e.g. a party hosted on an external participant node), addressed by its party id rather than an EVM address. The Canton SDK already supported sending to an arbitrary `ToPartyID` (and routes USDCx through the registry); the only blocker was the API/service layer resolving the recipient through the userstore.

## Changes

**Non-custodial** (existing `/prepare` + `/execute`, no new endpoints)
- `PrepareRequest` gains an optional `to_party_id`. When set, `Prepare` uses it directly and skips the `GetUserByEVMAddress` recipient lookup; when absent, behaviour is unchanged (EVM address → registered user). The handler now requires *exactly one* of `to` or `to_party_id`.

**Custodial** (new endpoint)
- `POST /api/v2/transfer/custodial` — single server-signed call (`{to_party_id, amount, token}`, EIP-191 sender auth). The middleware holds the custodial user's Canton key, so it both prepares and executes via `TransferByPartyID`; returns `{ "status": "submitted" }`.

