### PR TITLE
fix(relayer): reconnect Canton stream on EOF

### DIFF
--- a/pkg/cantonsdk/bridge/client.go
+++ b/pkg/cantonsdk/bridge/client.go
@@ -8,9 +8,7 @@ package bridge
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"io"
 	"strconv"
 	"time"
 
@@ -501,9 +499,19 @@ func (c *Client) StreamWithdrawalEvents(ctx context.Context, offset string) <-ch
 			}
 
 			err := c.streamWithdrawalEventsOnce(ctx, currentOffset, outCh, &currentOffset)
-			if err == nil || errors.Is(err, io.EOF) || ctx.Err() != nil {
+			if ctx.Err() != nil {
 				return
 			}
+
+			// A live GetUpdates subscription is open-ended, so any stream end —
+			// including io.EOF from a server-side/load-balancer idle timeout or a
+			// Canton node rollout — is transient. Reconnect from the last processed
+			// offset with backoff rather than closing the channel, which would make
+			// the relayer's Canton source report a fatal error and exit the process.
+			c.logger.Warn("withdrawal stream ended; reconnecting",
+				zap.String("from_offset", currentOffset),
+				zap.Duration("backoff", reconnectDelay),
+				zap.Error(err))
 
 			if isAuthError(err) {
 				c.ledger.InvalidateToken()

--- a/pkg/cantonsdk/bridge/client.go
+++ b/pkg/cantonsdk/bridge/client.go
@@ -24,8 +24,12 @@ import (
 )
 
 const (
-	streamReconnectDelay      = 5 * time.Second
-	streamMaxReconnectDelay   = 60 * time.Second
+	streamReconnectDelay    = 5 * time.Second
+	streamMaxReconnectDelay = 60 * time.Second
+	// streamHealthyThreshold is the minimum time a stream must stay connected for it
+	// to count as healthy, resetting the reconnect backoff. This keeps a routine
+	// stream end after hours of stable operation from inheriting a maxed-out delay.
+	streamHealthyThreshold    = 30 * time.Second
 	withdrawalEventChannelCap = 10
 
 	bridgeContractsModule = "Bridge.Contracts"
@@ -498,9 +502,17 @@ func (c *Client) StreamWithdrawalEvents(ctx context.Context, offset string) <-ch
 			default:
 			}
 
+			streamStart := time.Now()
 			err := c.streamWithdrawalEventsOnce(ctx, currentOffset, outCh, &currentOffset)
 			if ctx.Err() != nil {
 				return
+			}
+
+			// A stream that stayed connected for a healthy duration is treated as a
+			// fresh start, so a routine end after stable operation reconnects promptly
+			// instead of inheriting a backoff grown by earlier transient failures.
+			if time.Since(streamStart) >= streamHealthyThreshold {
+				reconnectDelay = streamReconnectDelay
 			}
 
 			// A live GetUpdates subscription is open-ended, so any stream end —


### PR DESCRIPTION
## Problem
The relayer restarts frequently. Root cause: the Canton withdrawal stream's reconnect loop treated **`io.EOF` as terminal**. A live `GetUpdates` subscription is open-ended, so an EOF (server-side / load-balancer idle timeout, or a Canton node rollout) made the loop `return` and close the channel. The relayer's Canton source reports a closed channel as a fatal error → the engine's shared context is torn down → `cmd/relayer` does `log.Fatal` → process exit → restart loop. (The `context canceled` seen in the eth poller was a symptom of that teardown, not the cause.)

## Fix
One file. Reconnect from the last processed offset on any non-context stream end (including EOF), reusing the existing exponential backoff; only a canceled context stops the stream.

## Test plan
- `go build ./...`, `go test ./pkg/relayer/... ./pkg/cantonsdk/...` pass.
- Backoff (`time.After(reconnectDelay)`, exponential up to max) is applied before each reconnect, so a clean/EOF end can't tight-loop.

Note: check the prod **liveness** probe targets `/health` (returns 200 unconditionally), not `/ready` (gates on sync) — a liveness probe on `/ready` would restart-loop during long catch-ups regardless of this fix.