### PR TITLE
feat: relayer restart resilience (scan progress + stream reconnect + RPC timeout)

### DIFF
--- a/pkg/cantonsdk/bridge/client.go
+++ b/pkg/cantonsdk/bridge/client.go
@@ -8,9 +8,7 @@ package bridge
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"io"
 	"strconv"
 	"time"
 
@@ -501,9 +499,19 @@ func (c *Client) StreamWithdrawalEvents(ctx context.Context, offset string) <-ch
 			}
 
 			err := c.streamWithdrawalEventsOnce(ctx, currentOffset, outCh, &currentOffset)
-			if err == nil || errors.Is(err, io.EOF) || ctx.Err() != nil {
+			if ctx.Err() != nil {
 				return
 			}
+
+			// A live GetUpdates subscription is open-ended, so any stream end —
+			// including io.EOF from a server-side/load-balancer idle timeout or a
+			// Canton node rollout — is transient. Reconnect from the last processed
+			// offset with backoff rather than closing the channel, which would make
+			// the relayer's Canton source report a fatal error and exit the process.
+			c.logger.Warn("withdrawal stream ended; reconnecting",
+				zap.String("from_offset", currentOffset),
+				zap.Duration("backoff", reconnectDelay),
+				zap.Error(err))
 
 			if isAuthError(err) {
 				c.ledger.InvalidateToken()

--- a/pkg/ethereum/client.go
+++ b/pkg/ethereum/client.go
@@ -234,7 +234,15 @@ func chunkRange(start, end, maxRange uint64) []blockRange {
 // config.MaxBlockRange blocks so requests stay under the provider's per-call cap.
 // On a slice failure, currentBlock advances only through the last successful
 // slice and the failing range is retried on the next tick.
-func (c *Client) WatchDepositEvents(ctx context.Context, fromBlock uint64, handler func(*DepositEvent) error) error {
+// onProgress, when non-nil, is invoked with the last block that has been fully
+// scanned after each successful slice — including slices with no deposits — so the
+// caller can persist scan progress and avoid re-scanning from the start on restart.
+func (c *Client) WatchDepositEvents(
+	ctx context.Context,
+	fromBlock uint64,
+	handler func(*DepositEvent) error,
+	onProgress func(block uint64) error,
+) error {
 	c.logger.Info("Starting deposit event poller",
 		zap.Uint64("from_block", fromBlock),
 		zap.Uint64("max_block_range", c.config.MaxBlockRange))
@@ -286,6 +294,15 @@ func (c *Client) WatchDepositEvents(ctx context.Context, fromBlock uint64, handl
 					}
 					currentBlock = r.end
 					c.setLastScannedBlock(currentBlock)
+					// Persist scan progress after this slice's deposits were handed to
+					// the handler (in order), so a restart resumes near here instead of
+					// re-scanning from the start. On failure, stop advancing so the same
+					// range is re-checkpointed on the next tick.
+					if onProgress != nil {
+						if err := onProgress(currentBlock); err != nil {
+							return
+						}
+					}
 				}
 			}()
 		}

--- a/pkg/ethereum/client.go
+++ b/pkg/ethereum/client.go
@@ -269,8 +269,10 @@ func (c *Client) WatchDepositEvents(
 					c.metrics.EventPollDuration.Observe(time.Since(pollStart).Seconds())
 				}()
 
-				// Get latest block
-				latestBlock, err := c.GetLatestBlockNumber(ctx)
+				// Get latest block (bounded by the per-call RPC timeout).
+				headCtx, headCancel := c.rpcContext(ctx)
+				latestBlock, err := c.GetLatestBlockNumber(headCtx)
+				headCancel()
 				if err != nil {
 					c.metrics.EventPollFailuresTotal.WithLabelValues("get_latest_block").Inc()
 					c.logger.Warn("Failed to get latest block", zap.Error(err))
@@ -309,15 +311,27 @@ func (c *Client) WatchDepositEvents(
 	}
 }
 
+// rpcContext derives a per-call context bounded by config.RPCTimeout so a single
+// slow/hung JSON-RPC call can't stall the poll loop. A non-positive timeout returns
+// the parent context unchanged with a no-op cancel.
+func (c *Client) rpcContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if c.config.RPCTimeout <= 0 {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, c.config.RPCTimeout)
+}
+
 // scanDepositRange filters DepositToCanton events for a single inclusive block
 // range and dispatches each to handler. A filter, iterator, or handler error is
 // returned so the caller can stop advancing scan progress and retry the range
 // on the next tick.
 func (c *Client) scanDepositRange(ctx context.Context, r blockRange, handler func(*DepositEvent) error) error {
+	callCtx, cancel := c.rpcContext(ctx)
+	defer cancel()
 	opts := &bind.FilterOpts{
 		Start:   r.start,
 		End:     &r.end,
-		Context: ctx,
+		Context: callCtx,
 	}
 
 	filterStart := time.Now()

--- a/pkg/ethereum/config.go
+++ b/pkg/ethereum/config.go
@@ -19,4 +19,8 @@ type Config struct {
 	StartBlock         int64         `yaml:"start_block" default:"0"`
 	LookbackBlocks     int64         `yaml:"lookback_blocks" default:"1000"`
 	MaxBlockRange      uint64        `yaml:"max_block_range" default:"100" validate:"required,gt=0"`
+	// RPCTimeout bounds each individual JSON-RPC call (eth_getLogs, eth_blockNumber)
+	// so a hung or slow provider fails that call — which is logged and retried on the
+	// next poll tick — instead of stalling the poll loop. <=0 disables the timeout.
+	RPCTimeout time.Duration `yaml:"rpc_timeout" default:"30s"`
 }

--- a/pkg/relayer/engine/engine.go
+++ b/pkg/relayer/engine/engine.go
@@ -43,7 +43,12 @@ type EthereumBridgeClient interface {
 		nonce *big.Int,
 		cantonTxHash [32]byte,
 	) (common.Hash, error)
-	WatchDepositEvents(ctx context.Context, fromBlock uint64, handler func(*ethereum.DepositEvent) error) error
+	WatchDepositEvents(
+		ctx context.Context,
+		fromBlock uint64,
+		handler func(*ethereum.DepositEvent) error,
+		onProgress func(block uint64) error,
+	) error
 	IsWithdrawalProcessed(ctx context.Context, cantonTxHash [32]byte) (bool, error)
 	GetLastScannedBlock() uint64
 }

--- a/pkg/relayer/engine/engine_test.go
+++ b/pkg/relayer/engine/engine_test.go
@@ -70,7 +70,7 @@ func TestEngine_StartAndStop_WithMockedDependencies(t *testing.T) {
 	cantonClient.EXPECT().GetLatestLedgerOffset(mock.Anything).Return(int64(100), nil).Maybe()
 
 	ethClient := relayermocks.NewEthereumBridgeClient(t)
-	ethClient.EXPECT().WatchDepositEvents(mock.Anything, uint64(20), mock.Anything).Return(nil).Maybe()
+	ethClient.EXPECT().WatchDepositEvents(mock.Anything, uint64(20), mock.Anything, mock.Anything).Return(nil).Maybe()
 	ethClient.EXPECT().GetLatestBlockNumber(mock.Anything).Return(uint64(20), nil).Maybe()
 	ethClient.EXPECT().GetLastScannedBlock().Return(uint64(20)).Maybe()
 
@@ -112,7 +112,7 @@ func TestEngine_Start_RestartsCantonProcessorOnUnexpectedStreamClose(t *testing.
 		Times(2)
 
 	ethClient := relayermocks.NewEthereumBridgeClient(t)
-	ethClient.EXPECT().WatchDepositEvents(mock.Anything, uint64(20), mock.Anything).Return(nil).Maybe()
+	ethClient.EXPECT().WatchDepositEvents(mock.Anything, uint64(20), mock.Anything, mock.Anything).Return(nil).Maybe()
 	ethClient.EXPECT().GetLatestBlockNumber(mock.Anything).Return(uint64(20), nil).Maybe()
 	ethClient.EXPECT().GetLastScannedBlock().Return(uint64(20)).Maybe()
 

--- a/pkg/relayer/engine/mocks/mock_canton_bridge.go
+++ b/pkg/relayer/engine/mocks/mock_canton_bridge.go
@@ -355,63 +355,6 @@ func (_c *CantonBridge_IsDepositProcessed_Call) RunAndReturn(run func(context.Co
 	return _c
 }
 
-// ProcessWithdrawal provides a mock function with given fields: ctx, withdrawalRequestCID
-func (_m *CantonBridge) ProcessWithdrawal(ctx context.Context, withdrawalRequestCID string) (string, error) {
-	ret := _m.Called(ctx, withdrawalRequestCID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ProcessWithdrawal")
-	}
-
-	var r0 string
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) (string, error)); ok {
-		return rf(ctx, withdrawalRequestCID)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) string); ok {
-		r0 = rf(ctx, withdrawalRequestCID)
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, withdrawalRequestCID)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// CantonBridge_ProcessWithdrawal_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ProcessWithdrawal'
-type CantonBridge_ProcessWithdrawal_Call struct {
-	*mock.Call
-}
-
-// ProcessWithdrawal is a helper method to define mock.On call
-//   - ctx context.Context
-//   - withdrawalRequestCID string
-func (_e *CantonBridge_Expecter) ProcessWithdrawal(ctx interface{}, withdrawalRequestCID interface{}) *CantonBridge_ProcessWithdrawal_Call {
-	return &CantonBridge_ProcessWithdrawal_Call{Call: _e.mock.On("ProcessWithdrawal", ctx, withdrawalRequestCID)}
-}
-
-func (_c *CantonBridge_ProcessWithdrawal_Call) Run(run func(ctx context.Context, withdrawalRequestCID string)) *CantonBridge_ProcessWithdrawal_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
-	})
-	return _c
-}
-
-func (_c *CantonBridge_ProcessWithdrawal_Call) Return(_a0 string, _a1 error) *CantonBridge_ProcessWithdrawal_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *CantonBridge_ProcessWithdrawal_Call) RunAndReturn(run func(context.Context, string) (string, error)) *CantonBridge_ProcessWithdrawal_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // ProcessDepositAndMint provides a mock function with given fields: ctx, req
 func (_m *CantonBridge) ProcessDepositAndMint(ctx context.Context, req bridge.ProcessDepositRequest) (*bridge.ProcessedDeposit, error) {
 	ret := _m.Called(ctx, req)
@@ -467,6 +410,63 @@ func (_c *CantonBridge_ProcessDepositAndMint_Call) Return(_a0 *bridge.ProcessedD
 }
 
 func (_c *CantonBridge_ProcessDepositAndMint_Call) RunAndReturn(run func(context.Context, bridge.ProcessDepositRequest) (*bridge.ProcessedDeposit, error)) *CantonBridge_ProcessDepositAndMint_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ProcessWithdrawal provides a mock function with given fields: ctx, withdrawalRequestCID
+func (_m *CantonBridge) ProcessWithdrawal(ctx context.Context, withdrawalRequestCID string) (string, error) {
+	ret := _m.Called(ctx, withdrawalRequestCID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ProcessWithdrawal")
+	}
+
+	var r0 string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (string, error)); ok {
+		return rf(ctx, withdrawalRequestCID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) string); ok {
+		r0 = rf(ctx, withdrawalRequestCID)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, withdrawalRequestCID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// CantonBridge_ProcessWithdrawal_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ProcessWithdrawal'
+type CantonBridge_ProcessWithdrawal_Call struct {
+	*mock.Call
+}
+
+// ProcessWithdrawal is a helper method to define mock.On call
+//   - ctx context.Context
+//   - withdrawalRequestCID string
+func (_e *CantonBridge_Expecter) ProcessWithdrawal(ctx interface{}, withdrawalRequestCID interface{}) *CantonBridge_ProcessWithdrawal_Call {
+	return &CantonBridge_ProcessWithdrawal_Call{Call: _e.mock.On("ProcessWithdrawal", ctx, withdrawalRequestCID)}
+}
+
+func (_c *CantonBridge_ProcessWithdrawal_Call) Run(run func(ctx context.Context, withdrawalRequestCID string)) *CantonBridge_ProcessWithdrawal_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *CantonBridge_ProcessWithdrawal_Call) Return(_a0 string, _a1 error) *CantonBridge_ProcessWithdrawal_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *CantonBridge_ProcessWithdrawal_Call) RunAndReturn(run func(context.Context, string) (string, error)) *CantonBridge_ProcessWithdrawal_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/relayer/engine/mocks/mock_ethereum_bridge_client.go
+++ b/pkg/relayer/engine/mocks/mock_ethereum_bridge_client.go
@@ -184,17 +184,17 @@ func (_c *EthereumBridgeClient_IsWithdrawalProcessed_Call) RunAndReturn(run func
 	return _c
 }
 
-// WatchDepositEvents provides a mock function with given fields: ctx, fromBlock, handler
-func (_m *EthereumBridgeClient) WatchDepositEvents(ctx context.Context, fromBlock uint64, handler func(*ethereum.DepositEvent) error) error {
-	ret := _m.Called(ctx, fromBlock, handler)
+// WatchDepositEvents provides a mock function with given fields: ctx, fromBlock, handler, onProgress
+func (_m *EthereumBridgeClient) WatchDepositEvents(ctx context.Context, fromBlock uint64, handler func(*ethereum.DepositEvent) error, onProgress func(uint64) error) error {
+	ret := _m.Called(ctx, fromBlock, handler, onProgress)
 
 	if len(ret) == 0 {
 		panic("no return value specified for WatchDepositEvents")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, uint64, func(*ethereum.DepositEvent) error) error); ok {
-		r0 = rf(ctx, fromBlock, handler)
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, func(*ethereum.DepositEvent) error, func(uint64) error) error); ok {
+		r0 = rf(ctx, fromBlock, handler, onProgress)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -211,13 +211,14 @@ type EthereumBridgeClient_WatchDepositEvents_Call struct {
 //   - ctx context.Context
 //   - fromBlock uint64
 //   - handler func(*ethereum.DepositEvent) error
-func (_e *EthereumBridgeClient_Expecter) WatchDepositEvents(ctx interface{}, fromBlock interface{}, handler interface{}) *EthereumBridgeClient_WatchDepositEvents_Call {
-	return &EthereumBridgeClient_WatchDepositEvents_Call{Call: _e.mock.On("WatchDepositEvents", ctx, fromBlock, handler)}
+//   - onProgress func(uint64) error
+func (_e *EthereumBridgeClient_Expecter) WatchDepositEvents(ctx interface{}, fromBlock interface{}, handler interface{}, onProgress interface{}) *EthereumBridgeClient_WatchDepositEvents_Call {
+	return &EthereumBridgeClient_WatchDepositEvents_Call{Call: _e.mock.On("WatchDepositEvents", ctx, fromBlock, handler, onProgress)}
 }
 
-func (_c *EthereumBridgeClient_WatchDepositEvents_Call) Run(run func(ctx context.Context, fromBlock uint64, handler func(*ethereum.DepositEvent) error)) *EthereumBridgeClient_WatchDepositEvents_Call {
+func (_c *EthereumBridgeClient_WatchDepositEvents_Call) Run(run func(ctx context.Context, fromBlock uint64, handler func(*ethereum.DepositEvent) error, onProgress func(uint64) error)) *EthereumBridgeClient_WatchDepositEvents_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(uint64), args[2].(func(*ethereum.DepositEvent) error))
+		run(args[0].(context.Context), args[1].(uint64), args[2].(func(*ethereum.DepositEvent) error), args[3].(func(uint64) error))
 	})
 	return _c
 }
@@ -227,7 +228,7 @@ func (_c *EthereumBridgeClient_WatchDepositEvents_Call) Return(_a0 error) *Ether
 	return _c
 }
 
-func (_c *EthereumBridgeClient_WatchDepositEvents_Call) RunAndReturn(run func(context.Context, uint64, func(*ethereum.DepositEvent) error) error) *EthereumBridgeClient_WatchDepositEvents_Call {
+func (_c *EthereumBridgeClient_WatchDepositEvents_Call) RunAndReturn(run func(context.Context, uint64, func(*ethereum.DepositEvent) error, func(uint64) error) error) *EthereumBridgeClient_WatchDepositEvents_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/relayer/engine/processor.go
+++ b/pkg/relayer/engine/processor.go
@@ -104,6 +104,13 @@ func (p *Processor) Start(ctx context.Context, startOffset string) error {
 			if !ok {
 				return nil
 			}
+			if event.Checkpoint {
+				// Scan-progress watermark, not a transfer: advance the persisted
+				// offset only. It arrives in order after the events it covers, so
+				// everything up to it has already been processed by this loop.
+				p.persistOffset(ctx, event)
+				continue
+			}
 			if err := p.processEvent(ctx, event); err != nil {
 				p.logger.Error("Failed to process event",
 					zap.String("event_id", event.ID),

--- a/pkg/relayer/engine/processor_test.go
+++ b/pkg/relayer/engine/processor_test.go
@@ -80,6 +80,47 @@ func TestProcessor_Start_ProcessesEventSuccess(t *testing.T) {
 	}
 }
 
+func TestProcessor_Start_CheckpointPersistsOffsetWithoutProcessing(t *testing.T) {
+	ctx := context.Background()
+	source := relayermocks.NewSource(t)
+	destination := relayermocks.NewDestination(t)
+	store := relayermocks.NewBridgeStore(t)
+
+	eventCh := make(chan *relayer.Event, 1)
+	errCh := make(chan error)
+
+	// A scan-progress checkpoint (no transfer payload).
+	eventCh <- &relayer.Event{
+		SourceChain:       relayer.ChainEthereum,
+		SourceBlockNumber: 150,
+		Checkpoint:        true,
+	}
+	close(eventCh)
+
+	source.EXPECT().GetChainID().Return(relayer.ChainEthereum).Maybe()
+	destination.EXPECT().GetChainID().Return(relayer.ChainCanton).Maybe()
+	source.EXPECT().StreamEvents(ctx, "100").Return((<-chan *relayer.Event)(eventCh), (<-chan error)(errCh)).Once()
+	source.EXPECT().ExtractOffset(mock.AnythingOfType("*relayer.Event")).Return("150").Once()
+	// No CreateTransfer / SubmitTransfer / UpdateTransferStatus expected — a
+	// checkpoint must only advance the offset. The strict mocks fail the test if any
+	// transfer-processing call is made.
+
+	var persistedChain, persistedOffset string
+	processor := engine.NewProcessor(source, destination, store, engine.NewNopMetrics(), zap.NewNop(), "processor_test", relayer.DirectionEthereumToCanton).
+		WithOffsetUpdate(func(_ context.Context, chainID string, offset string) error {
+			persistedChain = chainID
+			persistedOffset = offset
+			return nil
+		})
+
+	if err := processor.Start(ctx, "100"); err != nil {
+		t.Fatalf("Start() failed: %v", err)
+	}
+	if persistedChain != relayer.ChainEthereum || persistedOffset != "150" {
+		t.Fatalf("expected checkpoint to persist ethereum offset 150, got chain=%s offset=%s", persistedChain, persistedOffset)
+	}
+}
+
 func TestProcessor_Start_DuplicateTransferPersistsOffsetOnce(t *testing.T) {
 	ctx := context.Background()
 	source := relayermocks.NewSource(t)

--- a/pkg/relayer/engine/source.go
+++ b/pkg/relayer/engine/source.go
@@ -127,10 +127,19 @@ func (s *ethereumSource) StreamEvents(ctx context.Context, offset string) (<-cha
 			fromBlock = n
 		}
 
+		emit := func(ev *relayer.Event) error {
+			select {
+			case outCh <- ev:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+
 		err := s.client.WatchDepositEvents(ctx, fromBlock, func(event *ethereum.DepositEvent) error {
 			s.metrics.IncEventsDetected(relayer.ChainEthereum, EventTypeDeposit)
 
-			relayerEvent := &relayer.Event{
+			return emit(&relayer.Event{
 				ID:                fmt.Sprintf("%s-%d", event.TxHash.Hex(), event.LogIndex),
 				TransactionID:     event.TxHash.Hex(),
 				SourceChain:       relayer.ChainEthereum,
@@ -142,14 +151,16 @@ func (s *ethereumSource) StreamEvents(ctx context.Context, offset string) (<-cha
 				Recipient:         fmt.Sprintf("%x", event.CantonRecipient),
 				Nonce:             event.Nonce.Int64(),
 				SourceBlockNumber: event.BlockNumber,
-			}
-
-			select {
-			case outCh <- relayerEvent:
-				return nil
-			case <-ctx.Done():
-				return ctx.Err()
-			}
+			})
+		}, func(block uint64) error {
+			// Emit a scan-progress checkpoint after each slice. It rides the same
+			// ordered channel behind that slice's deposits, so the processor persists
+			// the block only once those deposits are processed.
+			return emit(&relayer.Event{
+				SourceChain:       relayer.ChainEthereum,
+				SourceBlockNumber: block,
+				Checkpoint:        true,
+			})
 		})
 
 		if err != nil && ctx.Err() == nil {

--- a/pkg/relayer/engine/source_test.go
+++ b/pkg/relayer/engine/source_test.go
@@ -140,8 +140,8 @@ func TestEthereumSource_StreamEvents_MapsDepositEvent(t *testing.T) {
 	deposit.CantonRecipient[1] = 0xbb
 
 	ethClient.EXPECT().
-		WatchDepositEvents(ctx, uint64(12), mock.Anything).
-		RunAndReturn(func(_ context.Context, _ uint64, handler func(*ethereum.DepositEvent) error) error {
+		WatchDepositEvents(ctx, uint64(12), mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, _ uint64, handler func(*ethereum.DepositEvent) error, _ func(uint64) error) error {
 			return handler(deposit)
 		})
 
@@ -173,5 +173,32 @@ func TestEthereumSource_StreamEvents_MapsDepositEvent(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for mapped ethereum event")
+	}
+}
+
+func TestEthereumSource_StreamEvents_EmitsScanCheckpoint(t *testing.T) {
+	ctx := context.Background()
+	ethClient := relayermocks.NewEthereumBridgeClient(t)
+
+	// The poller reports scan progress through onProgress even with no deposits.
+	ethClient.EXPECT().
+		WatchDepositEvents(ctx, uint64(12), mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, _ uint64, _ func(*ethereum.DepositEvent) error, onProgress func(uint64) error) error {
+			return onProgress(200)
+		})
+
+	source := engine.NewEthereumSource(ethClient, relayer.ChainEthereum, engine.NewNopMetrics())
+	eventCh, _ := source.StreamEvents(ctx, "12")
+
+	select {
+	case event, ok := <-eventCh:
+		if !ok {
+			t.Fatal("expected a checkpoint event, channel closed")
+		}
+		if !event.Checkpoint || event.SourceBlockNumber != 200 {
+			t.Fatalf("expected checkpoint at block 200, got %+v", event)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for scan checkpoint event")
 	}
 }

--- a/pkg/relayer/types.go
+++ b/pkg/relayer/types.go
@@ -76,4 +76,10 @@ type Event struct {
 	Recipient         string
 	Nonce             int64
 	SourceBlockNumber uint64
+
+	// Checkpoint marks a progress watermark rather than a real transfer: the source
+	// has scanned through SourceBlockNumber and emitted every event up to it. The
+	// processor persists the offset and skips transfer processing. Emitted in-order
+	// after a slice's events so persisting it cannot skip an unprocessed event.
+	Checkpoint bool
 }


### PR DESCRIPTION
Addresses frequent relayer restarts and re-scanning from far behind on restart.

## Root cause of the restarts

The relayer runs its components in an errgroup sharing one context, and `cmd/relayer` does `log.Fatal` when `engine.Run` returns — so **any** component error exits the process (and the orchestrator restarts it). The `context canceled` seen in the Ethereum poller was a *symptom* (the shared context being torn down), not the cause.

The actual trigger: the Canton withdrawal stream's reconnect loop treated **`io.EOF` as terminal**. A live `GetUpdates` subscription is open-ended, so an EOF (server-side/load-balancer idle timeout, or a Canton node rollout) closed the channel → the relayer's Canton source reported a fatal error → process exit → restart loop.

## Changes

1. **Canton stream reconnects on EOF** (`cantonsdk/bridge`): reconnect from the last processed offset on `io.EOF` (and any non-context error) with existing backoff; only a canceled context stops the stream. No more fatal exit on a routine stream end.

2. **Bounded Ethereum RPC calls** (`ethereum`): each `eth_getLogs` / `eth_blockNumber` runs under a configurable `RPCTimeout` (default `30s`; `<=0` disables). A hung/slow provider fails that call and it's retried next tick instead of stalling the poll loop. (Note: this surfaces as `deadline exceeded`, distinct from the `canceled` above.)

3. **Persist Ethereum scan progress** (`ethereum` + `relayer/engine`): the poller now checkpoints its scanned block continuously (not only when a deposit is processed), so restarts resume near chain head instead of re-scanning from the last deposit / needing a manual `eth_start_block` bump. The checkpoint rides the same in-order channel behind a slice's deposits, so persisting it can't skip an unprocessed deposit (the processor consumes single-threaded, in order).

## Tests
- Processor: a checkpoint event persists the offset and runs no transfer processing.
- Source: `onProgress` emits a checkpoint carrying the scanned block.
- Existing deposit-mapping / engine tests updated for the new callback arg.
- (Canton reconnect and the RPC timeout are behavioral/config; `pkg/cantonsdk/bridge` has no unit-test harness for the gRPC stream, so they're covered by build + the passing engine tests.)