### PR TITLE
ci: deploy main to devnet continuously, decouple from releases

### DIFF
--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -125,16 +125,16 @@ jobs:
     name: Open devnet deploy PR
     needs: build-and-push
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v') || startsWith(inputs.tag, 'v')
+    # Devnet continuously tracks main: deploy the main-<sha> image on every
+    # direct push to main. Release builds (workflow_call with a version tag)
+    # and manual dispatches build images only — mainnet promotion is manual.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && inputs.tag == ''
     steps:
-      - name: Compute version
+      - name: Compute image tag
         id: version
-        env:
-          REF: ${{ github.ref_name }}
-          INPUT: ${{ inputs.tag }}
         run: |
-          VERSION="${INPUT:-$REF}"
-          [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]] || { echo "Invalid version: $VERSION"; exit 1; }
+          # Must match the main-<sha> tag produced by docker/metadata-action above
+          VERSION="main-${GITHUB_SHA::7}"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Checkout infra-kubernetes
@@ -157,9 +157,11 @@ jobs:
           GH_TOKEN: ${{ secrets.INFRA_GH_TOKEN }}
           FILE_PATH: definitions/canton/validator-dev1/canton-middleware-api-values.yml
           REPO: ChainSafe/infra-kubernetes
+          SOURCE_REPO: ${{ github.repository }}
+          SOURCE_SHA: ${{ github.sha }}
         run: |
-          BRANCH="chore/bump-canton-middleware-api-${VERSION}"
-          COMMIT_MSG="chore: bump canton-middleware-api to ${VERSION} on devnet"
+          BRANCH="cd/devnet-canton-middleware-api-${VERSION}"
+          COMMIT_MSG="chore(devnet): deploy canton-middleware-api ${VERSION}"
 
           # Get current HEAD SHA of main
           HEAD_SHA=$(gh api repos/${REPO}/git/ref/heads/main --jq '.object.sha')
@@ -207,10 +209,18 @@ jobs:
             -f contents="${FILE_CONTENTS}"
 
           # Open PR and enable auto-merge
+          PR_BODY=$(cat <<EOF
+          Automated continuous deployment to \`validator-dev1\`.
+
+          Bumps \`canton-middleware-api\` image tag to \`${VERSION}\`.
+
+          Source: [${SOURCE_REPO}@${SOURCE_SHA:0:7}](https://github.com/${SOURCE_REPO}/commit/${SOURCE_SHA})
+          EOF
+          )
           gh pr create \
             --repo "${REPO}" \
             --title "${COMMIT_MSG}" \
-            --body "Automated PR: bump \`canton-middleware-api\` image tag to \`${VERSION}\` on \`validator-dev1\`." \
+            --body "${PR_BODY}" \
             --base main \
             --head "${BRANCH}" \
           || { echo "PR already exists for this branch, skipping"; exit 0; }

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,8 +26,11 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  build-and-deploy:
-    name: Build images and open devnet PR
+  # Builds the versioned vX.Y.Z images for manual mainnet promotion.
+  # Devnet is NOT deployed here — it tracks main via the push trigger in
+  # docker-build-release.yml (the open-devnet-pr job is skipped when tag is set).
+  build-release-images:
+    name: Build versioned release images
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
     uses: ./.github/workflows/docker-build-release.yml


### PR DESCRIPTION
## What

Devnet now continuously tracks `main`. Every merge to `main` auto-deploys the `main-<sha>` image to `validator-dev1`; a release is no longer needed to get code onto devnet.

## Why

Previously the only path to devnet was cutting a full semver release (merging the release-please PR → `vX.Y.Z` tag). That gated our fastest-moving environment behind the heaviest process, while mainnet is manual anyway.