### PR TITLE
feat: canceled status for withdrawn transfer offers

### DIFF
--- a/pkg/app/indexer/server.go
+++ b/pkg/app/indexer/server.go
@@ -120,7 +120,7 @@ func (s *Server) Run() error {
 
 	filterMode, instruments := cfg.Indexer.FilterModeAndKeys()
 	transferDecode := engine.NewTokenTransferDecoder(filterMode, instruments, logger)
-	offerDecode := engine.NewOfferDecoder(cfg.Indexer.UtilityRegistryPackageID, logger)
+	offerDecode := engine.NewOfferDecoder(cfg.Indexer.UtilityRegistryPackageID, engineMetrics, logger)
 	holdingDecode := engine.NewHoldingDecoder(cfg.Indexer.UtilityRegistryHoldingPackageID, logger)
 	decode := engine.NewMultiDecoder(transferDecode, offerDecode, holdingDecode)
 	fetcher := engine.NewFetcher(streamClient, templateIDs, decode, logger)

--- a/pkg/cantonsdk/streaming/client.go
+++ b/pkg/cantonsdk/streaming/client.go
@@ -242,10 +242,21 @@ func decodeLedgerTransaction(tx *lapiv2.Transaction) *LedgerTransaction {
 // so that callers never need to import lapiv2 directly.
 // With the LEDGER_EFFECTS transaction shape a contract archive arrives as a consuming
 // ExercisedEvent; it is decoded as an archive-shaped LedgerEvent carrying the Choice
-// name. Returns nil for event kinds the indexer does not process (non-consuming
-// exercises, plain ArchivedEvents from ACS_DELTA streams).
+// name.
+//
+// Only events with AcsDelta set are decoded. LEDGER_EFFECTS delivers every event the
+// subscribing parties are informees of — including witnessed events on contracts where
+// no subscribed party is a stakeholder, and transient contracts (created and consumed
+// in the same transaction). Consumers derive balances from create/archive pairs and
+// assume both ends of a contract's lifecycle are visible; a witnessed create whose
+// archive is never delivered would corrupt that accounting. The AcsDelta flag marks
+// exactly the events an ACS_DELTA stream would have delivered, so gating on it keeps
+// the pre-LEDGER_EFFECTS visibility semantics while still carrying the choice name.
+//
+// Returns nil for everything else (witnessed-only events, transient contracts,
+// non-consuming exercises, plain ArchivedEvents from ACS_DELTA streams).
 func decodeLedgerEvent(ev *lapiv2.Event) *LedgerEvent {
-	if created := ev.GetCreated(); created != nil {
+	if created := ev.GetCreated(); created != nil && created.GetAcsDelta() {
 		le := &LedgerEvent{
 			ContractID: created.GetContractId(),
 			IsCreated:  true,
@@ -259,7 +270,7 @@ func decodeLedgerEvent(ev *lapiv2.Event) *LedgerEvent {
 		return le
 	}
 
-	if exercised := ev.GetExercised(); exercised != nil && exercised.GetConsuming() {
+	if exercised := ev.GetExercised(); exercised != nil && exercised.GetConsuming() && exercised.GetAcsDelta() {
 		le := &LedgerEvent{
 			ContractID: exercised.GetContractId(),
 			IsCreated:  false,

--- a/pkg/cantonsdk/streaming/client.go
+++ b/pkg/cantonsdk/streaming/client.go
@@ -150,8 +150,11 @@ func (c *Client) runStream(
 		BeginExclusive: fromOffset,
 		UpdateFormat: &lapiv2.UpdateFormat{
 			IncludeTransactions: &lapiv2.TransactionFormat{
-				EventFormat:      eventFormat,
-				TransactionShape: lapiv2.TransactionShape_TRANSACTION_SHAPE_ACS_DELTA,
+				EventFormat: eventFormat,
+				// LEDGER_EFFECTS (rather than ACS_DELTA) so archives arrive as
+				// consuming ExercisedEvents carrying the choice name — consumers
+				// need it to tell an accepted offer from a withdrawn one.
+				TransactionShape: lapiv2.TransactionShape_TRANSACTION_SHAPE_LEDGER_EFFECTS,
 			},
 		},
 	})
@@ -237,7 +240,10 @@ func decodeLedgerTransaction(tx *lapiv2.Transaction) *LedgerTransaction {
 // decodeLedgerEvent converts a proto Event to a LedgerEvent.
 // For created events the DAML CreateArguments are pre-decoded into LedgerEvent.fields
 // so that callers never need to import lapiv2 directly.
-// Returns nil for event kinds the indexer does not process (e.g. exercised events).
+// With the LEDGER_EFFECTS transaction shape a contract archive arrives as a consuming
+// ExercisedEvent; it is decoded as an archive-shaped LedgerEvent carrying the Choice
+// name. Returns nil for event kinds the indexer does not process (non-consuming
+// exercises, plain ArchivedEvents from ACS_DELTA streams).
 func decodeLedgerEvent(ev *lapiv2.Event) *LedgerEvent {
 	if created := ev.GetCreated(); created != nil {
 		le := &LedgerEvent{
@@ -253,12 +259,13 @@ func decodeLedgerEvent(ev *lapiv2.Event) *LedgerEvent {
 		return le
 	}
 
-	if archived := ev.GetArchived(); archived != nil {
+	if exercised := ev.GetExercised(); exercised != nil && exercised.GetConsuming() {
 		le := &LedgerEvent{
-			ContractID: archived.GetContractId(),
+			ContractID: exercised.GetContractId(),
 			IsCreated:  false,
+			Choice:     exercised.GetChoice(),
 		}
-		if tid := archived.GetTemplateId(); tid != nil {
+		if tid := exercised.GetTemplateId(); tid != nil {
 			le.PackageID = tid.GetPackageId()
 			le.ModuleName = tid.GetModuleName()
 			le.TemplateName = tid.GetEntityName()

--- a/pkg/cantonsdk/streaming/client_test.go
+++ b/pkg/cantonsdk/streaming/client_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package streaming
+
+import (
+	"testing"
+
+	lapiv2 "github.com/chainsafe/canton-middleware/pkg/cantonsdk/lapi/v2"
+)
+
+func createdEvent(contractID string, acsDelta bool) *lapiv2.Event {
+	return &lapiv2.Event{Event: &lapiv2.Event_Created{Created: &lapiv2.CreatedEvent{
+		ContractId: contractID,
+		TemplateId: &lapiv2.Identifier{PackageId: "pkg", ModuleName: "Mod", EntityName: "Ent"},
+		AcsDelta:   acsDelta,
+	}}}
+}
+
+func exercisedEvent(contractID, choice string, consuming, acsDelta bool) *lapiv2.Event {
+	return &lapiv2.Event{Event: &lapiv2.Event_Exercised{Exercised: &lapiv2.ExercisedEvent{
+		ContractId: contractID,
+		TemplateId: &lapiv2.Identifier{PackageId: "pkg", ModuleName: "Mod", EntityName: "Ent"},
+		Choice:     choice,
+		Consuming:  consuming,
+		AcsDelta:   acsDelta,
+	}}}
+}
+
+// TestDecodeLedgerEvent_AcsDeltaGate pins the visibility semantics of the
+// LEDGER_EFFECTS stream decode: only events flagged AcsDelta — the ones an
+// ACS_DELTA stream would have delivered — are decoded. Witnessed-only events
+// and transient contracts (AcsDelta=false) and non-consuming exercises are
+// dropped, so balance accounting never sees one end of a contract lifecycle
+// without the other.
+func TestDecodeLedgerEvent_AcsDeltaGate(t *testing.T) {
+	cases := []struct {
+		name       string
+		ev         *lapiv2.Event
+		want       bool // decoded at all
+		wantCreate bool
+		wantChoice string
+	}{
+		{"created stakeholder", createdEvent("c1", true), true, true, ""},
+		{"created witnessed-only or transient", createdEvent("c2", false), false, false, ""},
+		{"consuming exercise on ACS contract", exercisedEvent("c3", "TransferInstruction_Withdraw", true, true), true, false, "TransferInstruction_Withdraw"},
+		{"consuming exercise witnessed-only", exercisedEvent("c4", "TransferInstruction_Withdraw", true, false), false, false, ""},
+		{"non-consuming exercise", exercisedEvent("c5", "SomeQuery", false, true), false, false, ""},
+		{"archived event (ACS_DELTA shape)", &lapiv2.Event{Event: &lapiv2.Event_Archived{Archived: &lapiv2.ArchivedEvent{ContractId: "c6"}}}, false, false, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			le := decodeLedgerEvent(tc.ev)
+			if (le != nil) != tc.want {
+				t.Fatalf("decoded=%v, want %v", le != nil, tc.want)
+			}
+			if le == nil {
+				return
+			}
+			if le.IsCreated != tc.wantCreate {
+				t.Fatalf("IsCreated=%v, want %v", le.IsCreated, tc.wantCreate)
+			}
+			if le.Choice != tc.wantChoice {
+				t.Fatalf("Choice=%q, want %q", le.Choice, tc.wantChoice)
+			}
+		})
+	}
+}

--- a/pkg/cantonsdk/streaming/types.go
+++ b/pkg/cantonsdk/streaming/types.go
@@ -49,6 +49,12 @@ type LedgerEvent struct {
 	// IsCreated is true for contract create events, false for archive events.
 	IsCreated bool
 
+	// Choice is the DAML choice that consumed the contract (e.g.
+	// "TransferInstruction_Withdraw"). Only set on archive events, and only when
+	// the stream delivers archives as consuming exercises (LEDGER_EFFECTS shape);
+	// "" otherwise.
+	Choice string
+
 	// fields holds the pre-decoded DAML record from CreateArguments, keyed by field label.
 	// Only populated for created events; nil for archived events.
 	fields map[string]*lapiv2.Value

--- a/pkg/indexer/client/http.go
+++ b/pkg/indexer/client/http.go
@@ -208,8 +208,8 @@ func (c *HTTP) GetTransfer(ctx context.Context, contractID string) (*indexer.Tra
 }
 
 // GetTransfers calls GET /indexer/v1/admin/parties/{partyID}/transfers,
-// filtering by role (receiver/sender/any) and status (pending/expired/completed;
-// "" = all).
+// filtering by role (receiver/sender/any) and status
+// (pending/expired/completed/canceled; "" = all).
 func (c *HTTP) GetTransfers(
 	ctx context.Context, partyID string, query indexer.TransferQuery, p indexer.Pagination,
 ) (*indexer.Page[indexer.Transfer], error) {

--- a/pkg/indexer/engine/decoder.go
+++ b/pkg/indexer/engine/decoder.go
@@ -21,6 +21,15 @@ const (
 	transferOfferModule = "Utility.Registry.App.V0.Model.Transfer"
 	transferOfferEntity = "TransferOffer"
 
+	// Splice token-standard TransferInstruction choices that archive a
+	// TransferOffer. The choice name arrives on the consuming exercised event
+	// (LEDGER_EFFECTS stream shape) and decides the offer's terminal status:
+	// accept settles it, withdraw (sender claim-back) and reject (receiver
+	// decline) cancel it.
+	choiceInstructionAccept   = "TransferInstruction_Accept"
+	choiceInstructionWithdraw = "TransferInstruction_Withdraw"
+	choiceInstructionReject   = "TransferInstruction_Reject"
+
 	holdingModule = "Utility.Registry.Holding.V0.Holding"
 	holdingEntity = "Holding"
 )
@@ -139,8 +148,9 @@ func NewTokenTransferDecoder(
 // packageID is empty (feature disabled).
 //
 // On CREATED the transfer is "pending" with all fields populated; on ARCHIVED only
-// ContractID/LedgerOffset/CreatedAt and the Archived flag are set — the processor
-// uses ContractID to complete the existing row.
+// ContractID/LedgerOffset/CreatedAt, the Archived flag, and the terminal Status
+// (derived from the archiving choice) are set — the processor uses ContractID to
+// finalize the existing row.
 func NewOfferDecoder(
 	packageID string, logger *zap.Logger,
 ) func(*streaming.LedgerTransaction, *streaming.LedgerEvent) (*indexer.Transfer, bool) {
@@ -165,6 +175,9 @@ func NewOfferDecoder(
 			LedgerOffset: tx.Offset,
 			CreatedAt:    tx.EffectiveTime,
 		}
+		if !ev.IsCreated {
+			transfer.Status = offerTerminalStatus(ev.Choice, ev.ContractID, logger)
+		}
 		if ev.IsCreated {
 			// TransferOffer CreateArguments: {operator, provider, transfer{...}}.
 			// Receiver/sender/amount/instrumentId all live inside the nested transfer record.
@@ -185,6 +198,26 @@ func NewOfferDecoder(
 			}
 		}
 		return transfer, true
+	}
+}
+
+// offerTerminalStatus maps the choice that archived a TransferOffer to the
+// transfer's terminal status: accept settles ("completed"); withdraw and reject
+// cancel ("canceled"). Unknown choices — including "" from a stream that does
+// not carry choice names — fall back to "completed", preserving the historical
+// any-archive-settles behavior, and are logged for visibility.
+func offerTerminalStatus(choice, contractID string, logger *zap.Logger) string {
+	switch choice {
+	case choiceInstructionAccept:
+		return indexer.TransferStatusCompleted
+	case choiceInstructionWithdraw, choiceInstructionReject:
+		return indexer.TransferStatusCanceled
+	default:
+		logger.Warn("TransferOffer archived by unrecognized choice — defaulting to completed",
+			zap.String("choice", choice),
+			zap.String("contract_id", contractID),
+		)
+		return indexer.TransferStatusCompleted
 	}
 }
 

--- a/pkg/indexer/engine/decoder.go
+++ b/pkg/indexer/engine/decoder.go
@@ -152,7 +152,7 @@ func NewTokenTransferDecoder(
 // (derived from the archiving choice) are set — the processor uses ContractID to
 // finalize the existing row.
 func NewOfferDecoder(
-	packageID string, logger *zap.Logger,
+	packageID string, metrics *Metrics, logger *zap.Logger,
 ) func(*streaming.LedgerTransaction, *streaming.LedgerEvent) (*indexer.Transfer, bool) {
 	if packageID == "" {
 		return func(*streaming.LedgerTransaction, *streaming.LedgerEvent) (*indexer.Transfer, bool) {
@@ -176,7 +176,7 @@ func NewOfferDecoder(
 			CreatedAt:    tx.EffectiveTime,
 		}
 		if !ev.IsCreated {
-			transfer.Status = offerTerminalStatus(ev.Choice, ev.ContractID, logger)
+			transfer.Status = offerTerminalStatus(ev.Choice, ev.ContractID, metrics, logger)
 		}
 		if ev.IsCreated {
 			// TransferOffer CreateArguments: {operator, provider, transfer{...}}.
@@ -205,14 +205,18 @@ func NewOfferDecoder(
 // transfer's terminal status: accept settles ("completed"); withdraw and reject
 // cancel ("canceled"). Unknown choices — including "" from a stream that does
 // not carry choice names — fall back to "completed", preserving the historical
-// any-archive-settles behavior, and are logged for visibility.
-func offerTerminalStatus(choice, contractID string, logger *zap.Logger) string {
+// any-archive-settles behavior. Each fallback increments the
+// OfferUnknownArchiveChoices counter (alertable) and logs a warning, since it
+// may mean a registry archives offers via a choice this mapping doesn't know
+// (e.g. TransferInstruction_Update) and statuses could be mislabeled.
+func offerTerminalStatus(choice, contractID string, metrics *Metrics, logger *zap.Logger) string {
 	switch choice {
 	case choiceInstructionAccept:
 		return indexer.TransferStatusCompleted
 	case choiceInstructionWithdraw, choiceInstructionReject:
 		return indexer.TransferStatusCanceled
 	default:
+		metrics.OfferUnknownArchiveChoices.Inc()
 		logger.Warn("TransferOffer archived by unrecognized choice — defaulting to completed",
 			zap.String("choice", choice),
 			zap.String("contract_id", contractID),

--- a/pkg/indexer/engine/decoder.go
+++ b/pkg/indexer/engine/decoder.go
@@ -219,7 +219,9 @@ func offerTerminalStatus(choice, contractID string, metrics *Metrics, logger *za
 	case choiceInstructionReject:
 		return indexer.TransferStatusRejected
 	default:
-		metrics.OfferUnknownArchiveChoices.Inc()
+		if metrics != nil {
+			metrics.OfferUnknownArchiveChoices.Inc()
+		}
 		logger.Warn("TransferOffer archived by unrecognized choice — defaulting to completed",
 			zap.String("choice", choice),
 			zap.String("contract_id", contractID),

--- a/pkg/indexer/engine/decoder.go
+++ b/pkg/indexer/engine/decoder.go
@@ -24,8 +24,8 @@ const (
 	// Splice token-standard TransferInstruction choices that archive a
 	// TransferOffer. The choice name arrives on the consuming exercised event
 	// (LEDGER_EFFECTS stream shape) and decides the offer's terminal status:
-	// accept settles it, withdraw (sender claim-back) and reject (receiver
-	// decline) cancel it.
+	// accept settles it ("completed"), withdraw is the sender claiming it back
+	// ("canceled"), reject is the receiver declining it ("rejected").
 	choiceInstructionAccept   = "TransferInstruction_Accept"
 	choiceInstructionWithdraw = "TransferInstruction_Withdraw"
 	choiceInstructionReject   = "TransferInstruction_Reject"
@@ -202,9 +202,10 @@ func NewOfferDecoder(
 }
 
 // offerTerminalStatus maps the choice that archived a TransferOffer to the
-// transfer's terminal status: accept settles ("completed"); withdraw and reject
-// cancel ("canceled"). Unknown choices — including "" from a stream that does
-// not carry choice names — fall back to "completed", preserving the historical
+// transfer's terminal status: accept settles ("completed"), withdraw is the
+// sender claiming the offer back ("canceled"), reject is the receiver declining
+// it ("rejected"). Unknown choices — including "" from a stream that does not
+// carry choice names — fall back to "completed", preserving the historical
 // any-archive-settles behavior. Each fallback increments the
 // OfferUnknownArchiveChoices counter (alertable) and logs a warning, since it
 // may mean a registry archives offers via a choice this mapping doesn't know
@@ -213,8 +214,10 @@ func offerTerminalStatus(choice, contractID string, metrics *Metrics, logger *za
 	switch choice {
 	case choiceInstructionAccept:
 		return indexer.TransferStatusCompleted
-	case choiceInstructionWithdraw, choiceInstructionReject:
+	case choiceInstructionWithdraw:
 		return indexer.TransferStatusCanceled
+	case choiceInstructionReject:
+		return indexer.TransferStatusRejected
 	default:
 		metrics.OfferUnknownArchiveChoices.Inc()
 		logger.Warn("TransferOffer archived by unrecognized choice — defaulting to completed",

--- a/pkg/indexer/engine/decoder_test.go
+++ b/pkg/indexer/engine/decoder_test.go
@@ -95,7 +95,7 @@ func makeOfferArchiveEvent(contractID, choice string) *streaming.LedgerEvent {
 }
 
 func TestOfferDecoder_ArchiveChoiceMapsTerminalStatus(t *testing.T) {
-	dec := NewOfferDecoder("pkg-id", zap.NewNop())
+	dec := NewOfferDecoder("pkg-id", NewNopMetrics(), zap.NewNop())
 
 	cases := []struct {
 		choice string

--- a/pkg/indexer/engine/decoder_test.go
+++ b/pkg/indexer/engine/decoder_test.go
@@ -103,7 +103,7 @@ func TestOfferDecoder_ArchiveChoiceMapsTerminalStatus(t *testing.T) {
 	}{
 		{choiceInstructionAccept, indexer.TransferStatusCompleted},
 		{choiceInstructionWithdraw, indexer.TransferStatusCanceled},
-		{choiceInstructionReject, indexer.TransferStatusCanceled},
+		{choiceInstructionReject, indexer.TransferStatusRejected},
 		{"Archive", indexer.TransferStatusCompleted}, // unknown choice → historical fallback
 		{"", indexer.TransferStatusCompleted},        // no choice info (ACS_DELTA) → fallback
 	}

--- a/pkg/indexer/engine/decoder_test.go
+++ b/pkg/indexer/engine/decoder_test.go
@@ -86,6 +86,35 @@ func makeHoldingEvent(contractID string, lock streaming.FieldValue) *streaming.L
 		})
 }
 
+// makeOfferArchiveEvent builds a TransferOffer archive event as delivered by the
+// LEDGER_EFFECTS stream: no create arguments, just the consuming choice name.
+func makeOfferArchiveEvent(contractID, choice string) *streaming.LedgerEvent {
+	ev := streaming.NewLedgerEvent(contractID, "pkg-id", transferOfferModule, transferOfferEntity, false, nil)
+	ev.Choice = choice
+	return ev
+}
+
+func TestOfferDecoder_ArchiveChoiceMapsTerminalStatus(t *testing.T) {
+	dec := NewOfferDecoder("pkg-id", zap.NewNop())
+
+	cases := []struct {
+		choice string
+		want   string
+	}{
+		{choiceInstructionAccept, indexer.TransferStatusCompleted},
+		{choiceInstructionWithdraw, indexer.TransferStatusCanceled},
+		{choiceInstructionReject, indexer.TransferStatusCanceled},
+		{"Archive", indexer.TransferStatusCompleted}, // unknown choice → historical fallback
+		{"", indexer.TransferStatusCompleted},        // no choice info (ACS_DELTA) → fallback
+	}
+	for _, tc := range cases {
+		tr, ok := dec(makeTx(1), makeOfferArchiveEvent("offer-1", tc.choice))
+		require.True(t, ok, "choice %q", tc.choice)
+		assert.True(t, tr.Archived, "choice %q", tc.choice)
+		assert.Equal(t, tc.want, tr.Status, "choice %q", tc.choice)
+	}
+}
+
 func TestHoldingDecoder_LockField(t *testing.T) {
 	dec := NewHoldingDecoder("pkg-id", zap.NewNop())
 

--- a/pkg/indexer/engine/metrics.go
+++ b/pkg/indexer/engine/metrics.go
@@ -21,6 +21,12 @@ type Metrics struct {
 	// retry. Each increment represents one failed attempt, not one lost batch.
 	BatchProcessingErrors prometheus.Counter
 
+	// OfferUnknownArchiveChoices counts TransferOffer archives whose consuming
+	// choice was not one of the recognized TransferInstruction choices. Each of
+	// these falls back to the "completed" status, so a non-zero value means
+	// offers may be mislabeled — alert on it and extend the decoder's mapping.
+	OfferUnknownArchiveChoices prometheus.Counter
+
 	// ── Sync state ───────────────────────────────────────────────────────────
 
 	// SyncLagSeconds reports how far behind real-time the indexer is, measured
@@ -49,6 +55,12 @@ func NewMetrics(reg sharedmetrics.NamespacedRegisterer) *Metrics {
 			Namespace: ns, Subsystem: sub,
 			Name: "batch_processing_errors_total",
 			Help: "Total number of batch processing failures that triggered a retry",
+		}),
+
+		OfferUnknownArchiveChoices: f.NewCounter(prometheus.CounterOpts{
+			Namespace: ns, Subsystem: sub,
+			Name: "offer_unknown_archive_choices_total",
+			Help: "TransferOffer archives via an unrecognized choice (fell back to completed status)",
 		}),
 
 		SyncLagSeconds: f.NewGauge(prometheus.GaugeOpts{

--- a/pkg/indexer/engine/mocks/mock_store.go
+++ b/pkg/indexer/engine/mocks/mock_store.go
@@ -123,17 +123,17 @@ func (_c *Store_ApplySupplyDelta_Call) RunAndReturn(run func(context.Context, st
 	return _c
 }
 
-// CompleteTransfer provides a mock function with given fields: ctx, contractID
-func (_m *Store) CompleteTransfer(ctx context.Context, contractID string) error {
-	ret := _m.Called(ctx, contractID)
+// FinalizeTransfer provides a mock function with given fields: ctx, contractID, status
+func (_m *Store) FinalizeTransfer(ctx context.Context, contractID string, status string) error {
+	ret := _m.Called(ctx, contractID, status)
 
 	if len(ret) == 0 {
-		panic("no return value specified for CompleteTransfer")
+		panic("no return value specified for FinalizeTransfer")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
-		r0 = rf(ctx, contractID)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = rf(ctx, contractID, status)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -141,31 +141,32 @@ func (_m *Store) CompleteTransfer(ctx context.Context, contractID string) error 
 	return r0
 }
 
-// Store_CompleteTransfer_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CompleteTransfer'
-type Store_CompleteTransfer_Call struct {
+// Store_FinalizeTransfer_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FinalizeTransfer'
+type Store_FinalizeTransfer_Call struct {
 	*mock.Call
 }
 
-// CompleteTransfer is a helper method to define mock.On call
+// FinalizeTransfer is a helper method to define mock.On call
 //   - ctx context.Context
 //   - contractID string
-func (_e *Store_Expecter) CompleteTransfer(ctx interface{}, contractID interface{}) *Store_CompleteTransfer_Call {
-	return &Store_CompleteTransfer_Call{Call: _e.mock.On("CompleteTransfer", ctx, contractID)}
+//   - status string
+func (_e *Store_Expecter) FinalizeTransfer(ctx interface{}, contractID interface{}, status interface{}) *Store_FinalizeTransfer_Call {
+	return &Store_FinalizeTransfer_Call{Call: _e.mock.On("FinalizeTransfer", ctx, contractID, status)}
 }
 
-func (_c *Store_CompleteTransfer_Call) Run(run func(ctx context.Context, contractID string)) *Store_CompleteTransfer_Call {
+func (_c *Store_FinalizeTransfer_Call) Run(run func(ctx context.Context, contractID string, status string)) *Store_FinalizeTransfer_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
 	})
 	return _c
 }
 
-func (_c *Store_CompleteTransfer_Call) Return(_a0 error) *Store_CompleteTransfer_Call {
+func (_c *Store_FinalizeTransfer_Call) Return(_a0 error) *Store_FinalizeTransfer_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *Store_CompleteTransfer_Call) RunAndReturn(run func(context.Context, string) error) *Store_CompleteTransfer_Call {
+func (_c *Store_FinalizeTransfer_Call) RunAndReturn(run func(context.Context, string, string) error) *Store_FinalizeTransfer_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/indexer/engine/processor.go
+++ b/pkg/indexer/engine/processor.go
@@ -88,10 +88,11 @@ type Store interface {
 	// (direct/completed). Idempotent by ContractID, so stream replays are no-ops.
 	InsertTransfer(ctx context.Context, t *indexer.Transfer) error
 
-	// CompleteTransfer transitions a transfer to "completed" when the Canton ledger
-	// emits an ARCHIVED event for the offer contract (receiver exercised Accept, or
-	// the offer was rejected/expired). The row is kept for history; no-op when not found.
-	CompleteTransfer(ctx context.Context, contractID string) error
+	// FinalizeTransfer transitions a still-pending transfer to the given terminal
+	// status ("completed" on accept, "canceled" on withdraw/reject) when the Canton
+	// ledger archives the offer contract. Rows already finalized are left untouched,
+	// so replays are no-ops. The row is kept for history; no-op when not found.
+	FinalizeTransfer(ctx context.Context, contractID, status string) error
 
 	// InsertHolding records an active Utility.Registry.Holding contract so its amount
 	// and owner can be recovered when the contract is later archived (archive events
@@ -207,8 +208,8 @@ func (p *Processor) processBatch(ctx context.Context, batch *streaming.Batch[any
 				}
 			case *indexer.Transfer:
 				if item.Archived {
-					if err := tx.CompleteTransfer(ctx, item.ContractID); err != nil {
-						return fmt.Errorf("complete transfer %s: %w", item.ContractID, err)
+					if err := tx.FinalizeTransfer(ctx, item.ContractID, item.Status); err != nil {
+						return fmt.Errorf("finalize transfer %s: %w", item.ContractID, err)
 					}
 				} else {
 					if err := tx.InsertTransfer(ctx, item); err != nil {

--- a/pkg/indexer/engine/processor.go
+++ b/pkg/indexer/engine/processor.go
@@ -208,7 +208,19 @@ func (p *Processor) processBatch(ctx context.Context, batch *streaming.Batch[any
 				}
 			case *indexer.Transfer:
 				if item.Archived {
-					if err := tx.FinalizeTransfer(ctx, item.ContractID, item.Status); err != nil {
+					status := item.Status
+					if status == "" {
+						// Defensive: the offer decoder always derives a terminal status
+						// for archives; an empty one is a decoder bug. Fall back to the
+						// historical any-archive-settles behavior rather than persisting
+						// an empty status.
+						p.logger.Warn("archived transfer with empty status — defaulting to completed",
+							zap.String("contract_id", item.ContractID),
+							zap.Int64("offset", batch.Offset),
+						)
+						status = indexer.TransferStatusCompleted
+					}
+					if err := tx.FinalizeTransfer(ctx, item.ContractID, status); err != nil {
 						return fmt.Errorf("finalize transfer %s: %w", item.ContractID, err)
 					}
 				} else {

--- a/pkg/indexer/engine/processor_test.go
+++ b/pkg/indexer/engine/processor_test.go
@@ -177,7 +177,7 @@ func TestProcessor_Run_StreamClosed_ReturnsNil(t *testing.T) {
 	assert.NoError(t, engine.NewProcessor(fetcher, store, engine.NewNopMetrics(), zap.NewNop()).Run(context.Background()))
 }
 
-func TestProcessor_Run_ContextCancelled(t *testing.T) {
+func TestProcessor_Run_ContextCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	store := mocks.NewStore(t)
 	fetcher := mocks.NewEventFetcher(t)
@@ -373,7 +373,7 @@ func TestProcessor_Run_StoreError_Retries(t *testing.T) {
 	require.NoError(t, engine.NewProcessor(fetcher, store, engine.NewNopMetrics(), zap.NewNop()).Run(context.Background()))
 }
 
-func TestProcessor_Run_ContextCancelledDuringRetry(t *testing.T) {
+func TestProcessor_Run_ContextCanceledDuringRetry(t *testing.T) {
 	engine.SetRetryBaseDelay(t, time.Hour)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -414,19 +414,38 @@ func TestProcessor_Run_PendingOfferCreated_Inserted(t *testing.T) {
 	require.NoError(t, engine.NewProcessor(fetcher, store, engine.NewNopMetrics(), zap.NewNop()).Run(context.Background()))
 }
 
-func TestProcessor_Run_OfferArchived_CompletesTransfer(t *testing.T) {
+func TestProcessor_Run_OfferArchived_FinalizesTransfer(t *testing.T) {
 	store := mocks.NewStore(t)
 	fetcher := mocks.NewEventFetcher(t)
-	// Archive event carries only the contract id; the existing row is completed by id.
-	archived := &indexer.Transfer{ContractID: "offer-contract-1", Kind: indexer.TransferKindOffer, Archived: true, LedgerOffset: 11, CreatedAt: time.Unix(1_700_000_500, 0)}
+	// Archive event carries only the contract id and the terminal status the decoder
+	// derived from the archiving choice; the existing row is finalized by id.
+	archived := &indexer.Transfer{ContractID: "offer-contract-1", Kind: indexer.TransferKindOffer, Status: indexer.TransferStatusCompleted, Archived: true, LedgerOffset: 11, CreatedAt: time.Unix(1_700_000_500, 0)}
 
 	store.EXPECT().LatestOffset(mock.Anything).Return(int64(0), nil)
 	fetcher.EXPECT().Start(mock.Anything, int64(0))
 	fetcher.EXPECT().Events().Return(feedCh(makeOfferBatch(11, archived)))
 
 	setupRunInTx(store)
-	store.EXPECT().CompleteTransfer(mock.Anything, archived.ContractID).Return(nil)
+	store.EXPECT().FinalizeTransfer(mock.Anything, archived.ContractID, indexer.TransferStatusCompleted).Return(nil)
 	store.EXPECT().SaveOffset(mock.Anything, int64(11)).Return(nil)
+
+	require.NoError(t, engine.NewProcessor(fetcher, store, engine.NewNopMetrics(), zap.NewNop()).Run(context.Background()))
+}
+
+func TestProcessor_Run_OfferWithdrawn_CancelsTransfer(t *testing.T) {
+	store := mocks.NewStore(t)
+	fetcher := mocks.NewEventFetcher(t)
+	// A withdraw/reject archive decodes with Status "canceled"; the processor must
+	// finalize the row with that status rather than blanket-completing it.
+	canceled := &indexer.Transfer{ContractID: "offer-contract-2", Kind: indexer.TransferKindOffer, Status: indexer.TransferStatusCanceled, Archived: true, LedgerOffset: 12, CreatedAt: time.Unix(1_700_000_600, 0)}
+
+	store.EXPECT().LatestOffset(mock.Anything).Return(int64(0), nil)
+	fetcher.EXPECT().Start(mock.Anything, int64(0))
+	fetcher.EXPECT().Events().Return(feedCh(makeOfferBatch(12, canceled)))
+
+	setupRunInTx(store)
+	store.EXPECT().FinalizeTransfer(mock.Anything, canceled.ContractID, indexer.TransferStatusCanceled).Return(nil)
+	store.EXPECT().SaveOffset(mock.Anything, int64(12)).Return(nil)
 
 	require.NoError(t, engine.NewProcessor(fetcher, store, engine.NewNopMetrics(), zap.NewNop()).Run(context.Background()))
 }

--- a/pkg/indexer/service/http.go
+++ b/pkg/indexer/service/http.go
@@ -219,10 +219,11 @@ func parseTransferQuery(r *http.Request) (indexer.TransferQuery, error) {
 	switch s := r.URL.Query().Get("status"); s {
 	case "", "all":
 		q.Status = ""
-	case indexer.TransferStatusPending, indexer.TransferStatusExpired, indexer.TransferStatusCompleted:
+	case indexer.TransferStatusPending, indexer.TransferStatusExpired,
+		indexer.TransferStatusCompleted, indexer.TransferStatusCanceled:
 		q.Status = s
 	default:
-		return q, apperrors.BadRequestError(nil, "status must be pending, expired, completed, or all")
+		return q, apperrors.BadRequestError(nil, "status must be pending, expired, completed, canceled, or all")
 	}
 	return q, nil
 }

--- a/pkg/indexer/service/http.go
+++ b/pkg/indexer/service/http.go
@@ -220,10 +220,11 @@ func parseTransferQuery(r *http.Request) (indexer.TransferQuery, error) {
 	case "", "all":
 		q.Status = ""
 	case indexer.TransferStatusPending, indexer.TransferStatusExpired,
-		indexer.TransferStatusCompleted, indexer.TransferStatusCanceled:
+		indexer.TransferStatusCompleted, indexer.TransferStatusCanceled,
+		indexer.TransferStatusRejected:
 		q.Status = s
 	default:
-		return q, apperrors.BadRequestError(nil, "status must be pending, expired, completed, canceled, or all")
+		return q, apperrors.BadRequestError(nil, "status must be pending, expired, completed, canceled, rejected, or all")
 	}
 	return q, nil
 }

--- a/pkg/indexer/store/instrumented.go
+++ b/pkg/indexer/store/instrumented.go
@@ -134,13 +134,13 @@ func (s *instrumentedWriteStore) InsertTransfer(ctx context.Context, t *indexer.
 	return err
 }
 
-func (s *instrumentedWriteStore) CompleteTransfer(ctx context.Context, contractID string) error {
-	timer := prometheus.NewTimer(s.metrics.ObserveQueryDuration(OpCompleteTransfer))
+func (s *instrumentedWriteStore) FinalizeTransfer(ctx context.Context, contractID, status string) error {
+	timer := prometheus.NewTimer(s.metrics.ObserveQueryDuration(OpFinalizeTransfer))
 	defer timer.ObserveDuration()
 
-	err := s.inner.CompleteTransfer(ctx, contractID)
+	err := s.inner.FinalizeTransfer(ctx, contractID, status)
 	if err != nil {
-		s.metrics.IncErrors(OpCompleteTransfer)
+		s.metrics.IncErrors(OpFinalizeTransfer)
 	}
 	return err
 }
@@ -233,13 +233,13 @@ func (s *InstrumentedStore) InsertTransfer(ctx context.Context, t *indexer.Trans
 	return err
 }
 
-func (s *InstrumentedStore) CompleteTransfer(ctx context.Context, contractID string) error {
-	timer := prometheus.NewTimer(s.metrics.ObserveQueryDuration(OpCompleteTransfer))
+func (s *InstrumentedStore) FinalizeTransfer(ctx context.Context, contractID, status string) error {
+	timer := prometheus.NewTimer(s.metrics.ObserveQueryDuration(OpFinalizeTransfer))
 	defer timer.ObserveDuration()
 
-	err := s.inner.CompleteTransfer(ctx, contractID)
+	err := s.inner.FinalizeTransfer(ctx, contractID, status)
 	if err != nil {
-		s.metrics.IncErrors(OpCompleteTransfer)
+		s.metrics.IncErrors(OpFinalizeTransfer)
 	}
 	return err
 }

--- a/pkg/indexer/store/metrics.go
+++ b/pkg/indexer/store/metrics.go
@@ -58,7 +58,7 @@ const (
 	OpApplyBalanceDelta StoreOperation = "apply_balance_delta"
 	OpApplySupplyDelta  StoreOperation = "apply_supply_delta"
 	OpInsertTransfer    StoreOperation = "insert_transfer"
-	OpCompleteTransfer  StoreOperation = "complete_transfer"
+	OpFinalizeTransfer  StoreOperation = "finalize_transfer"
 	OpInsertHolding     StoreOperation = "insert_holding"
 	OpTakeHolding       StoreOperation = "take_holding"
 

--- a/pkg/indexer/store/pg.go
+++ b/pkg/indexer/store/pg.go
@@ -362,6 +362,8 @@ func (s *PGStore) ListTransfers(
 			q = q.Where("status = ?", indexer.TransferStatusCompleted)
 		case indexer.TransferStatusCanceled:
 			q = q.Where("status = ?", indexer.TransferStatusCanceled)
+		case indexer.TransferStatusRejected:
+			q = q.Where("status = ?", indexer.TransferStatusRejected)
 		default: // "" = all statuses, no filter
 		}
 

--- a/pkg/indexer/store/pg.go
+++ b/pkg/indexer/store/pg.go
@@ -289,16 +289,19 @@ func (s *PGStore) InsertTransfer(ctx context.Context, t *indexer.Transfer) error
 	return nil
 }
 
-// CompleteTransfer sets a transfer's status to "completed" (offer archived).
+// FinalizeTransfer sets an archived offer's terminal status ("completed" on
+// accept, "canceled" on withdraw/reject). Only still-pending rows are updated —
+// an already-finalized row keeps its status, making stream replays no-ops.
 // No-op when not found.
-func (s *PGStore) CompleteTransfer(ctx context.Context, contractID string) error {
+func (s *PGStore) FinalizeTransfer(ctx context.Context, contractID, status string) error {
 	_, err := s.db.NewUpdate().
 		Model((*TransferDao)(nil)).
-		Set("status = ?", indexer.TransferStatusCompleted).
+		Set("status = ?", status).
 		Where("contract_id = ?", contractID).
+		Where("status = ?", indexer.TransferStatusPending).
 		Exec(ctx)
 	if err != nil {
-		return fmt.Errorf("complete transfer: %w", err)
+		return fmt.Errorf("finalize transfer: %w", err)
 	}
 	return nil
 }
@@ -357,6 +360,8 @@ func (s *PGStore) ListTransfers(
 				Where("expires_at IS NOT NULL AND expires_at <= ?", now)
 		case indexer.TransferStatusCompleted:
 			q = q.Where("status = ?", indexer.TransferStatusCompleted)
+		case indexer.TransferStatusCanceled:
+			q = q.Where("status = ?", indexer.TransferStatusCanceled)
 		default: // "" = all statuses, no filter
 		}
 

--- a/pkg/indexer/store/pg_test.go
+++ b/pkg/indexer/store/pg_test.go
@@ -800,8 +800,16 @@ func TestListTransfers(t *testing.T) {
 		}
 	}
 	// Complete the inbound offer so it reads as a completed transfer for alice.
-	if err := s.CompleteTransfer(ctx, "o-done"); err != nil {
-		t.Fatalf("CompleteTransfer(o-done): %v", err)
+	if err := s.FinalizeTransfer(ctx, "o-done", indexer.TransferStatusCompleted); err != nil {
+		t.Fatalf("FinalizeTransfer(o-done): %v", err)
+	}
+	// Cancel the never-expires outbound offer (sender claim-back / withdraw).
+	if err := s.FinalizeTransfer(ctx, "o-noexp", indexer.TransferStatusCanceled); err != nil {
+		t.Fatalf("FinalizeTransfer(o-noexp): %v", err)
+	}
+	// A replayed archive must not overwrite an already-finalized row.
+	if err := s.FinalizeTransfer(ctx, "o-noexp", indexer.TransferStatusCompleted); err != nil {
+		t.Fatalf("FinalizeTransfer(o-noexp, replay): %v", err)
 	}
 
 	ids := func(list []indexer.Transfer) map[string]string {
@@ -813,15 +821,27 @@ func TestListTransfers(t *testing.T) {
 	}
 	page := indexer.Pagination{Page: 1, Limit: 50}
 
-	// role=sender, status=pending → only live + never-expires (expired excluded).
+	// role=sender, status=pending → only the live offer (expired and canceled excluded).
 	got, total, err := s.ListTransfers(ctx, "alice",
 		indexer.TransferQuery{Role: indexer.TransferRoleSender, Status: indexer.TransferStatusPending}, page)
 	if err != nil {
 		t.Fatalf("sender/pending: %v", err)
 	}
 	m := ids(got)
-	if total != 2 || len(m) != 2 || m["o-live"] != indexer.TransferStatusPending || m["o-noexp"] != indexer.TransferStatusPending {
+	if total != 1 || m["o-live"] != indexer.TransferStatusPending {
 		t.Fatalf("sender/pending unexpected: total=%d m=%v", total, m)
+	}
+
+	// role=sender, status=canceled → the withdrawn offer, still canceled after the
+	// replayed finalize (the pending-only guard kept the first terminal status).
+	got, total, err = s.ListTransfers(ctx, "alice",
+		indexer.TransferQuery{Role: indexer.TransferRoleSender, Status: indexer.TransferStatusCanceled}, page)
+	if err != nil {
+		t.Fatalf("sender/canceled: %v", err)
+	}
+	m = ids(got)
+	if total != 1 || m["o-noexp"] != indexer.TransferStatusCanceled {
+		t.Fatalf("sender/canceled unexpected: total=%d m=%v", total, m)
 	}
 
 	// role=sender, status=expired → only the past-dated pending offer, surfaced as expired.
@@ -872,7 +892,7 @@ func TestListTransfers_DirectAndOffer(t *testing.T) {
 	if err := s.InsertTransfer(ctx, makeOffer("of-usdcx", "carol", "alice", 2, nil)); err != nil {
 		t.Fatalf("insert offer: %v", err)
 	}
-	if err := s.CompleteTransfer(ctx, "of-usdcx"); err != nil {
+	if err := s.FinalizeTransfer(ctx, "of-usdcx", indexer.TransferStatusCompleted); err != nil {
 		t.Fatalf("complete offer: %v", err)
 	}
 
@@ -912,7 +932,7 @@ func TestListPendingTransfers(t *testing.T) {
 	if err := s.InsertTransfer(ctx, makeOffer("p-done", "fred", "carol", 3, nil)); err != nil {
 		t.Fatalf("insert done offer: %v", err)
 	}
-	if err := s.CompleteTransfer(ctx, "p-done"); err != nil {
+	if err := s.FinalizeTransfer(ctx, "p-done", indexer.TransferStatusCompleted); err != nil {
 		t.Fatalf("complete offer: %v", err)
 	}
 	if err := s.InsertTransfer(ctx, makeDirect("p-direct", "gita", "hank", 4)); err != nil {

--- a/pkg/indexer/store/pg_test.go
+++ b/pkg/indexer/store/pg_test.go
@@ -787,12 +787,14 @@ func TestListTransfers(t *testing.T) {
 	past := time.Now().UTC().Add(-time.Hour)
 	future := time.Now().UTC().Add(time.Hour)
 
-	// alice sends three offers (live / expired / never-expires) and receives one completed.
+	// alice sends four offers (live / expired / never-expires / to-be-rejected)
+	// and receives one completed.
 	offers := []*indexer.Transfer{
 		makeOffer("o-live", "alice", "bob", 1, &future),
 		makeOffer("o-expired", "alice", "carol", 2, &past),
 		makeOffer("o-noexp", "alice", "eve", 3, nil),
 		makeOffer("o-done", "dave", "alice", 4, &past),
+		makeOffer("o-rejected", "alice", "frank", 5, &future),
 	}
 	for _, o := range offers {
 		if err := s.InsertTransfer(ctx, o); err != nil {
@@ -810,6 +812,10 @@ func TestListTransfers(t *testing.T) {
 	// A replayed archive must not overwrite an already-finalized row.
 	if err := s.FinalizeTransfer(ctx, "o-noexp", indexer.TransferStatusCompleted); err != nil {
 		t.Fatalf("FinalizeTransfer(o-noexp, replay): %v", err)
+	}
+	// Reject the last outbound offer (receiver declined).
+	if err := s.FinalizeTransfer(ctx, "o-rejected", indexer.TransferStatusRejected); err != nil {
+		t.Fatalf("FinalizeTransfer(o-rejected): %v", err)
 	}
 
 	ids := func(list []indexer.Transfer) map[string]string {
@@ -842,6 +848,19 @@ func TestListTransfers(t *testing.T) {
 	m = ids(got)
 	if total != 1 || m["o-noexp"] != indexer.TransferStatusCanceled {
 		t.Fatalf("sender/canceled unexpected: total=%d m=%v", total, m)
+	}
+
+	// role=sender, status=rejected → only the receiver-declined offer; it is not
+	// conflated with canceled (and vice versa — the canceled filter above found
+	// exactly one row).
+	got, total, err = s.ListTransfers(ctx, "alice",
+		indexer.TransferQuery{Role: indexer.TransferRoleSender, Status: indexer.TransferStatusRejected}, page)
+	if err != nil {
+		t.Fatalf("sender/rejected: %v", err)
+	}
+	m = ids(got)
+	if total != 1 || m["o-rejected"] != indexer.TransferStatusRejected {
+		t.Fatalf("sender/rejected unexpected: total=%d m=%v", total, m)
 	}
 
 	// role=sender, status=expired → only the past-dated pending offer, surfaced as expired.

--- a/pkg/indexer/types.go
+++ b/pkg/indexer/types.go
@@ -8,13 +8,16 @@ import "time"
 // A transfer is "completed" once settled; an offer that hasn't settled is
 // "pending" (or "expired" once past its executeBefore). "expired" is a derived
 // status — it is never persisted, only computed at read time from a still-pending
-// row whose ExpiresAt is in the past. "canceled" is persisted when the offer is
-// archived by a withdraw (sender claim-back) or reject instead of an accept.
+// row whose ExpiresAt is in the past. "canceled" is persisted when the sender
+// withdraws (claims back) the offer; "rejected" when the receiver declines it.
+// Both mean the offer did not settle and the escrowed funds returned to the
+// sender — they differ only in who ended it.
 const (
 	TransferStatusPending   = "pending"
 	TransferStatusExpired   = "expired"
 	TransferStatusCompleted = "completed"
 	TransferStatusCanceled  = "canceled"
+	TransferStatusRejected  = "rejected"
 )
 
 // Transfer kind values, recorded on Transfer.Kind / the indexer_transfers table.
@@ -24,7 +27,7 @@ const (
 	TransferKindDirect = "direct"
 	// TransferKindOffer is a 2-step (offer-based) transfer, e.g. USDCx. It starts
 	// "pending" on the TransferOffer CREATE and on its ARCHIVE becomes "completed"
-	// (accepted) or "canceled" (withdrawn/rejected).
+	// (accepted), "canceled" (sender withdrew), or "rejected" (receiver declined).
 	TransferKindOffer = "offer"
 )
 

--- a/pkg/indexer/types.go
+++ b/pkg/indexer/types.go
@@ -44,7 +44,7 @@ const (
 // A zero Role defaults to receiver; a zero Status means "all statuses".
 type TransferQuery struct {
 	Role   TransferRole
-	Status string // "" = all; pending / expired / completed / canceled
+	Status string // "" = all; pending / expired / completed / canceled / rejected
 }
 
 // Transfer is a token transfer, generalized across all tokens and both transfer

--- a/pkg/indexer/types.go
+++ b/pkg/indexer/types.go
@@ -8,11 +8,13 @@ import "time"
 // A transfer is "completed" once settled; an offer that hasn't settled is
 // "pending" (or "expired" once past its executeBefore). "expired" is a derived
 // status — it is never persisted, only computed at read time from a still-pending
-// row whose ExpiresAt is in the past.
+// row whose ExpiresAt is in the past. "canceled" is persisted when the offer is
+// archived by a withdraw (sender claim-back) or reject instead of an accept.
 const (
 	TransferStatusPending   = "pending"
 	TransferStatusExpired   = "expired"
 	TransferStatusCompleted = "completed"
+	TransferStatusCanceled  = "canceled"
 )
 
 // Transfer kind values, recorded on Transfer.Kind / the indexer_transfers table.
@@ -21,7 +23,8 @@ const (
 	// settled transfer. Always Status "completed".
 	TransferKindDirect = "direct"
 	// TransferKindOffer is a 2-step (offer-based) transfer, e.g. USDCx. It starts
-	// "pending" on the TransferOffer CREATE and becomes "completed" on its ARCHIVE.
+	// "pending" on the TransferOffer CREATE and on its ARCHIVE becomes "completed"
+	// (accepted) or "canceled" (withdrawn/rejected).
 	TransferKindOffer = "offer"
 )
 
@@ -38,19 +41,20 @@ const (
 // A zero Role defaults to receiver; a zero Status means "all statuses".
 type TransferQuery struct {
 	Role   TransferRole
-	Status string // "" = all; pending / expired / completed
+	Status string // "" = all; pending / expired / completed / canceled
 }
 
 // Transfer is a token transfer, generalized across all tokens and both transfer
 // shapes. Direct transfers (Kind "direct") are our atomic CIP-56
 // TokenTransferEvents; 2-step transfers (Kind "offer") are offer-based, e.g.
 // USDCx. Rows live in indexer_transfers with a mutable status lifecycle: offers
-// start "pending" and become "completed" on archive; direct transfers are always
-// "completed". "expired" is derived at read time and never stored.
+// start "pending" and on archive become "completed" (accepted) or "canceled"
+// (withdrawn/rejected); direct transfers are always "completed". "expired" is
+// derived at read time and never stored.
 type Transfer struct {
 	ContractID      string     `json:"contract_id"`
 	Kind            string     `json:"kind"`   // "direct" | "offer"
-	Status          string     `json:"status"` // "pending" | "expired" | "completed"
+	Status          string     `json:"status"` // "pending" | "expired" | "completed" | "canceled"
 	FromPartyID     string     `json:"from_party_id"`
 	ToPartyID       string     `json:"to_party_id"`
 	InstrumentAdmin string     `json:"instrument_admin"`
@@ -62,7 +66,8 @@ type Transfer struct {
 	CreatedAt       time.Time  `json:"created_at"`
 
 	// Archived is a decode-time signal only — not persisted. Set by the offer
-	// decoder on an ARCHIVED event so the processor completes the transfer.
+	// decoder on an ARCHIVED event so the processor finalizes the transfer with
+	// the terminal Status the decoder derived from the archiving choice.
 	Archived bool `json:"-"`
 }
 

--- a/pkg/transfer/http.go
+++ b/pkg/transfer/http.go
@@ -184,7 +184,7 @@ func (h *httpHandler) listIncoming(w http.ResponseWriter, r *http.Request) error
 
 // listOutgoing returns the queried address's outbound TransferOffers. Like
 // listIncoming it is unauthenticated and takes the EVM address as a query param;
-// ?status= filters by pending|expired|accepted|canceled|all (default all).
+// ?status= filters by pending|expired|accepted|canceled|rejected|all (default all).
 func (h *httpHandler) listOutgoing(w http.ResponseWriter, r *http.Request) error {
 	evmAddr := strings.TrimSpace(r.URL.Query().Get("address"))
 	if evmAddr == "" {
@@ -252,8 +252,10 @@ func parseOutgoingStatus(r *http.Request) (string, error) {
 		return indexer.TransferStatusCompleted, nil
 	case "canceled":
 		return indexer.TransferStatusCanceled, nil
+	case "rejected":
+		return indexer.TransferStatusRejected, nil
 	default:
-		return "", apperrors.BadRequestError(nil, "status must be pending, expired, completed, canceled, or all")
+		return "", apperrors.BadRequestError(nil, "status must be pending, expired, completed, canceled, rejected, or all")
 	}
 }
 

--- a/pkg/transfer/http.go
+++ b/pkg/transfer/http.go
@@ -184,7 +184,7 @@ func (h *httpHandler) listIncoming(w http.ResponseWriter, r *http.Request) error
 
 // listOutgoing returns the queried address's outbound TransferOffers. Like
 // listIncoming it is unauthenticated and takes the EVM address as a query param;
-// ?status= filters by pending|expired|accepted|all (default all).
+// ?status= filters by pending|expired|accepted|canceled|all (default all).
 func (h *httpHandler) listOutgoing(w http.ResponseWriter, r *http.Request) error {
 	evmAddr := strings.TrimSpace(r.URL.Query().Get("address"))
 	if evmAddr == "" {
@@ -250,8 +250,10 @@ func parseOutgoingStatus(r *http.Request) (string, error) {
 		return indexer.TransferStatusExpired, nil
 	case "completed", "accepted":
 		return indexer.TransferStatusCompleted, nil
+	case "canceled":
+		return indexer.TransferStatusCanceled, nil
 	default:
-		return "", apperrors.BadRequestError(nil, "status must be pending, expired, completed, or all")
+		return "", apperrors.BadRequestError(nil, "status must be pending, expired, completed, canceled, or all")
 	}
 }
 

--- a/pkg/transfer/service.go
+++ b/pkg/transfer/service.go
@@ -452,6 +452,7 @@ func (s *TransferService) ListOutgoing(
 			InstrumentAdmin: o.InstrumentAdmin,
 			InstrumentID:    o.InstrumentID,
 			Status:          o.Status,
+			CreatedAt:       o.CreatedAt.Format(time.RFC3339),
 		}
 		if o.ExpiresAt != nil {
 			item.ExpiresAt = o.ExpiresAt.Format(time.RFC3339)

--- a/pkg/transfer/service.go
+++ b/pkg/transfer/service.go
@@ -67,8 +67,8 @@ type Service interface {
 	// (party IDs truncated) to keep that from leaking counterparties.
 	ListIncoming(ctx context.Context, evmAddr string, p indexer.Pagination) (*IncomingTransfersList, error)
 	// ListOutgoing returns one page of the user's outbound transfers filtered
-	// by status (pending / expired / completed / all). Like ListIncoming it is
-	// unauthenticated and truncates party IDs.
+	// by status (pending / expired / completed / canceled / all). Like ListIncoming
+	// it is unauthenticated and truncates party IDs.
 	ListOutgoing(ctx context.Context, evmAddr string, status string, p indexer.Pagination) (*OutgoingTransfersList, error)
 	// ListCompleted returns one page of the user's settled transfers across all
 	// tokens (TokenTransferEvents and accepted TransferOffers), newest first.
@@ -606,6 +606,9 @@ func (s *TransferService) claimableTransfer(
 	}
 	if t.Status == indexer.TransferStatusCompleted {
 		return nil, apperrors.BadRequestError(nil, "transfer already completed; nothing to claim back")
+	}
+	if t.Status == indexer.TransferStatusCanceled {
+		return nil, apperrors.BadRequestError(nil, "transfer already canceled; nothing to claim back")
 	}
 	return t, nil
 }

--- a/pkg/transfer/service.go
+++ b/pkg/transfer/service.go
@@ -610,6 +610,10 @@ func (s *TransferService) claimableTransfer(
 	if t.Status == indexer.TransferStatusCanceled {
 		return nil, apperrors.BadRequestError(nil, "transfer already canceled; nothing to claim back")
 	}
+	if t.Status == indexer.TransferStatusRejected {
+		// The receiver's reject already returned the escrowed funds to the sender.
+		return nil, apperrors.BadRequestError(nil, "transfer was rejected by the receiver; nothing to claim back")
+	}
 	return t, nil
 }
 

--- a/pkg/transfer/service.go
+++ b/pkg/transfer/service.go
@@ -67,8 +67,8 @@ type Service interface {
 	// (party IDs truncated) to keep that from leaking counterparties.
 	ListIncoming(ctx context.Context, evmAddr string, p indexer.Pagination) (*IncomingTransfersList, error)
 	// ListOutgoing returns one page of the user's outbound transfers filtered
-	// by status (pending / expired / completed / canceled / all). Like ListIncoming
-	// it is unauthenticated and truncates party IDs.
+	// by status (pending / expired / completed / canceled / rejected / all).
+	// Like ListIncoming it is unauthenticated and truncates party IDs.
 	ListOutgoing(ctx context.Context, evmAddr string, status string, p indexer.Pagination) (*OutgoingTransfersList, error)
 	// ListCompleted returns one page of the user's settled transfers across all
 	// tokens (TokenTransferEvents and accepted TransferOffers), newest first.

--- a/pkg/transfer/types.go
+++ b/pkg/transfer/types.go
@@ -76,8 +76,8 @@ type IncomingTransfersList struct {
 }
 
 // OutgoingTransfer is a single TransferOffer the queried party sent. Mirrors
-// IncomingTransfer but adds Status (pending/expired/completed/canceled) and
-// ExpiresAt so callers can track an outbound offer through its lifecycle.
+// IncomingTransfer but adds Status (pending/expired/completed/canceled/rejected)
+// and ExpiresAt so callers can track an outbound offer through its lifecycle.
 type OutgoingTransfer struct {
 	ContractID      string `json:"contract_id"`
 	SenderPartyID   string `json:"sender_party_id"`

--- a/pkg/transfer/types.go
+++ b/pkg/transfer/types.go
@@ -86,6 +86,7 @@ type OutgoingTransfer struct {
 	InstrumentAdmin string `json:"instrument_admin"`
 	InstrumentID    string `json:"instrument_id"`
 	Status          string `json:"status"`
+	CreatedAt       string `json:"created_at"`           // RFC3339; ledger effective time of the offer's creation
 	ExpiresAt       string `json:"expires_at,omitempty"` // RFC3339; omitted when the offer never expires
 	Symbol          string `json:"symbol,omitempty"`
 	Decimals        int    `json:"decimals,omitempty"`

--- a/pkg/transfer/types.go
+++ b/pkg/transfer/types.go
@@ -76,8 +76,8 @@ type IncomingTransfersList struct {
 }
 
 // OutgoingTransfer is a single TransferOffer the queried party sent. Mirrors
-// IncomingTransfer but adds Status (pending/expired/accepted) and ExpiresAt so
-// callers can track an outbound offer through its lifecycle.
+// IncomingTransfer but adds Status (pending/expired/completed/canceled) and
+// ExpiresAt so callers can track an outbound offer through its lifecycle.
 type OutgoingTransfer struct {
 	ContractID      string `json:"contract_id"`
 	SenderPartyID   string `json:"sender_party_id"`

--- a/tests/e2e/tests/api/cross_transfer_test.go
+++ b/tests/e2e/tests/api/cross_transfer_test.go
@@ -460,6 +460,10 @@ func TestUSDCx_ClaimBackExpiredOffer_ToExternalParty(t *testing.T) {
 	if canceled.Status != indexer.TransferStatusCanceled {
 		t.Fatalf("expected canceled status on withdrawn offer, got %q", canceled.Status)
 	}
+	// created_at is what history UIs sort/group canceled rows by — must be set.
+	if canceled.CreatedAt == "" {
+		t.Fatal("expected a non-empty created_at on the canceled offer")
+	}
 
 	// And it must not show up in the completed history as a settled transfer.
 	// (The indexer has already processed the archive — the canceled row above —

--- a/tests/e2e/tests/api/cross_transfer_test.go
+++ b/tests/e2e/tests/api/cross_transfer_test.go
@@ -398,6 +398,11 @@ func TestUSDCx_OutgoingOffer_ExpiresAfterValidity(t *testing.T) {
 // the offer expires; the sender claims it back via the custodial withdraw endpoint; the
 // offer then leaves the expired set (archived on-ledger) and the sender's USDCx balance
 // is whole again (the locked funds are reclaimed).
+//
+// It also pins down the withdrawn offer's terminal status: the indexer reads the
+// archiving choice (TransferInstruction_Withdraw) from the ledger stream and marks the
+// row "canceled" — the offer must surface under the outgoing canceled filter and must
+// NOT appear in the completed history as if it had settled.
 func TestUSDCx_ClaimBackExpiredOffer_ToExternalParty(t *testing.T) {
 	t.Parallel()
 
@@ -447,6 +452,27 @@ func TestUSDCx_ClaimBackExpiredOffer_ToExternalParty(t *testing.T) {
 	// sender's USDCx balance is whole again (locked funds reclaimed).
 	sys.DSL.WaitForOutgoingTransferGone(ctx, t, sys.Accounts.User1, indexer.TransferStatusExpired, expired.ContractID)
 	sys.DSL.WaitForAPIBalance(ctx, t, &sys.Tokens.USDCx, sys.Accounts.User1.Address, "5")
+
+	// The withdrawn offer is marked canceled (not completed): it surfaces under the
+	// outgoing canceled filter with its terminal status set.
+	canceled := sys.DSL.WaitForOutgoingTransfer(ctx, t, sys.Accounts.User1, indexer.TransferStatusCanceled,
+		func(o transfer.OutgoingTransfer) bool { return o.ContractID == expired.ContractID })
+	if canceled.Status != indexer.TransferStatusCanceled {
+		t.Fatalf("expected canceled status on withdrawn offer, got %q", canceled.Status)
+	}
+
+	// And it must not show up in the completed history as a settled transfer.
+	// (The indexer has already processed the archive — the canceled row above —
+	// so a single read is race-free.)
+	completed, err := sys.APIServer.ListCompletedTransfers(ctx, &sys.Accounts.User1)
+	if err != nil {
+		t.Fatalf("list completed: %v", err)
+	}
+	for _, c := range completed.Items {
+		if c.ContractID == expired.ContractID {
+			t.Fatalf("withdrawn offer %s must not appear in completed history: %+v", expired.ContractID, c)
+		}
+	}
 }
 
 // TestUSDCx_ListIncoming_PendingOffer verifies the incoming API surfaces a


### PR DESCRIPTION
## Issue

When a sender cancels (claims back) a USDCx transfer offer, the transfer still shows up as a **completed sent transfer** in `/api/v2/transfer/completed` — as if the recipient had accepted it. Wallets like Loop correctly show the same transfer as *Canceled*.

Cause: the indexer marked an offer `completed` on **any** archive event. The ledger stream ran in `ACS_DELTA` shape, where an archive event doesn't say *which choice* archived the contract — so an accept and a cancel looked identical.

## Fix

- Stream in `LEDGER_EFFECTS` shape so archives arrive with the choice that caused them (`pkg/cantonsdk/streaming`).
- Map the choice to a terminal status: `Accept` → `completed`, `Withdraw` (sender claim-back) → new persisted **`canceled`** status, `Reject` (receiver declined) → new persisted **`rejected`** status; unknown choices keep the old behavior (`completed` + warn log + metric).
- `FinalizeTransfer` only updates still-pending rows, so replays can't overwrite a terminal status. No DB migration needed.
- `?status=canceled` and `?status=rejected` supported on the outgoing list (api-server + indexer admin API); claim-back rejects offers already in a terminal state; canceled/rejected offers no longer appear in the completed history.

Note for the dapp: `canceled` and `rejected` are separate filter values — query/badge both. The middleware has no reject endpoint, so `rejected` rows only ever come from third-party wallets declining an offer.

## Hardening (self-review follow-ups)

- **`acs_delta` gate**: `LEDGER_EFFECTS` delivers more than the old stakeholder view (witnessed events, transient contracts), which could leave phantom balances if a witnessed holding create's archive is never delivered. The decoder now only processes events flagged `acs_delta` — exactly what the old `ACS_DELTA` stream delivered — while still reading the choice name.
- New `offer_unknown_archive_choices_total` metric: any offer archived by a choice outside the known mapping (e.g. a registry-side cleanup choice) increments it, so mislabeling is alertable instead of log-only.
- Processor guards against an empty terminal status (defensive).

## Testing

- Unit: choice→status mapping, processor finalize paths, store filter + replay guard.
- E2E: full `api` and `indexer` suites pass on a fresh devstack. `TestUSDCx_ClaimBackExpiredOffer_ToExternalParty` now asserts the withdrawn offer surfaces as `canceled` and is absent from the completed list.

Note: rows mis-marked `completed` before this change can only be repaired by re-indexing from ledger begin.
