### PR TITLE
ci: deploy all three services to devnet on release

### DIFF
--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -144,22 +144,38 @@ jobs:
           token: ${{ secrets.INFRA_GH_TOKEN }}
           ref: main
 
-      - name: Update canton-middleware-api image tag
+      # Each service maps to a Helm values file in infra-kubernetes whose
+      # top-level key matches the Helm release name. Add a service here to
+      # have it bumped and deployed to devnet automatically on release.
+      - name: Update image tags for all services
         env:
           VERSION: ${{ steps.version.outputs.version }}
+          DIR: definitions/canton/validator-dev1
         run: |
-          yq e '.["canton-middleware-api"].image.tag = env(VERSION)' -i \
-            definitions/canton/validator-dev1/canton-middleware-api-values.yml
+          while IFS='|' read -r key file; do
+            [ -z "$key" ] && continue
+            echo "Bumping ${key} -> ${VERSION} in ${file}"
+            yq e ".[\"${key}\"].image.tag = env(VERSION)" -i "${DIR}/${file}"
+          done <<'EOF'
+          canton-middleware-api|canton-middleware-api-values.yml
+          canton-indexer|canton-indexer-values.yml
+          canton-middleware|canton-middleware-values.yml
+          EOF
 
       - name: Create signed commit and open PR
         env:
           VERSION: ${{ steps.version.outputs.version }}
           GH_TOKEN: ${{ secrets.INFRA_GH_TOKEN }}
-          FILE_PATH: definitions/canton/validator-dev1/canton-middleware-api-values.yml
+          DIR: definitions/canton/validator-dev1
           REPO: ChainSafe/infra-kubernetes
         run: |
-          BRANCH="chore/bump-canton-middleware-api-${VERSION}"
-          COMMIT_MSG="chore: bump canton-middleware-api to ${VERSION} on devnet"
+          FILES=(
+            canton-middleware-api-values.yml
+            canton-indexer-values.yml
+            canton-middleware-values.yml
+          )
+          BRANCH="chore/bump-canton-services-${VERSION}"
+          COMMIT_MSG="chore: bump canton services to ${VERSION} on devnet"
 
           # Get current HEAD SHA of main
           HEAD_SHA=$(gh api repos/${REPO}/git/ref/heads/main --jq '.object.sha')
@@ -173,44 +189,45 @@ jobs:
           # Get current branch HEAD SHA
           BRANCH_SHA=$(gh api repos/${REPO}/git/ref/heads/${BRANCH} --jq '.object.sha')
 
-          # Skip if branch already has this version (idempotent re-run)
-          BRANCH_TAG=$(gh api "repos/${REPO}/contents/${FILE_PATH}?ref=${BRANCH}" \
-            -H "Accept: application/vnd.github.raw" 2>/dev/null \
-            | yq e '.["canton-middleware-api"].image.tag' - 2>/dev/null || echo "")
-          if [ "$BRANCH_TAG" = "$VERSION" ]; then
-            echo "Branch already has tag ${VERSION}, ensuring auto-merge"
+          # Skip if every file on the branch already has this version (idempotent re-run)
+          ALL_MATCH=true
+          for f in "${FILES[@]}"; do
+            KEY="${f%-values.yml}"
+            BRANCH_TAG=$(gh api "repos/${REPO}/contents/${DIR}/${f}?ref=${BRANCH}" \
+              -H "Accept: application/vnd.github.raw" 2>/dev/null \
+              | yq e ".[\"${KEY}\"].image.tag" - 2>/dev/null || echo "")
+            [ "$BRANCH_TAG" = "$VERSION" ] || ALL_MATCH=false
+          done
+          if [ "$ALL_MATCH" = "true" ]; then
+            echo "Branch already at tag ${VERSION} for all services, ensuring auto-merge"
             gh pr merge --auto --squash --repo "${REPO}" "${BRANCH}" 2>/dev/null || true
             exit 0
           fi
 
-          # Base64-encode the updated file (no line wrapping, Linux base64)
-          FILE_CONTENTS=$(base64 -w0 "${FILE_PATH}")
+          # Build the GraphQL additions array: one entry per file, base64-encoded
+          # (no line wrapping, Linux base64). Commits via createCommitOnBranch are
+          # automatically signed by GitHub (Verified).
+          ADDITIONS="[]"
+          for f in "${FILES[@]}"; do
+            CONTENTS=$(base64 -w0 "${DIR}/${f}")
+            ADDITIONS=$(jq -nc --argjson acc "$ADDITIONS" \
+              --arg path "${DIR}/${f}" --arg contents "$CONTENTS" \
+              '$acc + [{path: $path, contents: $contents}]')
+          done
 
-          # Create signed commit via GitHub GraphQL API
-          # Commits via this API are automatically signed by GitHub (Verified)
-          gh api graphql -f query='
-            mutation($repo: String!, $branch: String!, $oid: GitObjectID!, $msg: String!, $path: String!, $contents: Base64String!) {
-              createCommitOnBranch(input: {
-                branch: { repositoryNameWithOwner: $repo, branchName: $branch }
-                message: { headline: $msg }
-                fileChanges: { additions: [{ path: $path, contents: $contents }] }
-                expectedHeadOid: $oid
-              }) {
-                commit { url }
-              }
-            }' \
-            -f repo="${REPO}" \
-            -f branch="${BRANCH}" \
-            -f oid="${BRANCH_SHA}" \
-            -f msg="${COMMIT_MSG}" \
-            -f path="${FILE_PATH}" \
-            -f contents="${FILE_CONTENTS}"
+          jq -nc \
+            --arg repo "$REPO" --arg branch "$BRANCH" --arg oid "$BRANCH_SHA" \
+            --arg msg "$COMMIT_MSG" --argjson additions "$ADDITIONS" \
+            '{
+              query: "mutation($repo: String!, $branch: String!, $oid: GitObjectID!, $msg: String!, $additions: [FileAddition!]!) { createCommitOnBranch(input: { branch: { repositoryNameWithOwner: $repo, branchName: $branch }, message: { headline: $msg }, fileChanges: { additions: $additions }, expectedHeadOid: $oid }) { commit { url } } }",
+              variables: { repo: $repo, branch: $branch, oid: $oid, msg: $msg, additions: $additions }
+            }' | gh api graphql --input -
 
           # Open PR and enable auto-merge
           gh pr create \
             --repo "${REPO}" \
             --title "${COMMIT_MSG}" \
-            --body "Automated PR: bump \`canton-middleware-api\` image tag to \`${VERSION}\` on \`validator-dev1\`." \
+            --body "Automated PR: bump \`canton-middleware-api\`, \`canton-indexer\` and \`canton-middleware\` image tags to \`${VERSION}\` on \`validator-dev1\`." \
             --base main \
             --head "${BRANCH}" \
           || { echo "PR already exists for this branch, skipping"; exit 0; }

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Only one release run per branch at a time; never cancel an in-flight
+# release (it may be mid-publish to the registry or opening infra PRs).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write
@@ -20,7 +26,7 @@ jobs:
       tag_name: ${{ steps.release.outputs.tag_name }}
       version: ${{ steps.release.outputs.version }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         id: release
         with:
           config-file: release-please-config.json


### PR DESCRIPTION
## What

Improves the release CI so a release deploys **all three** services to devnet, and hardens `release-please.yml`.

### 1. Devnet PR bumps all three services (the main gap)

`docker-build-release.yml` already **builds and pushes** all three images, but the `open-devnet-pr` job only bumped **one** infra values file (`canton-middleware-api`). The Indexer and Relayer were never auto-deployed to devnet.

The job now bumps all three in a **single signed infra-kubernetes PR**:

| Service | Image | infra values file |
|---|---|---|
| Middleware API | `canton-erc20-api` | `canton-middleware-api-values.yml` |
| Indexer | `canton-indexer` | `canton-indexer-values.yml` |
| Relayer | `canton-middleware` | `canton-middleware-values.yml` |

- One `createCommitOnBranch` mutation with a `[FileAddition!]!` array (built via `jq`), so the commit stays GitHub-signed/Verified.
- Idempotency check now requires **all** files to already match the version before skipping.
- Service list is table-driven — add a row to onboard a new service.

### 2. Harden `release-please.yml`

- Pin `googleapis/release-please-action` to a commit SHA (`v4.4.1`).
- Add non-cancelling `concurrency` so release runs don't overlap.

## Notes

No new version is being cut (no commits since `v0.7.0`). This only changes CI behavior; the new all-three devnet logic takes effect on the next release / `docker-build-release` dispatch.