### PR TITLE
feat: claim back expired offers

### DIFF
--- a/pkg/cantonsdk/token/client.go
+++ b/pkg/cantonsdk/token/client.go
@@ -47,6 +47,7 @@ const (
 	spliceTransferFactory = "TransferFactory"
 	transferInstrEntity   = "TransferInstruction"
 	acceptChoice          = "TransferInstruction_Accept"
+	withdrawChoice        = "TransferInstruction_Withdraw"
 
 	spliceHoldingModule = "Splice.Api.Token.HoldingV1"
 	spliceHoldingEntity = "Holding"
@@ -139,6 +140,17 @@ type Token interface {
 	// transfer instruction and returns the hash that the client must sign externally.
 	// Use ExecuteTransfer to complete the accept once the client has signed.
 	PrepareAcceptTransfer(
+		ctx context.Context, partyID, instructionCID, instrumentAdmin string,
+	) (*PreparedTransfer, error)
+
+	// WithdrawTransferInstruction reclaims a pending/expired offer-based transfer for a
+	// custodial sender by exercising TransferInstruction_Withdraw server-side.
+	WithdrawTransferInstruction(ctx context.Context, partyID, instructionCID, instrumentAdmin string) error
+
+	// PrepareWithdrawTransfer builds a Canton transaction for a non-custodial sender to
+	// reclaim a pending/expired offer and returns the hash to sign externally. Use
+	// ExecuteTransfer to complete it.
+	PrepareWithdrawTransfer(
 		ctx context.Context, partyID, instructionCID, instrumentAdmin string,
 	) (*PreparedTransfer, error)
 }
@@ -1285,22 +1297,66 @@ func (c *Client) AcceptTransferInstruction(ctx context.Context, partyID, instruc
 	if partyID == "" || instructionCID == "" || instrumentAdmin == "" {
 		return fmt.Errorf("partyID, instructionCID, and instrumentAdmin are required")
 	}
+	cmd, disclosed, err := c.buildInstructionChoiceCommand(ctx, instructionCID, instrumentAdmin, "accept", acceptChoice)
+	if err != nil {
+		return err
+	}
+	if err := c.exerciseInstructionAsCustodial(ctx, partyID, cmd, disclosed); err != nil {
+		return fmt.Errorf("accept transfer instruction: %w", err)
+	}
+	return nil
+}
+
+// WithdrawTransferInstruction reclaims a pending or expired offer-based transfer for a
+// custodial sender: the middleware holds the user's key and exercises
+// TransferInstruction_Withdraw server-side, returning the locked holding to the sender.
+// Mirrors AcceptTransferInstruction but for the sender side.
+func (c *Client) WithdrawTransferInstruction(ctx context.Context, partyID, instructionCID, instrumentAdmin string) error {
+	if partyID == "" || instructionCID == "" || instrumentAdmin == "" {
+		return fmt.Errorf("partyID, instructionCID, and instrumentAdmin are required")
+	}
+	cmd, disclosed, err := c.buildInstructionChoiceCommand(ctx, instructionCID, instrumentAdmin, "withdraw", withdrawChoice)
+	if err != nil {
+		return err
+	}
+	if err := c.exerciseInstructionAsCustodial(ctx, partyID, cmd, disclosed); err != nil {
+		return fmt.Errorf("withdraw transfer instruction: %w", err)
+	}
+	return nil
+}
+
+// buildInstructionChoiceCommand fetches the registrar's choice-context for the given
+// action ("accept"/"withdraw") on a TransferInstruction and builds the exercise command
+// plus its disclosed contracts. Shared by the accept and withdraw (claim-back) flows,
+// which differ only in the registry endpoint and the on-ledger choice name.
+func (c *Client) buildInstructionChoiceCommand(
+	ctx context.Context, instructionCID, instrumentAdmin, action, choice string,
+) (*lapiv2.Command, []*lapiv2.DisclosedContract, error) {
 	if c.registryClient == nil {
-		return fmt.Errorf("no registry client configured for accept")
+		return nil, nil, fmt.Errorf("no registry client configured for %s", action)
 	}
 	extCfg, ok := c.cfg.ExternalTokens[instrumentAdmin]
 	if !ok {
-		return fmt.Errorf("unsupported external token issuer: %s", instrumentAdmin)
+		return nil, nil, fmt.Errorf("unsupported external token issuer: %s", instrumentAdmin)
 	}
 
-	acceptResp, err := c.registryClient.GetAcceptChoiceContext(ctx, extCfg.RegistryURL, instrumentAdmin, instructionCID)
+	var ctxResp *AcceptContextResponse
+	var err error
+	switch action {
+	case "accept":
+		ctxResp, err = c.registryClient.GetAcceptChoiceContext(ctx, extCfg.RegistryURL, instrumentAdmin, instructionCID)
+	case "withdraw":
+		ctxResp, err = c.registryClient.GetWithdrawChoiceContext(ctx, extCfg.RegistryURL, instrumentAdmin, instructionCID)
+	default:
+		return nil, nil, fmt.Errorf("unsupported instruction action: %s", action)
+	}
 	if err != nil {
-		return fmt.Errorf("get accept choice context: %w", err)
+		return nil, nil, fmt.Errorf("get %s choice context: %w", action, err)
 	}
 
-	ctxValue, err := encodeChoiceContextRecord(acceptResp.ChoiceContextData)
+	ctxValue, err := encodeChoiceContextRecord(ctxResp.ChoiceContextData)
 	if err != nil {
-		return fmt.Errorf("encode choice context: %w", err)
+		return nil, nil, fmt.Errorf("encode choice context: %w", err)
 	}
 
 	extraArgs := &lapiv2.Value{
@@ -1314,9 +1370,9 @@ func (c *Client) AcceptTransferInstruction(ctx context.Context, partyID, instruc
 		},
 	}
 
-	disclosed, err := convertDisclosedContractSlice(acceptResp.DisclosedContracts, c.cfg.DomainID)
+	disclosed, err := convertDisclosedContractSlice(ctxResp.DisclosedContracts, c.cfg.DomainID)
 	if err != nil {
-		return fmt.Errorf("convert disclosed contracts: %w", err)
+		return nil, nil, fmt.Errorf("convert disclosed contracts: %w", err)
 	}
 
 	cmd := &lapiv2.Command{
@@ -1328,7 +1384,7 @@ func (c *Client) AcceptTransferInstruction(ctx context.Context, partyID, instruc
 					EntityName: transferInstrEntity,
 				},
 				ContractId: instructionCID,
-				Choice:     acceptChoice,
+				Choice:     choice,
 				ChoiceArgument: &lapiv2.Value{
 					Sum: &lapiv2.Value_Record{
 						Record: &lapiv2.Record{
@@ -1341,19 +1397,23 @@ func (c *Client) AcceptTransferInstruction(ctx context.Context, partyID, instruc
 			},
 		},
 	}
+	return cmd, disclosed, nil
+}
 
-	// External parties (the only kind this api-server creates for custodial users)
-	// can't be submitted as via plain SubmitAndWait — the participant doesn't hold
-	// the signing key. Use Interactive Submission with the user's stored key.
+// exerciseInstructionAsCustodial submits a TransferInstruction choice on behalf of a
+// custodial party via Interactive Submission with the user's middleware-held key.
+// External parties can't use plain SubmitAndWait (the participant doesn't hold the key).
+func (c *Client) exerciseInstructionAsCustodial(
+	ctx context.Context, partyID string, cmd *lapiv2.Command, disclosed []*lapiv2.DisclosedContract,
+) error {
 	if c.keyResolver == nil {
-		return fmt.Errorf("accept transfer instruction: no key resolver configured " +
-			"(custodial accept requires the api-server to hold the user's signing key)")
+		return fmt.Errorf("no key resolver configured " +
+			"(custodial instruction exercise requires the api-server to hold the user's signing key)")
 	}
 	signerKey, err := c.keyResolver(partyID)
 	if err != nil {
-		return fmt.Errorf("accept transfer instruction: resolve signing key for %s: %w", partyID, err)
+		return fmt.Errorf("resolve signing key for %s: %w", partyID, err)
 	}
-
 	commands := &lapiv2.Commands{
 		SynchronizerId:     c.cfg.DomainID,
 		CommandId:          uuid.NewString(),
@@ -1362,10 +1422,7 @@ func (c *Client) AcceptTransferInstruction(ctx context.Context, partyID, instruc
 		Commands:           []*lapiv2.Command{cmd},
 		DisclosedContracts: disclosed,
 	}
-	if err := c.prepareAndExecuteAsUser(ctx, commands, signerKey, partyID); err != nil {
-		return fmt.Errorf("accept transfer instruction: %w", err)
-	}
-	return nil
+	return c.prepareAndExecuteAsUser(ctx, commands, signerKey, partyID)
 }
 
 func (c *Client) PrepareAcceptTransfer(
@@ -1374,63 +1431,35 @@ func (c *Client) PrepareAcceptTransfer(
 	if partyID == "" || instructionCID == "" || instrumentAdmin == "" {
 		return nil, fmt.Errorf("partyID, instructionCID, and instrumentAdmin are required")
 	}
-	if c.registryClient == nil {
-		return nil, fmt.Errorf("no registry client configured for accept")
-	}
-	extCfg, ok := c.cfg.ExternalTokens[instrumentAdmin]
-	if !ok {
-		return nil, fmt.Errorf("unsupported external token issuer: %s", instrumentAdmin)
-	}
-
-	acceptResp, err := c.registryClient.GetAcceptChoiceContext(ctx, extCfg.RegistryURL, instrumentAdmin, instructionCID)
+	cmd, disclosed, err := c.buildInstructionChoiceCommand(ctx, instructionCID, instrumentAdmin, "accept", acceptChoice)
 	if err != nil {
-		return nil, fmt.Errorf("get accept choice context: %w", err)
+		return nil, err
 	}
+	return c.prepareInstructionTx(ctx, partyID, instructionCID, cmd, disclosed)
+}
 
-	ctxValue, err := encodeChoiceContextRecord(acceptResp.ChoiceContextData)
+// PrepareWithdrawTransfer builds a Canton transaction for a non-custodial sender to
+// reclaim a pending or expired offer-based transfer (TransferInstruction_Withdraw) and
+// returns the hash the sender signs externally. Use ExecuteTransfer to complete it.
+func (c *Client) PrepareWithdrawTransfer(
+	ctx context.Context, partyID, instructionCID, instrumentAdmin string,
+) (*PreparedTransfer, error) {
+	if partyID == "" || instructionCID == "" || instrumentAdmin == "" {
+		return nil, fmt.Errorf("partyID, instructionCID, and instrumentAdmin are required")
+	}
+	cmd, disclosed, err := c.buildInstructionChoiceCommand(ctx, instructionCID, instrumentAdmin, "withdraw", withdrawChoice)
 	if err != nil {
-		return nil, fmt.Errorf("encode choice context: %w", err)
+		return nil, err
 	}
+	return c.prepareInstructionTx(ctx, partyID, instructionCID, cmd, disclosed)
+}
 
-	extraArgs := &lapiv2.Value{
-		Sum: &lapiv2.Value_Record{
-			Record: &lapiv2.Record{
-				Fields: []*lapiv2.RecordField{
-					{Label: "context", Value: ctxValue},
-					{Label: "meta", Value: values.EmptyMetadata()},
-				},
-			},
-		},
-	}
-
-	disclosed, err := convertDisclosedContractSlice(acceptResp.DisclosedContracts, c.cfg.DomainID)
-	if err != nil {
-		return nil, fmt.Errorf("convert disclosed contracts: %w", err)
-	}
-
-	cmd := &lapiv2.Command{
-		Command: &lapiv2.Command_Exercise{
-			Exercise: &lapiv2.ExerciseCommand{
-				TemplateId: &lapiv2.Identifier{
-					PackageId:  c.cfg.SpliceTransferPackageID,
-					ModuleName: spliceTransferModule,
-					EntityName: transferInstrEntity,
-				},
-				ContractId: instructionCID,
-				Choice:     acceptChoice,
-				ChoiceArgument: &lapiv2.Value{
-					Sum: &lapiv2.Value_Record{
-						Record: &lapiv2.Record{
-							Fields: []*lapiv2.RecordField{
-								{Label: "extraArgs", Value: extraArgs},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
+// prepareInstructionTx prepares a TransferInstruction-choice exercise for external
+// (non-custodial) signing and returns the hash to sign. Shared by the accept and
+// withdraw prepare flows.
+func (c *Client) prepareInstructionTx(
+	ctx context.Context, partyID, instructionCID string, cmd *lapiv2.Command, disclosed []*lapiv2.DisclosedContract,
+) (*PreparedTransfer, error) {
 	authCtx := c.ledger.AuthContext(ctx)
 	prepResp, err := c.ledger.Interactive().PrepareSubmission(authCtx, &interactivev2.PrepareSubmissionRequest{
 		UserId:             c.cfg.UserID,
@@ -1441,7 +1470,7 @@ func (c *Client) PrepareAcceptTransfer(
 		DisclosedContracts: disclosed,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("prepare accept submission: %w", err)
+		return nil, fmt.Errorf("prepare submission: %w", err)
 	}
 
 	pt := &PreparedTransfer{
@@ -1453,7 +1482,7 @@ func (c *Client) PrepareAcceptTransfer(
 		ExpiresAt:            time.Now().UTC().Add(preparedTxCacheTTL),
 	}
 
-	c.logger.Info("prepared non-custodial accept",
+	c.logger.Info("prepared non-custodial instruction tx",
 		zap.String("transfer_id", pt.TransferID),
 		zap.String("party_id", partyID),
 		zap.String("contract_id", instructionCID),

--- a/pkg/cantonsdk/token/registry_client.go
+++ b/pkg/cantonsdk/token/registry_client.go
@@ -17,8 +17,10 @@ import (
 )
 
 const (
-	registryPathFmt      = "/api/token-standard/v0/registrars/%s/registry/transfer-instruction/v1/transfer-factory"
-	acceptContextPathFmt = "/api/token-standard/v0/registrars/%s/registry/transfer-instruction/v1/%s/choice-contexts/accept"
+	registryPathFmt = "/api/token-standard/v0/registrars/%s/registry/transfer-instruction/v1/transfer-factory"
+	// choiceContextPathFmt is the registrar's per-instruction choice-context
+	// endpoint. The final %s is the action ("accept" or "withdraw").
+	choiceContextPathFmt = "/api/token-standard/v0/registrars/%s/registry/transfer-instruction/v1/%s/choice-contexts/%s"
 )
 
 // RegistryClient calls the Splice Transfer Factory Registry API to discover
@@ -294,35 +296,54 @@ func ConvertAnyValueChoiceContext(raw json.RawMessage) (AcceptChoiceContext, err
 func (rc *RegistryClient) GetAcceptChoiceContext(
 	ctx context.Context, registryBaseURL, registrarParty, instructionCID string,
 ) (*AcceptContextResponse, error) {
-	path := fmt.Sprintf(acceptContextPathFmt, registrarParty, instructionCID)
+	return rc.getChoiceContext(ctx, registryBaseURL, registrarParty, instructionCID, "accept")
+}
+
+// GetWithdrawChoiceContext calls the registrar's withdraw choice-context endpoint for a
+// TransferInstruction. Returns the choiceContextData and disclosed contracts needed to
+// exercise TransferInstruction_Withdraw (sender reclaims a pending/expired offer).
+func (rc *RegistryClient) GetWithdrawChoiceContext(
+	ctx context.Context, registryBaseURL, registrarParty, instructionCID string,
+) (*AcceptContextResponse, error) {
+	return rc.getChoiceContext(ctx, registryBaseURL, registrarParty, instructionCID, "withdraw")
+}
+
+// getChoiceContext fetches a per-instruction choice-context for the given action
+// ("accept" or "withdraw"). The response shape is identical across actions, so both
+// the accept and withdraw flows share this. action is interpolated into the registrar
+// endpoint path and the error messages.
+func (rc *RegistryClient) getChoiceContext(
+	ctx context.Context, registryBaseURL, registrarParty, instructionCID, action string,
+) (*AcceptContextResponse, error) {
+	path := fmt.Sprintf(choiceContextPathFmt, registrarParty, instructionCID, action)
 	url := strings.TrimRight(registryBaseURL, "/") + path
 	body := []byte(`{"meta":{},"excludeDebugFields":false}`)
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
-		return nil, fmt.Errorf("create accept context request: %w", err)
+		return nil, fmt.Errorf("create %s context request: %w", action, err)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 
 	resp, err := rc.httpClient.Do(httpReq)
 	if err != nil {
-		return nil, fmt.Errorf("accept context request failed: %w", err)
+		return nil, fmt.Errorf("%s context request failed: %w", action, err)
 	}
 	defer resp.Body.Close()
 
 	const maxResponseBytes = 1 << 20
 	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
 	if err != nil {
-		return nil, fmt.Errorf("read accept context response: %w", err)
+		return nil, fmt.Errorf("read %s context response: %w", action, err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("accept context returned %d: %s", resp.StatusCode, string(respBody))
+		return nil, fmt.Errorf("%s context returned %d: %s", action, resp.StatusCode, string(respBody))
 	}
 
 	var result AcceptContextResponse
 	if err := json.Unmarshal(respBody, &result); err != nil {
-		return nil, fmt.Errorf("parse accept context response: %w", err)
+		return nil, fmt.Errorf("parse %s context response: %w", action, err)
 	}
 	return &result, nil
 }

--- a/pkg/custodial/mocks/mock_canton_token.go
+++ b/pkg/custodial/mocks/mock_canton_token.go
@@ -927,6 +927,67 @@ func (_c *Token_PrepareTransfer_Call) RunAndReturn(run func(context.Context, *to
 	return _c
 }
 
+// PrepareWithdrawTransfer provides a mock function with given fields: ctx, partyID, instructionCID, instrumentAdmin
+func (_m *Token) PrepareWithdrawTransfer(ctx context.Context, partyID string, instructionCID string, instrumentAdmin string) (*token.PreparedTransfer, error) {
+	ret := _m.Called(ctx, partyID, instructionCID, instrumentAdmin)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PrepareWithdrawTransfer")
+	}
+
+	var r0 *token.PreparedTransfer
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) (*token.PreparedTransfer, error)); ok {
+		return rf(ctx, partyID, instructionCID, instrumentAdmin)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) *token.PreparedTransfer); ok {
+		r0 = rf(ctx, partyID, instructionCID, instrumentAdmin)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*token.PreparedTransfer)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
+		r1 = rf(ctx, partyID, instructionCID, instrumentAdmin)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Token_PrepareWithdrawTransfer_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PrepareWithdrawTransfer'
+type Token_PrepareWithdrawTransfer_Call struct {
+	*mock.Call
+}
+
+// PrepareWithdrawTransfer is a helper method to define mock.On call
+//   - ctx context.Context
+//   - partyID string
+//   - instructionCID string
+//   - instrumentAdmin string
+func (_e *Token_Expecter) PrepareWithdrawTransfer(ctx interface{}, partyID interface{}, instructionCID interface{}, instrumentAdmin interface{}) *Token_PrepareWithdrawTransfer_Call {
+	return &Token_PrepareWithdrawTransfer_Call{Call: _e.mock.On("PrepareWithdrawTransfer", ctx, partyID, instructionCID, instrumentAdmin)}
+}
+
+func (_c *Token_PrepareWithdrawTransfer_Call) Run(run func(ctx context.Context, partyID string, instructionCID string, instrumentAdmin string)) *Token_PrepareWithdrawTransfer_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string))
+	})
+	return _c
+}
+
+func (_c *Token_PrepareWithdrawTransfer_Call) Return(_a0 *token.PreparedTransfer, _a1 error) *Token_PrepareWithdrawTransfer_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Token_PrepareWithdrawTransfer_Call) RunAndReturn(run func(context.Context, string, string, string) (*token.PreparedTransfer, error)) *Token_PrepareWithdrawTransfer_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // TransferByFingerprint provides a mock function with given fields: ctx, idempotencyKey, fromFingerprint, toFingerprint, amount, tokenSymbol, validity
 func (_m *Token) TransferByFingerprint(ctx context.Context, idempotencyKey string, fromFingerprint string, toFingerprint string, amount string, tokenSymbol string, validity time.Duration) error {
 	ret := _m.Called(ctx, idempotencyKey, fromFingerprint, toFingerprint, amount, tokenSymbol, validity)
@@ -1079,6 +1140,55 @@ func (_c *Token_TransferInternalByPartyID_Call) Return(_a0 error) *Token_Transfe
 }
 
 func (_c *Token_TransferInternalByPartyID_Call) RunAndReturn(run func(context.Context, string, string, string, string, string, time.Duration) error) *Token_TransferInternalByPartyID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// WithdrawTransferInstruction provides a mock function with given fields: ctx, partyID, instructionCID, instrumentAdmin
+func (_m *Token) WithdrawTransferInstruction(ctx context.Context, partyID string, instructionCID string, instrumentAdmin string) error {
+	ret := _m.Called(ctx, partyID, instructionCID, instrumentAdmin)
+
+	if len(ret) == 0 {
+		panic("no return value specified for WithdrawTransferInstruction")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) error); ok {
+		r0 = rf(ctx, partyID, instructionCID, instrumentAdmin)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Token_WithdrawTransferInstruction_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'WithdrawTransferInstruction'
+type Token_WithdrawTransferInstruction_Call struct {
+	*mock.Call
+}
+
+// WithdrawTransferInstruction is a helper method to define mock.On call
+//   - ctx context.Context
+//   - partyID string
+//   - instructionCID string
+//   - instrumentAdmin string
+func (_e *Token_Expecter) WithdrawTransferInstruction(ctx interface{}, partyID interface{}, instructionCID interface{}, instrumentAdmin interface{}) *Token_WithdrawTransferInstruction_Call {
+	return &Token_WithdrawTransferInstruction_Call{Call: _e.mock.On("WithdrawTransferInstruction", ctx, partyID, instructionCID, instrumentAdmin)}
+}
+
+func (_c *Token_WithdrawTransferInstruction_Call) Run(run func(ctx context.Context, partyID string, instructionCID string, instrumentAdmin string)) *Token_WithdrawTransferInstruction_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string))
+	})
+	return _c
+}
+
+func (_c *Token_WithdrawTransferInstruction_Call) Return(_a0 error) *Token_WithdrawTransferInstruction_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Token_WithdrawTransferInstruction_Call) RunAndReturn(run func(context.Context, string, string, string) error) *Token_WithdrawTransferInstruction_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/indexer/client/http.go
+++ b/pkg/indexer/client/http.go
@@ -51,6 +51,7 @@ type Client interface {
 	) (*indexer.Page[*indexer.ParsedEvent], error)
 
 	// Transfers
+	GetTransfer(ctx context.Context, contractID string) (*indexer.Transfer, error)
 	GetTransfers(
 		ctx context.Context, partyID string, query indexer.TransferQuery, p indexer.Pagination,
 	) (*indexer.Page[indexer.Transfer], error)
@@ -193,6 +194,17 @@ func (c *HTTP) ListPartyEvents(
 		return nil, fmt.Errorf("list events for party %s: %w", partyID, err)
 	}
 	return &page, nil
+}
+
+// GetTransfer calls GET /indexer/v1/admin/transfers/{contractID}. A 404 is mapped
+// to a not-found app error by getJSON.
+func (c *HTTP) GetTransfer(ctx context.Context, contractID string) (*indexer.Transfer, error) {
+	u := c.baseURL + "/indexer/v1/admin/transfers/" + url.PathEscape(contractID)
+	var t indexer.Transfer
+	if err := c.getJSON(ctx, u, &t); err != nil {
+		return nil, fmt.Errorf("get transfer %s: %w", contractID, err)
+	}
+	return &t, nil
 }
 
 // GetTransfers calls GET /indexer/v1/admin/parties/{partyID}/transfers,

--- a/pkg/indexer/client/instrumented.go
+++ b/pkg/indexer/client/instrumented.go
@@ -87,6 +87,13 @@ func (c *InstrumentedClient) GetEvent(ctx context.Context, contractID string) (*
 	return e, err
 }
 
+func (c *InstrumentedClient) GetTransfer(ctx context.Context, contractID string) (*indexer.Transfer, error) {
+	defer c.observe(OpGetTransfer)()
+	t, err := c.inner.GetTransfer(ctx, contractID)
+	c.incErr(OpGetTransfer, err)
+	return t, err
+}
+
 func (c *InstrumentedClient) ListTokenEvents(
 	ctx context.Context,
 	admin, id string,

--- a/pkg/indexer/client/metrics.go
+++ b/pkg/indexer/client/metrics.go
@@ -20,6 +20,7 @@ const (
 	OpGetEvent             ClientOperation = "get_event"
 	OpListTokenEvents      ClientOperation = "list_token_events"
 	OpListPartyEvents      ClientOperation = "list_party_events"
+	OpGetTransfer          ClientOperation = "get_transfer"
 	OpGetTransfers         ClientOperation = "get_transfers"
 	OpGetPendingTransfers  ClientOperation = "get_pending_transfers"
 )

--- a/pkg/indexer/client/mocks/mock_client.go
+++ b/pkg/indexer/client/mocks/mock_client.go
@@ -261,6 +261,65 @@ func (_c *Client_GetToken_Call) RunAndReturn(run func(context.Context, string, s
 	return _c
 }
 
+// GetTransfer provides a mock function with given fields: ctx, contractID
+func (_m *Client) GetTransfer(ctx context.Context, contractID string) (*indexer.Transfer, error) {
+	ret := _m.Called(ctx, contractID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTransfer")
+	}
+
+	var r0 *indexer.Transfer
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*indexer.Transfer, error)); ok {
+		return rf(ctx, contractID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) *indexer.Transfer); ok {
+		r0 = rf(ctx, contractID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*indexer.Transfer)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, contractID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Client_GetTransfer_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetTransfer'
+type Client_GetTransfer_Call struct {
+	*mock.Call
+}
+
+// GetTransfer is a helper method to define mock.On call
+//   - ctx context.Context
+//   - contractID string
+func (_e *Client_Expecter) GetTransfer(ctx interface{}, contractID interface{}) *Client_GetTransfer_Call {
+	return &Client_GetTransfer_Call{Call: _e.mock.On("GetTransfer", ctx, contractID)}
+}
+
+func (_c *Client_GetTransfer_Call) Run(run func(ctx context.Context, contractID string)) *Client_GetTransfer_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *Client_GetTransfer_Call) Return(_a0 *indexer.Transfer, _a1 error) *Client_GetTransfer_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Client_GetTransfer_Call) RunAndReturn(run func(context.Context, string) (*indexer.Transfer, error)) *Client_GetTransfer_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetTransfers provides a mock function with given fields: ctx, partyID, query, p
 func (_m *Client) GetTransfers(ctx context.Context, partyID string, query indexer.TransferQuery, p indexer.Pagination) (*indexer.Page[indexer.Transfer], error) {
 	ret := _m.Called(ctx, partyID, query, p)

--- a/pkg/indexer/service/http.go
+++ b/pkg/indexer/service/http.go
@@ -45,6 +45,7 @@ func RegisterPrivateRoutes(r chi.Router, svc Service, logger *zap.Logger) {
 		r.Get("/pending-transfers", apphttp.HandleError(h.listPendingTransfers))
 
 		r.Get("/events/{contractID}", apphttp.HandleError(h.getEvent))
+		r.Get("/transfers/{contractID}", apphttp.HandleError(h.getTransfer))
 	})
 }
 
@@ -168,6 +169,16 @@ func (h *HTTP) getEvent(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 	h.writeJSON(w, e)
+	return nil
+}
+
+func (h *HTTP) getTransfer(w http.ResponseWriter, r *http.Request) error {
+	contractID := chi.URLParam(r, "contractID")
+	t, err := h.service.GetTransfer(r.Context(), contractID)
+	if err != nil {
+		return err
+	}
+	h.writeJSON(w, t)
 	return nil
 }
 

--- a/pkg/indexer/service/log.go
+++ b/pkg/indexer/service/log.go
@@ -225,6 +225,31 @@ func (ls *logService) GetEvent(ctx context.Context, contractID string) (e *index
 	return ls.svc.GetEvent(ctx, contractID)
 }
 
+func (ls *logService) GetTransfer(ctx context.Context, contractID string) (t *indexer.Transfer, err error) {
+	start := time.Now()
+	ls.logger.Info("GetTransfer started",
+		zap.String("service", indexerServiceName),
+		zap.String("contract_id", contractID),
+	)
+	defer func() {
+		if err != nil {
+			ls.logger.Error("GetTransfer failed",
+				zap.String("service", indexerServiceName),
+				zap.String("contract_id", contractID),
+				zap.Duration("duration", time.Since(start)),
+				zap.Error(err),
+			)
+		} else {
+			ls.logger.Info("GetTransfer completed",
+				zap.String("service", indexerServiceName),
+				zap.String("contract_id", contractID),
+				zap.Duration("duration", time.Since(start)),
+			)
+		}
+	}()
+	return ls.svc.GetTransfer(ctx, contractID)
+}
+
 func (ls *logService) ListTokenEvents(
 	ctx context.Context,
 	admin, id string,

--- a/pkg/indexer/service/mocks/mock_service.go
+++ b/pkg/indexer/service/mocks/mock_service.go
@@ -261,6 +261,65 @@ func (_c *Service_GetToken_Call) RunAndReturn(run func(context.Context, string, 
 	return _c
 }
 
+// GetTransfer provides a mock function with given fields: ctx, contractID
+func (_m *Service) GetTransfer(ctx context.Context, contractID string) (*indexer.Transfer, error) {
+	ret := _m.Called(ctx, contractID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTransfer")
+	}
+
+	var r0 *indexer.Transfer
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*indexer.Transfer, error)); ok {
+		return rf(ctx, contractID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) *indexer.Transfer); ok {
+		r0 = rf(ctx, contractID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*indexer.Transfer)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, contractID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Service_GetTransfer_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetTransfer'
+type Service_GetTransfer_Call struct {
+	*mock.Call
+}
+
+// GetTransfer is a helper method to define mock.On call
+//   - ctx context.Context
+//   - contractID string
+func (_e *Service_Expecter) GetTransfer(ctx interface{}, contractID interface{}) *Service_GetTransfer_Call {
+	return &Service_GetTransfer_Call{Call: _e.mock.On("GetTransfer", ctx, contractID)}
+}
+
+func (_c *Service_GetTransfer_Call) Run(run func(ctx context.Context, contractID string)) *Service_GetTransfer_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *Service_GetTransfer_Call) Return(_a0 *indexer.Transfer, _a1 error) *Service_GetTransfer_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Service_GetTransfer_Call) RunAndReturn(run func(context.Context, string) (*indexer.Transfer, error)) *Service_GetTransfer_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetTransfers provides a mock function with given fields: ctx, partyID, query, p
 func (_m *Service) GetTransfers(ctx context.Context, partyID string, query indexer.TransferQuery, p indexer.Pagination) (*indexer.Page[indexer.Transfer], error) {
 	ret := _m.Called(ctx, partyID, query, p)

--- a/pkg/indexer/service/mocks/mock_store.go
+++ b/pkg/indexer/service/mocks/mock_store.go
@@ -202,6 +202,65 @@ func (_c *Store_GetToken_Call) RunAndReturn(run func(context.Context, string, st
 	return _c
 }
 
+// GetTransfer provides a mock function with given fields: ctx, contractID
+func (_m *Store) GetTransfer(ctx context.Context, contractID string) (*indexer.Transfer, error) {
+	ret := _m.Called(ctx, contractID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTransfer")
+	}
+
+	var r0 *indexer.Transfer
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*indexer.Transfer, error)); ok {
+		return rf(ctx, contractID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) *indexer.Transfer); ok {
+		r0 = rf(ctx, contractID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*indexer.Transfer)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, contractID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Store_GetTransfer_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetTransfer'
+type Store_GetTransfer_Call struct {
+	*mock.Call
+}
+
+// GetTransfer is a helper method to define mock.On call
+//   - ctx context.Context
+//   - contractID string
+func (_e *Store_Expecter) GetTransfer(ctx interface{}, contractID interface{}) *Store_GetTransfer_Call {
+	return &Store_GetTransfer_Call{Call: _e.mock.On("GetTransfer", ctx, contractID)}
+}
+
+func (_c *Store_GetTransfer_Call) Run(run func(ctx context.Context, contractID string)) *Store_GetTransfer_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *Store_GetTransfer_Call) Return(_a0 *indexer.Transfer, _a1 error) *Store_GetTransfer_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Store_GetTransfer_Call) RunAndReturn(run func(context.Context, string) (*indexer.Transfer, error)) *Store_GetTransfer_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListBalancesForParty provides a mock function with given fields: ctx, partyID, p
 func (_m *Store) ListBalancesForParty(ctx context.Context, partyID string, p indexer.Pagination) ([]*indexer.Balance, int64, error) {
 	ret := _m.Called(ctx, partyID, p)

--- a/pkg/indexer/service/service.go
+++ b/pkg/indexer/service/service.go
@@ -28,6 +28,9 @@ type Store interface {
 	ListEvents(ctx context.Context, f indexer.EventFilter, p indexer.Pagination) ([]*indexer.ParsedEvent, int64, error)
 	// GetEvent looks up a single event by its unique contract ID.
 	GetEvent(ctx context.Context, contractID string) (*indexer.ParsedEvent, error)
+	// GetTransfer looks up a single transfer by its contract ID. Returns (nil, nil)
+	// when not found.
+	GetTransfer(ctx context.Context, contractID string) (*indexer.Transfer, error)
 	// ListTransfers returns a party's transfers filtered by role and status.
 	ListTransfers(
 		ctx context.Context, partyID string, query indexer.TransferQuery, p indexer.Pagination,
@@ -65,6 +68,8 @@ type Service interface {
 		p indexer.Pagination,
 	) (*indexer.Page[*indexer.ParsedEvent], error)
 
+	// GetTransfer returns a single transfer by its contract ID (404 when not found).
+	GetTransfer(ctx context.Context, contractID string) (*indexer.Transfer, error)
 	// GetTransfers returns a party's transfers filtered by role and status, paginated.
 	GetTransfers(
 		ctx context.Context, partyID string, query indexer.TransferQuery, p indexer.Pagination,
@@ -138,6 +143,17 @@ func (s *svc) ListBalancesForToken(ctx context.Context, admin, id string, p inde
 		return nil, err
 	}
 	return &indexer.Page[*indexer.Balance]{Items: items, Total: total, Page: p.Page, Limit: p.Limit}, nil
+}
+
+func (s *svc) GetTransfer(ctx context.Context, contractID string) (*indexer.Transfer, error) {
+	t, err := s.store.GetTransfer(ctx, contractID)
+	if err != nil {
+		return nil, err
+	}
+	if t == nil {
+		return nil, apperrors.ResourceNotFoundError(nil, "transfer not found")
+	}
+	return t, nil
 }
 
 func (s *svc) GetEvent(ctx context.Context, contractID string) (*indexer.ParsedEvent, error) {

--- a/pkg/indexer/store/instrumented.go
+++ b/pkg/indexer/store/instrumented.go
@@ -338,6 +338,17 @@ func (s *InstrumentedStore) GetEvent(ctx context.Context, contractID string) (*i
 	return event, err
 }
 
+func (s *InstrumentedStore) GetTransfer(ctx context.Context, contractID string) (*indexer.Transfer, error) {
+	timer := prometheus.NewTimer(s.metrics.ObserveQueryDuration(OpGetTransfer))
+	defer timer.ObserveDuration()
+
+	transfer, err := s.inner.GetTransfer(ctx, contractID)
+	if err != nil {
+		s.metrics.IncErrors(OpGetTransfer)
+	}
+	return transfer, err
+}
+
 func (s *InstrumentedStore) ListEvents(
 	ctx context.Context, f indexer.EventFilter, p indexer.Pagination,
 ) ([]*indexer.ParsedEvent, int64, error) {

--- a/pkg/indexer/store/metrics.go
+++ b/pkg/indexer/store/metrics.go
@@ -70,6 +70,7 @@ const (
 	OpListBalancesForToken StoreOperation = "list_balances_for_token"
 	OpGetEvent             StoreOperation = "get_event"
 	OpListEvents           StoreOperation = "list_events"
+	OpGetTransfer          StoreOperation = "get_transfer"
 	OpListTransfers        StoreOperation = "list_transfers"
 	OpListPendingTransfers StoreOperation = "list_pending_transfers"
 )

--- a/pkg/indexer/store/pg.go
+++ b/pkg/indexer/store/pg.go
@@ -303,6 +303,28 @@ func (s *PGStore) CompleteTransfer(ctx context.Context, contractID string) error
 	return nil
 }
 
+// GetTransfer looks up a single transfer by its contract ID. Returns (nil, nil)
+// when no such row exists. A pending offer whose expires_at is in the past is
+// surfaced with the derived "expired" status, matching ListTransfers.
+func (s *PGStore) GetTransfer(ctx context.Context, contractID string) (*indexer.Transfer, error) {
+	dao := new(TransferDao)
+	err := s.db.NewSelect().Model(dao).
+		Where("contract_id = ?", contractID).
+		Limit(1).Scan(ctx)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get transfer: %w", err)
+	}
+	t := fromTransferDao(dao)
+	now := time.Now().UTC()
+	if t.Status == indexer.TransferStatusPending && t.ExpiresAt != nil && !t.ExpiresAt.After(now) {
+		t.Status = indexer.TransferStatusExpired
+	}
+	return &t, nil
+}
+
 // ListTransfers returns a party's transfers from indexer_transfers, newest first,
 // with native pagination. Role selects the matching side; status filters the
 // lifecycle. "expired" is derived (pending row whose expires_at is in the past) —

--- a/pkg/token/mocks/mock_canton_token.go
+++ b/pkg/token/mocks/mock_canton_token.go
@@ -927,6 +927,67 @@ func (_c *Token_PrepareTransfer_Call) RunAndReturn(run func(context.Context, *to
 	return _c
 }
 
+// PrepareWithdrawTransfer provides a mock function with given fields: ctx, partyID, instructionCID, instrumentAdmin
+func (_m *Token) PrepareWithdrawTransfer(ctx context.Context, partyID string, instructionCID string, instrumentAdmin string) (*token.PreparedTransfer, error) {
+	ret := _m.Called(ctx, partyID, instructionCID, instrumentAdmin)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PrepareWithdrawTransfer")
+	}
+
+	var r0 *token.PreparedTransfer
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) (*token.PreparedTransfer, error)); ok {
+		return rf(ctx, partyID, instructionCID, instrumentAdmin)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) *token.PreparedTransfer); ok {
+		r0 = rf(ctx, partyID, instructionCID, instrumentAdmin)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*token.PreparedTransfer)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
+		r1 = rf(ctx, partyID, instructionCID, instrumentAdmin)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Token_PrepareWithdrawTransfer_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PrepareWithdrawTransfer'
+type Token_PrepareWithdrawTransfer_Call struct {
+	*mock.Call
+}
+
+// PrepareWithdrawTransfer is a helper method to define mock.On call
+//   - ctx context.Context
+//   - partyID string
+//   - instructionCID string
+//   - instrumentAdmin string
+func (_e *Token_Expecter) PrepareWithdrawTransfer(ctx interface{}, partyID interface{}, instructionCID interface{}, instrumentAdmin interface{}) *Token_PrepareWithdrawTransfer_Call {
+	return &Token_PrepareWithdrawTransfer_Call{Call: _e.mock.On("PrepareWithdrawTransfer", ctx, partyID, instructionCID, instrumentAdmin)}
+}
+
+func (_c *Token_PrepareWithdrawTransfer_Call) Run(run func(ctx context.Context, partyID string, instructionCID string, instrumentAdmin string)) *Token_PrepareWithdrawTransfer_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string))
+	})
+	return _c
+}
+
+func (_c *Token_PrepareWithdrawTransfer_Call) Return(_a0 *token.PreparedTransfer, _a1 error) *Token_PrepareWithdrawTransfer_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Token_PrepareWithdrawTransfer_Call) RunAndReturn(run func(context.Context, string, string, string) (*token.PreparedTransfer, error)) *Token_PrepareWithdrawTransfer_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // TransferByFingerprint provides a mock function with given fields: ctx, idempotencyKey, fromFingerprint, toFingerprint, amount, tokenSymbol, validity
 func (_m *Token) TransferByFingerprint(ctx context.Context, idempotencyKey string, fromFingerprint string, toFingerprint string, amount string, tokenSymbol string, validity time.Duration) error {
 	ret := _m.Called(ctx, idempotencyKey, fromFingerprint, toFingerprint, amount, tokenSymbol, validity)
@@ -1079,6 +1140,55 @@ func (_c *Token_TransferInternalByPartyID_Call) Return(_a0 error) *Token_Transfe
 }
 
 func (_c *Token_TransferInternalByPartyID_Call) RunAndReturn(run func(context.Context, string, string, string, string, string, time.Duration) error) *Token_TransferInternalByPartyID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// WithdrawTransferInstruction provides a mock function with given fields: ctx, partyID, instructionCID, instrumentAdmin
+func (_m *Token) WithdrawTransferInstruction(ctx context.Context, partyID string, instructionCID string, instrumentAdmin string) error {
+	ret := _m.Called(ctx, partyID, instructionCID, instrumentAdmin)
+
+	if len(ret) == 0 {
+		panic("no return value specified for WithdrawTransferInstruction")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) error); ok {
+		r0 = rf(ctx, partyID, instructionCID, instrumentAdmin)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Token_WithdrawTransferInstruction_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'WithdrawTransferInstruction'
+type Token_WithdrawTransferInstruction_Call struct {
+	*mock.Call
+}
+
+// WithdrawTransferInstruction is a helper method to define mock.On call
+//   - ctx context.Context
+//   - partyID string
+//   - instructionCID string
+//   - instrumentAdmin string
+func (_e *Token_Expecter) WithdrawTransferInstruction(ctx interface{}, partyID interface{}, instructionCID interface{}, instrumentAdmin interface{}) *Token_WithdrawTransferInstruction_Call {
+	return &Token_WithdrawTransferInstruction_Call{Call: _e.mock.On("WithdrawTransferInstruction", ctx, partyID, instructionCID, instrumentAdmin)}
+}
+
+func (_c *Token_WithdrawTransferInstruction_Call) Run(run func(ctx context.Context, partyID string, instructionCID string, instrumentAdmin string)) *Token_WithdrawTransferInstruction_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string))
+	})
+	return _c
+}
+
+func (_c *Token_WithdrawTransferInstruction_Call) Return(_a0 error) *Token_WithdrawTransferInstruction_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Token_WithdrawTransferInstruction_Call) RunAndReturn(run func(context.Context, string, string, string) error) *Token_WithdrawTransferInstruction_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/transfer/http.go
+++ b/pkg/transfer/http.go
@@ -53,6 +53,13 @@ func RegisterRoutes(r chi.Router, svc Service, logger *zap.Logger) {
 	r.Get("/api/v2/transfer/completed", apphttp.HandleError(h.listCompleted))
 	r.Post("/api/v2/transfer/incoming/{contractID}/prepare", apphttp.HandleError(h.prepareAccept))
 	r.Post("/api/v2/transfer/incoming/{contractID}/execute", apphttp.HandleError(h.executeAccept))
+
+	// Claim back (withdraw) an offer the caller sent — pending or expired. Two-step
+	// prepare/execute for non-custodial (external-key) senders; a single server-signed
+	// call for custodial senders. Validated against the indexer before touching Canton.
+	r.Post("/api/v2/transfer/outgoing/{contractID}/withdraw/prepare", apphttp.HandleError(h.prepareWithdraw))
+	r.Post("/api/v2/transfer/outgoing/{contractID}/withdraw/execute", apphttp.HandleError(h.executeWithdraw))
+	r.Post("/api/v2/transfer/outgoing/{contractID}/withdraw/custodial", apphttp.HandleError(h.withdrawCustodial))
 }
 
 func (h *httpHandler) prepare(w http.ResponseWriter, r *http.Request) error {
@@ -314,6 +321,74 @@ func (h *httpHandler) executeAccept(w http.ResponseWriter, r *http.Request) erro
 	}
 
 	resp, err := h.svc.ExecuteAccept(r.Context(), evmAddr, &req)
+	if err != nil {
+		return err
+	}
+
+	h.writeJSON(w, resp)
+	return nil
+}
+
+// prepareWithdraw builds a claim-back (withdraw) transaction for a non-custodial sender
+// to reclaim a pending/expired offer they sent. The offer is identified solely by the
+// {contractID} path param; instrument routing is resolved from the indexer server-side.
+func (h *httpHandler) prepareWithdraw(w http.ResponseWriter, r *http.Request) error {
+	evmAddr, err := authenticateEVM(r)
+	if err != nil {
+		return err
+	}
+	contractID := chi.URLParam(r, "contractID")
+	if contractID == "" {
+		return apperrors.BadRequestError(nil, "contractID path parameter is required")
+	}
+
+	resp, err := h.svc.PrepareWithdraw(r.Context(), evmAddr, contractID)
+	if err != nil {
+		return err
+	}
+
+	h.writeJSON(w, resp)
+	return nil
+}
+
+// executeWithdraw completes a previously prepared withdraw using the client's DER
+// signature. The cached prepared transaction is generic, so this reuses Execute.
+func (h *httpHandler) executeWithdraw(w http.ResponseWriter, r *http.Request) error {
+	evmAddr, err := authenticateEVM(r)
+	if err != nil {
+		return err
+	}
+
+	var req ExecuteRequest
+	if jsonErr := readJSON(r, &req); jsonErr != nil {
+		return jsonErr
+	}
+	if req.TransferID == "" || req.Signature == "" || req.SignedBy == "" {
+		return apperrors.BadRequestError(nil, "transfer_id, signature, and signed_by are required")
+	}
+
+	resp, err := h.svc.Execute(r.Context(), evmAddr, &req)
+	if err != nil {
+		return err
+	}
+
+	h.writeJSON(w, resp)
+	return nil
+}
+
+// withdrawCustodial claims back a pending/expired offer for a custodial sender in a
+// single server-signed call.
+func (h *httpHandler) withdrawCustodial(w http.ResponseWriter, r *http.Request) error {
+	evmAddr, err := authenticateEVM(r)
+	if err != nil {
+		return err
+	}
+	contractID := chi.URLParam(r, "contractID")
+	if contractID == "" {
+		return apperrors.BadRequestError(nil, "contractID path parameter is required")
+	}
+
+	resp, err := h.svc.WithdrawCustodial(r.Context(), evmAddr, contractID)
 	if err != nil {
 		return err
 	}

--- a/pkg/transfer/log.go
+++ b/pkg/transfer/log.go
@@ -341,6 +341,74 @@ func (ls *logService) SendCustodial(
 	return ls.svc.SendCustodial(ctx, senderEVMAddr, req)
 }
 
+// PrepareWithdraw wraps the service method with logging.
+func (ls *logService) PrepareWithdraw(
+	ctx context.Context, evmAddr, contractID string,
+) (resp *PrepareResponse, err error) {
+	start := time.Now()
+	ls.logger.Info("PrepareWithdraw started",
+		zap.String("service", transferServiceName),
+		zap.String("method", "PrepareWithdraw"),
+		zap.String("evm_addr", evmAddr),
+		zap.String("contract_id", contractID),
+	)
+	defer func() {
+		duration := time.Since(start)
+		if err != nil {
+			ls.logger.Error("PrepareWithdraw failed",
+				zap.String("service", transferServiceName),
+				zap.String("method", "PrepareWithdraw"),
+				zap.String("contract_id", contractID),
+				zap.Duration("duration", duration),
+				zap.Error(err),
+			)
+		} else {
+			ls.logger.Info("PrepareWithdraw completed",
+				zap.String("service", transferServiceName),
+				zap.String("method", "PrepareWithdraw"),
+				zap.String("transfer_id", resp.TransferID),
+				zap.String("party_id", resp.PartyID),
+				zap.Duration("duration", duration),
+			)
+		}
+	}()
+	return ls.svc.PrepareWithdraw(ctx, evmAddr, contractID)
+}
+
+// WithdrawCustodial wraps the service method with logging.
+func (ls *logService) WithdrawCustodial(
+	ctx context.Context, evmAddr, contractID string,
+) (resp *ExecuteResponse, err error) {
+	start := time.Now()
+	ls.logger.Info("WithdrawCustodial started",
+		zap.String("service", transferServiceName),
+		zap.String("method", "WithdrawCustodial"),
+		zap.String("evm_addr", evmAddr),
+		zap.String("contract_id", contractID),
+	)
+	defer func() {
+		duration := time.Since(start)
+		if err != nil {
+			ls.logger.Error("WithdrawCustodial failed",
+				zap.String("service", transferServiceName),
+				zap.String("method", "WithdrawCustodial"),
+				zap.String("contract_id", contractID),
+				zap.Duration("duration", duration),
+				zap.Error(err),
+			)
+		} else {
+			ls.logger.Info("WithdrawCustodial completed",
+				zap.String("service", transferServiceName),
+				zap.String("method", "WithdrawCustodial"),
+				zap.String("contract_id", contractID),
+				zap.String("status", resp.Status),
+				zap.Duration("duration", duration),
+			)
+		}
+	}()
+	return ls.svc.WithdrawCustodial(ctx, evmAddr, contractID)
+}
+
 // redactSignature redacts signature data to show only metadata.
 // Signatures are sensitive and should not be logged in full.
 func redactSignature(sig string) string {

--- a/pkg/transfer/mocks/mock_canton_token.go
+++ b/pkg/transfer/mocks/mock_canton_token.go
@@ -927,6 +927,67 @@ func (_c *Token_PrepareTransfer_Call) RunAndReturn(run func(context.Context, *to
 	return _c
 }
 
+// PrepareWithdrawTransfer provides a mock function with given fields: ctx, partyID, instructionCID, instrumentAdmin
+func (_m *Token) PrepareWithdrawTransfer(ctx context.Context, partyID string, instructionCID string, instrumentAdmin string) (*token.PreparedTransfer, error) {
+	ret := _m.Called(ctx, partyID, instructionCID, instrumentAdmin)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PrepareWithdrawTransfer")
+	}
+
+	var r0 *token.PreparedTransfer
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) (*token.PreparedTransfer, error)); ok {
+		return rf(ctx, partyID, instructionCID, instrumentAdmin)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) *token.PreparedTransfer); ok {
+		r0 = rf(ctx, partyID, instructionCID, instrumentAdmin)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*token.PreparedTransfer)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
+		r1 = rf(ctx, partyID, instructionCID, instrumentAdmin)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Token_PrepareWithdrawTransfer_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PrepareWithdrawTransfer'
+type Token_PrepareWithdrawTransfer_Call struct {
+	*mock.Call
+}
+
+// PrepareWithdrawTransfer is a helper method to define mock.On call
+//   - ctx context.Context
+//   - partyID string
+//   - instructionCID string
+//   - instrumentAdmin string
+func (_e *Token_Expecter) PrepareWithdrawTransfer(ctx interface{}, partyID interface{}, instructionCID interface{}, instrumentAdmin interface{}) *Token_PrepareWithdrawTransfer_Call {
+	return &Token_PrepareWithdrawTransfer_Call{Call: _e.mock.On("PrepareWithdrawTransfer", ctx, partyID, instructionCID, instrumentAdmin)}
+}
+
+func (_c *Token_PrepareWithdrawTransfer_Call) Run(run func(ctx context.Context, partyID string, instructionCID string, instrumentAdmin string)) *Token_PrepareWithdrawTransfer_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string))
+	})
+	return _c
+}
+
+func (_c *Token_PrepareWithdrawTransfer_Call) Return(_a0 *token.PreparedTransfer, _a1 error) *Token_PrepareWithdrawTransfer_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Token_PrepareWithdrawTransfer_Call) RunAndReturn(run func(context.Context, string, string, string) (*token.PreparedTransfer, error)) *Token_PrepareWithdrawTransfer_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // TransferByFingerprint provides a mock function with given fields: ctx, idempotencyKey, fromFingerprint, toFingerprint, amount, tokenSymbol, validity
 func (_m *Token) TransferByFingerprint(ctx context.Context, idempotencyKey string, fromFingerprint string, toFingerprint string, amount string, tokenSymbol string, validity time.Duration) error {
 	ret := _m.Called(ctx, idempotencyKey, fromFingerprint, toFingerprint, amount, tokenSymbol, validity)
@@ -1079,6 +1140,55 @@ func (_c *Token_TransferInternalByPartyID_Call) Return(_a0 error) *Token_Transfe
 }
 
 func (_c *Token_TransferInternalByPartyID_Call) RunAndReturn(run func(context.Context, string, string, string, string, string, time.Duration) error) *Token_TransferInternalByPartyID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// WithdrawTransferInstruction provides a mock function with given fields: ctx, partyID, instructionCID, instrumentAdmin
+func (_m *Token) WithdrawTransferInstruction(ctx context.Context, partyID string, instructionCID string, instrumentAdmin string) error {
+	ret := _m.Called(ctx, partyID, instructionCID, instrumentAdmin)
+
+	if len(ret) == 0 {
+		panic("no return value specified for WithdrawTransferInstruction")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) error); ok {
+		r0 = rf(ctx, partyID, instructionCID, instrumentAdmin)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Token_WithdrawTransferInstruction_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'WithdrawTransferInstruction'
+type Token_WithdrawTransferInstruction_Call struct {
+	*mock.Call
+}
+
+// WithdrawTransferInstruction is a helper method to define mock.On call
+//   - ctx context.Context
+//   - partyID string
+//   - instructionCID string
+//   - instrumentAdmin string
+func (_e *Token_Expecter) WithdrawTransferInstruction(ctx interface{}, partyID interface{}, instructionCID interface{}, instrumentAdmin interface{}) *Token_WithdrawTransferInstruction_Call {
+	return &Token_WithdrawTransferInstruction_Call{Call: _e.mock.On("WithdrawTransferInstruction", ctx, partyID, instructionCID, instrumentAdmin)}
+}
+
+func (_c *Token_WithdrawTransferInstruction_Call) Run(run func(ctx context.Context, partyID string, instructionCID string, instrumentAdmin string)) *Token_WithdrawTransferInstruction_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string))
+	})
+	return _c
+}
+
+func (_c *Token_WithdrawTransferInstruction_Call) Return(_a0 error) *Token_WithdrawTransferInstruction_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Token_WithdrawTransferInstruction_Call) RunAndReturn(run func(context.Context, string, string, string) error) *Token_WithdrawTransferInstruction_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/transfer/mocks/mock_indexer_reader.go
+++ b/pkg/transfer/mocks/mock_indexer_reader.go
@@ -22,6 +22,65 @@ func (_m *IndexerReader) EXPECT() *IndexerReader_Expecter {
 	return &IndexerReader_Expecter{mock: &_m.Mock}
 }
 
+// GetTransfer provides a mock function with given fields: ctx, contractID
+func (_m *IndexerReader) GetTransfer(ctx context.Context, contractID string) (*indexer.Transfer, error) {
+	ret := _m.Called(ctx, contractID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTransfer")
+	}
+
+	var r0 *indexer.Transfer
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*indexer.Transfer, error)); ok {
+		return rf(ctx, contractID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) *indexer.Transfer); ok {
+		r0 = rf(ctx, contractID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*indexer.Transfer)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, contractID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// IndexerReader_GetTransfer_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetTransfer'
+type IndexerReader_GetTransfer_Call struct {
+	*mock.Call
+}
+
+// GetTransfer is a helper method to define mock.On call
+//   - ctx context.Context
+//   - contractID string
+func (_e *IndexerReader_Expecter) GetTransfer(ctx interface{}, contractID interface{}) *IndexerReader_GetTransfer_Call {
+	return &IndexerReader_GetTransfer_Call{Call: _e.mock.On("GetTransfer", ctx, contractID)}
+}
+
+func (_c *IndexerReader_GetTransfer_Call) Run(run func(ctx context.Context, contractID string)) *IndexerReader_GetTransfer_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *IndexerReader_GetTransfer_Call) Return(_a0 *indexer.Transfer, _a1 error) *IndexerReader_GetTransfer_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *IndexerReader_GetTransfer_Call) RunAndReturn(run func(context.Context, string) (*indexer.Transfer, error)) *IndexerReader_GetTransfer_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetTransfers provides a mock function with given fields: ctx, partyID, query, p
 func (_m *IndexerReader) GetTransfers(ctx context.Context, partyID string, query indexer.TransferQuery, p indexer.Pagination) (*indexer.Page[indexer.Transfer], error) {
 	ret := _m.Called(ctx, partyID, query, p)

--- a/pkg/transfer/service.go
+++ b/pkg/transfer/service.go
@@ -46,6 +46,9 @@ type IndexerReader interface {
 	GetTransfers(
 		ctx context.Context, partyID string, query indexer.TransferQuery, p indexer.Pagination,
 	) (*indexer.Page[indexer.Transfer], error)
+	// GetTransfer returns a single transfer by its contract id (used to validate a
+	// claim-back request directly, without scanning a party's transfer list).
+	GetTransfer(ctx context.Context, contractID string) (*indexer.Transfer, error)
 }
 
 // Service is the interface for the non-custodial prepare/execute transfer flow.
@@ -76,6 +79,12 @@ type Service interface {
 	) (*PrepareResponse, error)
 	// ExecuteAccept completes a previously prepared accept using the client's DER signature.
 	ExecuteAccept(ctx context.Context, evmAddr string, req *ExecuteRequest) (*ExecuteResponse, error)
+	// PrepareWithdraw builds a Canton transaction for a non-custodial sender to claim
+	// back (withdraw) a pending/expired offer they sent. Complete it via Execute.
+	PrepareWithdraw(ctx context.Context, evmAddr, contractID string) (*PrepareResponse, error)
+	// WithdrawCustodial claims back a pending/expired offer for a custodial sender in a
+	// single server-signed call.
+	WithdrawCustodial(ctx context.Context, evmAddr, contractID string) (*ExecuteResponse, error)
 }
 
 // TransferService implements the non-custodial prepare/execute transfer flow.
@@ -566,4 +575,108 @@ func (s *TransferService) PrepareAccept(
 // ExecuteAccept completes a previously prepared accept using the client's DER signature.
 func (s *TransferService) ExecuteAccept(ctx context.Context, evmAddr string, req *ExecuteRequest) (*ExecuteResponse, error) {
 	return s.Execute(ctx, evmAddr, req)
+}
+
+// claimableTransfer validates a claim-back request against the indexer before any
+// Canton call. It looks the offer up directly by contract id and confirms the caller
+// owns it (is the sender), it is an offer (not a direct CIP-56 transfer), and it is
+// still withdrawable (pending or expired, not already completed). Returns the offer so
+// callers can use its InstrumentAdmin for the on-ledger withdraw. Errors: 404 when no
+// such offer exists for the caller, 400 when it is not a withdrawable offer.
+func (s *TransferService) claimableTransfer(
+	ctx context.Context, callerParty, contractID string,
+) (*indexer.Transfer, error) {
+	t, err := s.offerLister.GetTransfer(ctx, contractID)
+	if err != nil {
+		// The indexer client maps a missing contract id to a not-found app error;
+		// propagate it (and any other lookup failure) as-is.
+		return nil, err
+	}
+	// Ownership: only the sender may claim back. Report a missing/foreign offer as
+	// not-found so callers can't probe other parties' offers by contract id.
+	if t.FromPartyID != callerParty {
+		return nil, apperrors.ResourceNotFoundError(nil, "no claimable offer found for this contract id")
+	}
+	if t.Kind != indexer.TransferKindOffer {
+		return nil, apperrors.BadRequestError(nil, "only offer-based transfers can be claimed back")
+	}
+	if t.Status == indexer.TransferStatusCompleted {
+		return nil, apperrors.BadRequestError(nil, "transfer already completed; nothing to claim back")
+	}
+	return t, nil
+}
+
+// PrepareWithdraw builds a Canton transaction for a non-custodial sender to claim back
+// (withdraw) a pending or expired offer they sent. Returns the hash to sign; complete
+// it via the standard Execute endpoint.
+func (s *TransferService) PrepareWithdraw(ctx context.Context, evmAddr, contractID string) (*PrepareResponse, error) {
+	u, err := s.userStore.GetUserByEVMAddress(ctx, evmAddr)
+	if err != nil {
+		if errors.Is(err, user.ErrUserNotFound) {
+			return nil, apperrors.UnAuthorizedError(err, "user not found")
+		}
+		return nil, fmt.Errorf("lookup user: %w", err)
+	}
+	if u.KeyMode != user.KeyModeExternal {
+		return nil, apperrors.BadRequestError(nil, "withdraw prepare/execute API requires key_mode=external")
+	}
+
+	offer, err := s.claimableTransfer(ctx, u.CantonPartyID, contractID)
+	if err != nil {
+		return nil, err
+	}
+
+	pt, err := s.cantonToken.PrepareWithdrawTransfer(ctx, u.CantonPartyID, contractID, offer.InstrumentAdmin)
+	if err != nil {
+		return nil, mapWithdrawErr(err)
+	}
+
+	if err := s.cache.Put(pt); err != nil {
+		return nil, apperrors.GeneralError(fmt.Errorf("too many pending transfers: %w", err))
+	}
+
+	return &PrepareResponse{
+		TransferID:      pt.TransferID,
+		TransactionHash: "0x" + hex.EncodeToString(pt.TransactionHash),
+		PartyID:         pt.PartyID,
+		ExpiresAt:       pt.ExpiresAt.Format(time.RFC3339),
+	}, nil
+}
+
+// WithdrawCustodial claims back a pending or expired offer for a custodial sender in a
+// single server-signed call (the middleware holds the user's Canton key).
+func (s *TransferService) WithdrawCustodial(ctx context.Context, evmAddr, contractID string) (*ExecuteResponse, error) {
+	u, err := s.userStore.GetUserByEVMAddress(ctx, evmAddr)
+	if err != nil {
+		if errors.Is(err, user.ErrUserNotFound) {
+			return nil, apperrors.UnAuthorizedError(err, "user not found")
+		}
+		return nil, fmt.Errorf("lookup user: %w", err)
+	}
+	if u.KeyMode != user.KeyModeCustodial {
+		return nil, apperrors.BadRequestError(nil, "this endpoint requires key_mode=custodial")
+	}
+
+	offer, err := s.claimableTransfer(ctx, u.CantonPartyID, contractID)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := s.cantonToken.WithdrawTransferInstruction(ctx, u.CantonPartyID, contractID, offer.InstrumentAdmin); err != nil {
+		return nil, mapWithdrawErr(err)
+	}
+	return &ExecuteResponse{Status: "submitted"}, nil
+}
+
+// mapWithdrawErr maps a Canton/registry withdraw failure to an HTTP-shaped error.
+// A receiver who accepted first (or any state where the instruction is no longer
+// active) surfaces as 409 Conflict; everything else is a generic dependency error.
+func mapWithdrawErr(err error) error {
+	if st, ok := status.FromError(err); ok {
+		switch st.Code() {
+		case codes.NotFound, codes.FailedPrecondition, codes.Aborted, codes.AlreadyExists:
+			return apperrors.ConflictError(err, "offer is no longer claimable (it may have been accepted or already withdrawn)")
+		}
+	}
+	return fmt.Errorf("withdraw transfer: %w", err)
 }

--- a/pkg/transfer/service.go
+++ b/pkg/transfer/service.go
@@ -592,6 +592,10 @@ func (s *TransferService) claimableTransfer(
 		// propagate it (and any other lookup failure) as-is.
 		return nil, err
 	}
+	if t == nil {
+		// Defensive: the interface permits (nil, nil); treat as not found.
+		return nil, apperrors.ResourceNotFoundError(nil, "no claimable offer found for this contract id")
+	}
 	// Ownership: only the sender may claim back. Report a missing/foreign offer as
 	// not-found so callers can't probe other parties' offers by contract id.
 	if t.FromPartyID != callerParty {

--- a/pkg/transfer/service_test.go
+++ b/pkg/transfer/service_test.go
@@ -934,3 +934,144 @@ func TestTransferService_ListCompleted_UserNotFound(t *testing.T) {
 	_, err := svc.ListCompleted(ctx, senderUser().EVMAddress, indexer.Pagination{Page: 1, Limit: 50})
 	assertServiceErrorCategory(t, err, apperrors.CategoryDataError)
 }
+
+// --- Withdraw (claim back) tests ---
+
+const withdrawCID = "offer-cid-1"
+
+// withdrawableOffer is an offer-kind transfer the given sender owns, in a state that
+// can be claimed back. The claim-back lookup queries by sender role, so ownership is
+// implied by the party the mock is keyed on.
+func withdrawableOffer(sender *user.User) indexer.Transfer {
+	return indexer.Transfer{
+		ContractID:      withdrawCID,
+		Kind:            indexer.TransferKindOffer,
+		Status:          indexer.TransferStatusExpired,
+		FromPartyID:     sender.CantonPartyID,
+		ToPartyID:       "external::1220abcd",
+		InstrumentAdmin: "usdc::admin",
+		InstrumentID:    "USDCx",
+		Amount:          "10",
+	}
+}
+
+func expectGetTransfer(offers *mocks.IndexerReader, ctx context.Context, offer *indexer.Transfer) {
+	offers.EXPECT().GetTransfer(ctx, withdrawCID).Return(offer, nil).Once()
+}
+
+func TestTransferService_PrepareWithdraw_Success(t *testing.T) {
+	ctx := context.Background()
+	sender := senderUser() // external key mode
+
+	store := mocks.NewUserStore(t)
+	store.EXPECT().GetUserByEVMAddress(ctx, sender.EVMAddress).Return(sender, nil).Once()
+
+	offer := withdrawableOffer(sender)
+	offers := mocks.NewIndexerReader(t)
+	expectGetTransfer(offers, ctx, &offer)
+
+	prepared := &token.PreparedTransfer{
+		TransferID: "wd-1", TransactionHash: []byte{0x01, 0x02},
+		PartyID: sender.CantonPartyID, ExpiresAt: time.Now().Add(time.Hour),
+	}
+	tok := mocks.NewToken(t)
+	tok.EXPECT().PrepareWithdrawTransfer(ctx, sender.CantonPartyID, withdrawCID, "usdc::admin").
+		Return(prepared, nil).Once()
+
+	cache := mocks.NewTransferCache(t)
+	cache.EXPECT().Put(prepared).Return(nil).Once()
+
+	svc := newTestServiceWithOffers(tok, store, cache, offers)
+	resp, err := svc.PrepareWithdraw(ctx, sender.EVMAddress, withdrawCID)
+	require.NoError(t, err)
+	assert.Equal(t, "wd-1", resp.TransferID)
+	assert.Equal(t, sender.CantonPartyID, resp.PartyID)
+}
+
+func TestTransferService_WithdrawCustodial_Success(t *testing.T) {
+	ctx := context.Background()
+	sender := custodialSender()
+
+	store := mocks.NewUserStore(t)
+	store.EXPECT().GetUserByEVMAddress(ctx, sender.EVMAddress).Return(sender, nil).Once()
+
+	offer := withdrawableOffer(sender)
+	offer.Status = indexer.TransferStatusPending // a still-pending offer is claimable too
+	offers := mocks.NewIndexerReader(t)
+	expectGetTransfer(offers, ctx, &offer)
+
+	tok := mocks.NewToken(t)
+	tok.EXPECT().WithdrawTransferInstruction(ctx, sender.CantonPartyID, withdrawCID, "usdc::admin").
+		Return(nil).Once()
+
+	svc := newTestServiceWithOffers(tok, store, mocks.NewTransferCache(t), offers)
+	resp, err := svc.WithdrawCustodial(ctx, sender.EVMAddress, withdrawCID)
+	require.NoError(t, err)
+	assert.Equal(t, "submitted", resp.Status)
+}
+
+func TestTransferService_PrepareWithdraw_NotFound(t *testing.T) {
+	ctx := context.Background()
+	sender := senderUser()
+
+	store := mocks.NewUserStore(t)
+	store.EXPECT().GetUserByEVMAddress(ctx, sender.EVMAddress).Return(sender, nil).Once()
+
+	offers := mocks.NewIndexerReader(t)
+	offers.EXPECT().GetTransfer(ctx, "missing-cid").
+		Return(nil, apperrors.ResourceNotFoundError(nil, "transfer not found")).Once()
+
+	svc := newTestServiceWithOffers(mocks.NewToken(t), store, mocks.NewTransferCache(t), offers)
+	_, err := svc.PrepareWithdraw(ctx, sender.EVMAddress, "missing-cid")
+	assertServiceErrorCategory(t, err, apperrors.CategoryResourceNotFound)
+}
+
+func TestTransferService_PrepareWithdraw_ForeignOffer(t *testing.T) {
+	ctx := context.Background()
+	sender := senderUser()
+
+	store := mocks.NewUserStore(t)
+	store.EXPECT().GetUserByEVMAddress(ctx, sender.EVMAddress).Return(sender, nil).Once()
+
+	// An offer sent by a different party must not be claimable by this caller; it is
+	// reported as not-found so callers can't probe foreign offers by contract id.
+	foreign := withdrawableOffer(sender)
+	foreign.FromPartyID = "party::someone-else"
+	offers := mocks.NewIndexerReader(t)
+	expectGetTransfer(offers, ctx, &foreign)
+
+	svc := newTestServiceWithOffers(mocks.NewToken(t), store, mocks.NewTransferCache(t), offers)
+	_, err := svc.PrepareWithdraw(ctx, sender.EVMAddress, withdrawCID)
+	assertServiceErrorCategory(t, err, apperrors.CategoryResourceNotFound)
+}
+
+func TestTransferService_PrepareWithdraw_RequiresExternal(t *testing.T) {
+	ctx := context.Background()
+	sender := custodialSender() // custodial cannot use the prepare/execute withdraw
+
+	store := mocks.NewUserStore(t)
+	store.EXPECT().GetUserByEVMAddress(ctx, sender.EVMAddress).Return(sender, nil).Once()
+
+	svc := newTestServiceWithOffers(mocks.NewToken(t), store, mocks.NewTransferCache(t), mocks.NewIndexerReader(t))
+	_, err := svc.PrepareWithdraw(ctx, sender.EVMAddress, withdrawCID)
+	assertServiceErrorCategory(t, err, apperrors.CategoryDataError)
+}
+
+func TestTransferService_WithdrawCustodial_NotAnOffer(t *testing.T) {
+	ctx := context.Background()
+	sender := custodialSender()
+
+	store := mocks.NewUserStore(t)
+	store.EXPECT().GetUserByEVMAddress(ctx, sender.EVMAddress).Return(sender, nil).Once()
+
+	// A direct (CIP-56) transfer is not an offer and cannot be claimed back.
+	direct := withdrawableOffer(sender)
+	direct.Kind = indexer.TransferKindDirect
+	direct.Status = indexer.TransferStatusCompleted
+	offers := mocks.NewIndexerReader(t)
+	expectGetTransfer(offers, ctx, &direct)
+
+	svc := newTestServiceWithOffers(mocks.NewToken(t), store, mocks.NewTransferCache(t), offers)
+	_, err := svc.WithdrawCustodial(ctx, sender.EVMAddress, withdrawCID)
+	assertServiceErrorCategory(t, err, apperrors.CategoryDataError)
+}

--- a/scripts/setup/usdcx-registry.go
+++ b/scripts/setup/usdcx-registry.go
@@ -323,7 +323,9 @@ func (s *server) routeRegistrar(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case len(parts) == 5 && parts[4] == "transfer-factory":
 		s.handleTransferFactory(w, r)
-	case len(parts) == 7 && parts[5] == "choice-contexts" && parts[6] == "accept":
+	case len(parts) == 7 && parts[5] == "choice-contexts" && (parts[6] == "accept" || parts[6] == "withdraw"):
+		// Accept (receiver) and Withdraw (sender claim-back) both need the same
+		// instrument-level choice context (TransferRule + InstrumentConfiguration).
 		s.handleAcceptContext(w, r)
 	default:
 		writeJSON(w, http.StatusNotFound, errorBody{Error: "not found"})

--- a/tests/e2e/devstack/dsl/helpers.go
+++ b/tests/e2e/devstack/dsl/helpers.go
@@ -86,6 +86,40 @@ func (d *DSL) WaitForIncomingTransferOffer(ctx context.Context, t *testing.T, ac
 	return ""
 }
 
+// WaitForOutgoingTransferGone polls the outgoing list (filtered by status) until no
+// item with contractID remains, then returns. Used to confirm an offer left a state
+// (e.g. an expired offer that was claimed back / archived). Fails after the timeout.
+func (d *DSL) WaitForOutgoingTransferGone(
+	ctx context.Context, t *testing.T, account stack.Account, status, contractID string,
+) {
+	t.Helper()
+	deadline := time.Now().Add(cantonBalanceTimeout)
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+	for time.Now().Before(deadline) {
+		resp, err := d.apiServer.ListOutgoingTransfers(ctx, &account, status)
+		if err == nil {
+			present := false
+			for i := range resp.Items {
+				if resp.Items[i].ContractID == contractID {
+					present = true
+					break
+				}
+			}
+			if !present {
+				return
+			}
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatal("context canceled waiting for outgoing transfer to clear")
+		case <-ticker.C:
+		}
+	}
+	t.Fatalf("timeout waiting for outgoing transfer %s to leave status=%q for %s",
+		contractID, status, account.Address.Hex())
+}
+
 // WaitForOutgoingTransfer polls the api-server's GET /api/v2/transfer/outgoing
 // (filtered by status) until an item satisfying match appears for account, then
 // returns it. Fails the test after the standard 60s timeout. Use status "" for

--- a/tests/e2e/devstack/shim/apiserver.go
+++ b/tests/e2e/devstack/shim/apiserver.go
@@ -238,6 +238,27 @@ func (a *APIServerShim) SendCustodial(
 	return &resp, nil
 }
 
+// WithdrawCustodial claims back (withdraws) a pending or expired offer the custodial
+// account sent, via POST /api/v2/transfer/outgoing/{contractID}/withdraw/custodial.
+// account supplies the timed EIP-191 auth headers; the offer is identified by contractID.
+func (a *APIServerShim) WithdrawCustodial(
+	ctx context.Context,
+	account *stack.Account,
+	contractID string,
+) (*transfer.ExecuteResponse, error) {
+	msg := fmt.Sprintf("transfer:%d", time.Now().Unix())
+	sig, err := util.SignEIP191(account.PrivateKey, msg)
+	if err != nil {
+		return nil, err
+	}
+	var resp transfer.ExecuteResponse
+	path := "/api/v2/transfer/outgoing/" + contractID + "/withdraw/custodial"
+	if err := a.post(ctx, path, sig, msg, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
 // ListOutgoingTransfers sends GET /api/v2/transfer/outgoing?address=<addr>&status=<status>.
 // The endpoint is unauthenticated; account is used only to derive the address query
 // parameter. An empty status omits the filter (server defaults to all).

--- a/tests/e2e/devstack/stack/interfaces.go
+++ b/tests/e2e/devstack/stack/interfaces.go
@@ -195,6 +195,11 @@ type APIServer interface {
 	// headers; req carries the recipient party id, amount, token and validity.
 	SendCustodial(ctx context.Context, account *Account, req *transfer.CustodialTransferRequest) (*transfer.ExecuteResponse, error)
 
+	// WithdrawCustodial claims back (withdraws) a pending or expired offer the
+	// custodial account sent, via POST
+	// /api/v2/transfer/outgoing/{contractID}/withdraw/custodial.
+	WithdrawCustodial(ctx context.Context, account *Account, contractID string) (*transfer.ExecuteResponse, error)
+
 	// ListIncomingTransfers returns pending inbound TransferOffer details for the
 	// given account via GET /api/v2/transfer/incoming?address=…. The endpoint is
 	// unauthenticated; account is used only to derive the query parameter.

--- a/tests/e2e/tests/api/cross_transfer_test.go
+++ b/tests/e2e/tests/api/cross_transfer_test.go
@@ -16,6 +16,10 @@ import (
 // statusCompleted is the api-server's terminal status for a settled transfer.
 const statusCompleted = "completed"
 
+// statusSubmitted is the api-server's response status for an accepted single-call
+// (server-signed) submission, e.g. custodial transfer / withdraw.
+const statusSubmitted = "submitted"
+
 // amountEq reports whether two decimal-string amounts are numerically equal,
 // tolerating Canton's fixed-scale rendering (e.g. "20" vs "20.0000000000").
 func amountEq(t *testing.T, got, want string) bool {
@@ -237,7 +241,7 @@ func TestUSDCx_CustodialTransfer_ByPartyID_ToExternalParty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("custodial send to external party: %v", err)
 	}
-	if resp.Status != "submitted" {
+	if resp.Status != statusSubmitted {
 		t.Fatalf("expected status 'submitted', got %q", resp.Status)
 	}
 
@@ -381,6 +385,62 @@ func TestUSDCx_OutgoingOffer_ExpiresAfterValidity(t *testing.T) {
 	if expired.Status != indexer.TransferStatusExpired {
 		t.Fatalf("expected expired status, got %q", expired.Status)
 	}
+}
+
+// TestUSDCx_ClaimBackExpiredOffer_ToExternalParty verifies a custodial sender can
+// reclaim a USDCx offer that expired unaccepted. The external recipient never accepts;
+// the offer expires; the sender claims it back via the custodial withdraw endpoint; the
+// offer then leaves the expired set (archived on-ledger) and the sender's USDCx balance
+// is whole again (the locked funds are reclaimed).
+func TestUSDCx_ClaimBackExpiredOffer_ToExternalParty(t *testing.T) {
+	t.Parallel()
+
+	sys := presets.NewMultiParticipantStack(t)
+	ctx := context.Background()
+	external := sys.Manifest.USDCxInstrumentAdmin
+
+	reg := sys.DSL.RegisterUser(ctx, t, sys.Accounts.User1)
+
+	if err := sys.Canton2.MintToken(ctx, external, "USDCx", "10"); err != nil {
+		t.Fatalf("mint USDCx to issuer: %v", err)
+	}
+	if err := sys.Canton2.TransferToken(ctx, external, reg.Party, "USDCx", "5"); err != nil {
+		t.Fatalf("fund User1 (P2 issuer → P1): %v", err)
+	}
+	sys.DSL.WaitForAPIBalance(ctx, t, &sys.Tokens.USDCx, sys.Accounts.User1.Address, "5")
+
+	// Offer 2 USDCx to the external party with a short validity — it is never accepted
+	// (the recipient is unregistered) and expires. 15s clears the SDK's ~5s requestedAt
+	// backdate while still expiring within the poll window.
+	const shortValiditySeconds = 15
+	if _, err := sys.APIServer.SendCustodial(ctx, &sys.Accounts.User1, &transfer.CustodialTransferRequest{
+		ToPartyID:       external,
+		Amount:          "2",
+		Token:           "USDCx",
+		ValiditySeconds: shortValiditySeconds,
+	}); err != nil {
+		t.Fatalf("custodial send (short validity) to external party: %v", err)
+	}
+
+	// Wait for it to flip to expired, capturing its contract id for the claim-back.
+	expired := sys.DSL.WaitForOutgoingTransfer(ctx, t, sys.Accounts.User1, indexer.TransferStatusExpired,
+		func(o transfer.OutgoingTransfer) bool {
+			return o.InstrumentAdmin == external && amountEq(t, o.Amount, "2")
+		})
+
+	// Claim back the expired offer (single-call custodial withdraw).
+	resp, err := sys.APIServer.WithdrawCustodial(ctx, &sys.Accounts.User1, expired.ContractID)
+	if err != nil {
+		t.Fatalf("custodial withdraw (claim back) expired offer: %v", err)
+	}
+	if resp.Status != statusSubmitted {
+		t.Fatalf("expected withdraw status 'submitted', got %q", resp.Status)
+	}
+
+	// The withdraw archives the offer on-ledger: it leaves the expired set, and the
+	// sender's USDCx balance is whole again (locked funds reclaimed).
+	sys.DSL.WaitForOutgoingTransferGone(ctx, t, sys.Accounts.User1, indexer.TransferStatusExpired, expired.ContractID)
+	sys.DSL.WaitForAPIBalance(ctx, t, &sys.Tokens.USDCx, sys.Accounts.User1.Address, "5")
 }
 
 // TestUSDCx_ListIncoming_PendingOffer verifies the incoming API surfaces a


### PR DESCRIPTION
Implements #292.

## Problem

Offer-based transfers (registry / `AllocationFactory` tokens like USDCx) lock the sender's holding when the offer is created. If the receiver never accepts — or the offer expires — the sender currently has **no way to reclaim** those locked funds through the middleware.

## Change

Sender-side **claim-back** that exercises the Splice `TransferInstruction_Withdraw` choice, in both signing modes (mirrors the existing accept flow):

- `POST /api/v2/transfer/outgoing/{contractID}/withdraw/prepare` — non-custodial (returns hash to sign)
- `POST /api/v2/transfer/outgoing/{contractID}/withdraw/execute` — non-custodial (reuses the generic execute)
- `POST /api/v2/transfer/outgoing/{contractID}/withdraw/custodial` — custodial, single server-signed call

Works on **pending or expired** offers (after expiry, accept fails on-ledger but withdraw still returns the locked holding).

### Validated against the indexer first
Each request is checked **before** any Canton call via a new direct lookup `GET /indexer/v1/admin/transfers/{contractID}`: the offer must exist, be **owned by the caller** (sender), be offer-kind (not a direct CIP-56 transfer), and still be withdrawable (not completed). A missing/foreign offer returns `404` (so callers can't probe others' offers by id); registry "already accepted / archived" conflicts map to `409`.

### SDK
`registry.GetWithdrawChoiceContext` + `WithdrawTransferInstruction` (custodial) / `PrepareWithdrawTransfer` (non-custodial), refactored so accept and withdraw share the choice-context command builder and the submission tails.

## Tests
Unit tests for the service (prepare/custodial success, 404 not-found, foreign-offer 404, requires-external gate, not-an-offer rejection). E2E (short-validity → expire → withdraw → balance restored) is a natural follow-up.

## Notes
Out of scope and tracked separately: reflecting the offer lock in indexed balances at offer time (#338).