### PR TITLE
feat: ledger tx id on offer-based transfers

### DIFF
--- a/pkg/indexer/engine/decoder.go
+++ b/pkg/indexer/engine/decoder.go
@@ -182,6 +182,7 @@ func NewOfferDecoder(
 			// TransferOffer CreateArguments: {operator, provider, transfer{...}}.
 			// Receiver/sender/amount/instrumentId all live inside the nested transfer record.
 			transfer.Status = indexer.TransferStatusPending
+			transfer.TxID = tx.UpdateID
 			transfer.ToPartyID = ev.NestedPartyField("transfer", "receiver")
 			transfer.FromPartyID = ev.NestedPartyField("transfer", "sender")
 			transfer.Amount = ev.NestedNumericField("transfer", "amount")

--- a/pkg/indexer/engine/decoder_test.go
+++ b/pkg/indexer/engine/decoder_test.go
@@ -3,6 +3,7 @@
 package engine
 
 import (
+	"maps"
 	"testing"
 	"time"
 
@@ -45,9 +46,7 @@ func makeTransferEvent(contractID string, fromParty, toParty streaming.FieldValu
 		"timestamp": streaming.MakeTimestampField(time.Unix(1_700_000_000, 0)),
 		"meta":      streaming.MakeNoneField(),
 	}
-	for k, v := range extra {
-		fields[k] = v
-	}
+	maps.Copy(fields, extra)
 	return streaming.NewLedgerEvent(contractID, "pkg-id", tokenTransferEventModule, tokenTransferEventEntity, true, fields)
 }
 
@@ -113,6 +112,30 @@ func TestOfferDecoder_ArchiveChoiceMapsTerminalStatus(t *testing.T) {
 		assert.True(t, tr.Archived, "choice %q", tc.choice)
 		assert.Equal(t, tc.want, tr.Status, "choice %q", tc.choice)
 	}
+}
+
+func TestOfferDecoder_CreateCarriesLedgerTxID(t *testing.T) {
+	dec := NewOfferDecoder("pkg-id", NewNopMetrics(), zap.NewNop())
+
+	ev := streaming.NewLedgerEvent("offer-1", "pkg-id", transferOfferModule, transferOfferEntity, true,
+		map[string]streaming.FieldValue{
+			"transfer": streaming.MakeRecordField(map[string]streaming.FieldValue{
+				"sender":   streaming.MakePartyField(testSender),
+				"receiver": streaming.MakePartyField(testRecipient),
+				"amount":   streaming.MakeNumericField(testAmount),
+				"instrumentId": streaming.MakeRecordField(map[string]streaming.FieldValue{
+					"admin": streaming.MakePartyField(testInstrumentAdmin),
+					"id":    streaming.MakeTextField(testInstrumentID),
+				}),
+			}),
+		})
+
+	tr, ok := dec(makeTx(1), ev)
+	require.True(t, ok)
+	assert.Equal(t, indexer.TransferStatusPending, tr.Status)
+	assert.Equal(t, "update-1", tr.TxID)
+	assert.Equal(t, testSender, tr.FromPartyID)
+	assert.Equal(t, testRecipient, tr.ToPartyID)
 }
 
 func TestHoldingDecoder_LockField(t *testing.T) {


### PR DESCRIPTION
## Problem

Offer-based transfers (USDCx) in the transfer history APIs (`/api/v2/transfer/outgoing`, `/completed`) return an empty `tx_id`, so there is no ledger-level identifier for them. Direct CIP-56 transfers already carry the Canton ledger update id via the `TokenTransferEvent` decoder, but `NewOfferDecoder` never set it and `FinalizeTransfer` only updates `status`.

## Change

Set `TxID = tx.UpdateID` when decoding a `TransferOffer` CREATE. The pending row is inserted with the update id of the offer-creation transaction, and finalization preserves it — so every offer-based transfer now carries a unique ledger identifier through its whole lifecycle. This matches the rest of the row's semantics (`created_at`, parties, amount all describe the offer creation).

No API or store changes: the `tx_id` column and the response field already exist for direct transfers.

## Notes

- The id identifies the offer-**creation** ledger transaction, not the settling one. Carrying the settlement update id instead would require plumbing it through `FinalizeTransfer` (interface, store, instrumented wrappers, mock) — deliberately skipped to keep this minimal.
- Existing rows are not backfilled; only offers indexed after deploy get a `tx_id`.

## Testing

Added `TestOfferDecoder_CreateCarriesLedgerTxID` (the offer create path had no decode test). Also replaced a map-copy loop in the test helper with `maps.Copy` per linter.