### PR TITLE
feat(relayer): xreserve adapter — USDCx inbound tracking

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -195,8 +195,11 @@ services:
       target: relayer
     container_name: canton-bridge-relayer
     ports:
-      - "8080:8080"
-      - "9090:9090"
+      # Bind to loopback only: the api-server reaches the relayer over the
+      # internal bridge-network by service name, so the API (incl. the
+      # transfer-registration endpoint) never needs host-wide exposure.
+      - "127.0.0.1:8080:8080"
+      - "127.0.0.1:9090:9090"
     volumes:
       - config_state:/app/state:ro
     command: ["-config", "/app/state/config.yaml"]

--- a/pkg/app/relayer/server.go
+++ b/pkg/app/relayer/server.go
@@ -15,11 +15,13 @@ import (
 	sharedmetrics "github.com/chainsafe/canton-middleware/internal/metrics"
 	apphttp "github.com/chainsafe/canton-middleware/pkg/app/http"
 	canton "github.com/chainsafe/canton-middleware/pkg/cantonsdk/client"
+	cantontkn "github.com/chainsafe/canton-middleware/pkg/cantonsdk/token"
 	"github.com/chainsafe/canton-middleware/pkg/config"
 	"github.com/chainsafe/canton-middleware/pkg/ethereum"
 	"github.com/chainsafe/canton-middleware/pkg/log"
 	"github.com/chainsafe/canton-middleware/pkg/pgutil"
 	relayerpkg "github.com/chainsafe/canton-middleware/pkg/relayer"
+	"github.com/chainsafe/canton-middleware/pkg/relayer/bridges/xreserve"
 	relayerengine "github.com/chainsafe/canton-middleware/pkg/relayer/engine"
 	relayersvc "github.com/chainsafe/canton-middleware/pkg/relayer/service"
 	relayerstore "github.com/chainsafe/canton-middleware/pkg/relayer/store"
@@ -100,7 +102,7 @@ func (s *Server) Run() error {
 
 	// TokenBridge adapter pipelines (multi-token, #356) run alongside the
 	// legacy single-token engine above until its port to an adapter (#372).
-	registry, err := buildBridgeRegistry(cfg.Bridge)
+	registry, err := buildBridgeRegistry(cfg.Bridge, cantonClient.Token, logger)
 	if err != nil {
 		return err
 	}
@@ -112,7 +114,7 @@ func (s *Server) Run() error {
 		defer driver.Stop()
 	}
 
-	router := s.newRouter(store, engine, httpMetrics, logger)
+	router := s.newRouter(store, engine, registry.Keys(), httpMetrics, logger)
 
 	g, gCtx := errgroup.WithContext(ctx)
 	s.registerServers(g, gCtx, router, logger)
@@ -121,14 +123,32 @@ func (s *Server) Run() error {
 
 // buildBridgeRegistry constructs the TokenBridge adapter registry from the
 // per-token config. Each mechanism registers a case here as it lands
-// (xreserve: #357, wayfinder: #372).
-func buildBridgeRegistry(cfg *relayerpkg.Config) (*relayerpkg.Registry, error) {
+// (wayfinder: #372).
+func buildBridgeRegistry(
+	cfg *relayerpkg.Config, cantonToken cantontkn.Token, logger *zap.Logger,
+) (*relayerpkg.Registry, error) {
 	registry := relayerpkg.NewRegistry()
+
+	xreserveTokens := make(map[string]relayerpkg.TokenConfig)
 	for symbol, tc := range cfg.Tokens {
-		// No adapter mechanisms are implemented yet, so any configured token
-		// is rejected until its adapter lands and adds a dispatch case here.
-		return nil, fmt.Errorf("token %s: unknown bridge mechanism %q", symbol, tc.Mechanism)
+		switch tc.Mechanism {
+		case xreserve.Mechanism:
+			xreserveTokens[symbol] = tc
+		default:
+			return nil, fmt.Errorf("token %s: unknown bridge mechanism %q", symbol, tc.Mechanism)
+		}
 	}
+
+	if len(xreserveTokens) > 0 {
+		bridge, err := xreserve.New(xreserveTokens, cantonToken, logger)
+		if err != nil {
+			return nil, fmt.Errorf("build xreserve adapter: %w", err)
+		}
+		if err = registry.Register(bridge); err != nil {
+			return nil, err
+		}
+	}
+
 	return registry, nil
 }
 
@@ -155,7 +175,11 @@ func (s *Server) registerServers(g *errgroup.Group, gCtx context.Context, router
 }
 
 func (s *Server) newRouter(
-	store relayersvc.Store, engine *relayerengine.Engine, metrics *apphttp.HTTPMetrics, logger *zap.Logger,
+	store relayersvc.Store,
+	engine *relayerengine.Engine,
+	bridgeKeys []string,
+	metrics *apphttp.HTTPMetrics,
+	logger *zap.Logger,
 ) http.Handler {
 	r := chi.NewRouter()
 	r.Use(middleware.RequestID)
@@ -169,7 +193,7 @@ func (s *Server) newRouter(
 		_, _ = w.Write([]byte("OK"))
 	})
 
-	svc := relayersvc.NewLog(relayersvc.NewService(store), logger)
+	svc := relayersvc.NewLog(relayersvc.NewService(store, bridgeKeys), logger)
 	relayersvc.RegisterRoutes(r, svc, engine, logger)
 
 	return r

--- a/pkg/app/relayer/server.go
+++ b/pkg/app/relayer/server.go
@@ -194,7 +194,12 @@ func (s *Server) newRouter(
 	})
 
 	svc := relayersvc.NewLog(relayersvc.NewService(store, bridgeKeys), logger)
-	relayersvc.RegisterRoutes(r, svc, engine, logger)
+	// Optional bearer token guarding the internal registration endpoint. When
+	// unset (single-host/dev), the guard is disabled; set it (and the matching
+	// api-server value) in any topology where the relayer API is reachable
+	// beyond the api-server.
+	registrationToken := os.Getenv("RELAYER_REGISTRATION_TOKEN")
+	relayersvc.RegisterRoutes(r, svc, engine, registrationToken, logger)
 
 	return r
 }

--- a/pkg/config/defaults/config.relayer.docker.yaml
+++ b/pkg/config/defaults/config.relayer.docker.yaml
@@ -79,6 +79,19 @@ bridge:
   eth_lookback_blocks: 1000
   eth_token_contract: "0x5fbdb2315678afecb367f032d93f642f64180aa3"
 
+  # TokenBridge adapters (multi-token). USDCx via Circle xReserve — observer
+  # mechanism, so the relayer only tracks transfers the api-server registers.
+  # attestation_url points at the devstack stub; real Circle endpoint is #360.
+  tokens:
+    USDCX:
+      mechanism: xreserve
+      evm_address: "0xC1A0000000000000000000000000000000000001"
+      decimals: 6
+      xreserve:
+        attestation_url: "http://usdcx-registry:8090"
+        instrument_admin: "${CANTON_USDCX_ISSUER_PARTY}"
+        instrument_id: "USDCx"
+
 monitoring:
   enabled: true
   server:

--- a/pkg/config/defaults/config.relayer.local-devnet.yaml
+++ b/pkg/config/defaults/config.relayer.local-devnet.yaml
@@ -80,6 +80,19 @@ bridge:
   eth_lookback_blocks: 200
   eth_token_contract: "0x90cb4f9eF6d682F4338f0E360B9C079fbb32048e"
 
+  # TokenBridge adapters (multi-token). USDCx via Circle xReserve — observer
+  # mechanism, so the relayer only tracks transfers the api-server registers.
+  # Sepolia USDC + xReserve addresses; confirm the attestation endpoint (#360).
+  tokens:
+    USDCX:
+      mechanism: xreserve
+      evm_address: "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
+      decimals: 6
+      xreserve:
+        attestation_url: "https://xreserve-api.circle.com"
+        instrument_admin: "${CANTON_USDCX_ISSUER_PARTY}"
+        instrument_id: "USDCx"
+
 monitoring:
   enabled: true
   server:

--- a/pkg/config/defaults/config.relayer.mainnet.yaml
+++ b/pkg/config/defaults/config.relayer.mainnet.yaml
@@ -75,6 +75,9 @@ bridge:
   eth_start_block: 0
   eth_lookback_blocks: 5000
   eth_token_contract: "${ETHEREUM_TOKEN_CONTRACT}"
+  # USDCx (xReserve) bridging is not enabled on mainnet yet — needs DA
+  # Utilities onboarding + the confirmed Circle addresses/endpoint (#360).
+  # Add a `tokens:` block mirroring the devnet configs once those are pinned.
 
 monitoring:
   enabled: true

--- a/pkg/relayer/bridges/xreserve/bridge.go
+++ b/pkg/relayer/bridges/xreserve/bridge.go
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package xreserve implements the TokenBridge adapter for tokens bridged by
+// Circle xReserve (USDCx). It is an observer mechanism: Circle executes the
+// bridge, so the adapter exposes no event sources and never submits anything
+// for deposits — transfers are registered at initiation time via the relayer
+// API and Step only tracks their progress.
+//
+// Deposit stage sequence:
+//
+//	"" -> awaiting_attestation -> awaiting_mint -> completed (stage "minted")
+//
+// Mint detection is balance-based: the recipient's instrument balance is
+// snapshotted on the first step (before Ethereum finality, so before any mint
+// for this deposit can exist) and the transfer completes once the balance has
+// grown by the deposited amount. This assumes the transfer is registered
+// promptly after the deposit transaction is sent, well within the ~15 minute
+// attestation window.
+package xreserve
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"go.uber.org/zap"
+
+	"github.com/chainsafe/canton-middleware/pkg/relayer"
+)
+
+// Mechanism is the TokenConfig mechanism value and registry bridge key.
+const Mechanism = "xreserve"
+
+// Deposit stages.
+const (
+	StageAwaitingAttestation = "awaiting_attestation"
+	StageAwaitingMint        = "awaiting_mint"
+	StageMinted              = "minted"
+)
+
+// Metadata keys accumulated on transfers.
+const (
+	metaBaselineBalance = "baseline_balance"
+	metaAttestationID   = "attestation_id"
+)
+
+const (
+	defaultAttestationPollInterval = time.Minute
+	defaultMintPollInterval        = 15 * time.Second
+	defaultHTTPTimeout             = 10 * time.Second
+)
+
+// tokenRuntime is one configured xreserve token with its attestation client.
+type tokenRuntime struct {
+	symbol string
+	cfg    relayer.XReserveConfig
+	circle AttestationClient
+}
+
+// Bridge is the xreserve TokenBridge adapter.
+type Bridge struct {
+	tokens   map[string]*tokenRuntime // keyed by token symbol
+	holdings HoldingLister
+	logger   *zap.Logger
+}
+
+// Option customizes the Bridge, primarily for tests.
+type Option func(*options)
+
+type options struct {
+	httpClient  *http.Client
+	newAttester func(t *tokenRuntime) (AttestationClient, error)
+}
+
+// WithHTTPClient overrides the HTTP client used for attestation calls.
+func WithHTTPClient(c *http.Client) Option {
+	return func(o *options) { o.httpClient = c }
+}
+
+// WithAttestationClient overrides attestation-client construction (tests).
+func WithAttestationClient(client AttestationClient) Option {
+	return func(o *options) {
+		o.newAttester = func(*tokenRuntime) (AttestationClient, error) { return client, nil }
+	}
+}
+
+// New creates the xreserve adapter for every configured token whose
+// mechanism is "xreserve".
+func New(
+	tokens map[string]relayer.TokenConfig,
+	holdings HoldingLister,
+	logger *zap.Logger,
+	opts ...Option,
+) (*Bridge, error) {
+	o := &options{httpClient: &http.Client{Timeout: defaultHTTPTimeout}}
+	for _, opt := range opts {
+		opt(o)
+	}
+	if o.newAttester == nil {
+		o.newAttester = func(t *tokenRuntime) (AttestationClient, error) {
+			return NewAttestationClient(t.cfg.AttestationURL, o.httpClient)
+		}
+	}
+
+	b := &Bridge{
+		tokens:   make(map[string]*tokenRuntime, len(tokens)),
+		holdings: holdings,
+		logger:   logger,
+	}
+
+	for symbol, tc := range tokens {
+		if tc.Mechanism != Mechanism {
+			return nil, fmt.Errorf("token %s: mechanism %q is not %q", symbol, tc.Mechanism, Mechanism)
+		}
+		if tc.XReserve == nil {
+			return nil, fmt.Errorf("token %s: xreserve config block is required", symbol)
+		}
+		rt := &tokenRuntime{symbol: symbol, cfg: *tc.XReserve}
+		circle, err := o.newAttester(rt)
+		if err != nil {
+			return nil, fmt.Errorf("token %s: %w", symbol, err)
+		}
+		rt.circle = circle
+		b.tokens[symbol] = rt
+	}
+	if len(b.tokens) == 0 {
+		return nil, errors.New("xreserve: no tokens configured")
+	}
+	return b, nil
+}
+
+// Key implements relayer.TokenBridge.
+func (*Bridge) Key() string { return Mechanism }
+
+// Sources implements relayer.TokenBridge. Observer mechanism: Circle executes
+// the bridge whether or not we watch, so there is nothing to stream —
+// transfers enter the store via the relayer registration API.
+func (*Bridge) Sources(context.Context) ([]relayer.Source, error) { return nil, nil }
+
+// Step implements relayer.TokenBridge.
+func (b *Bridge) Step(ctx context.Context, t *relayer.Transfer) (relayer.StepResult, error) {
+	rt, ok := b.tokens[t.TokenSymbol]
+	if !ok {
+		return relayer.StepResult{}, fmt.Errorf("token %q is not configured for xreserve", t.TokenSymbol)
+	}
+
+	switch t.Direction {
+	case relayer.DirectionEthereumToCanton:
+		return b.stepDeposit(ctx, rt, t)
+	case relayer.DirectionCantonToEthereum:
+		// Outbound (BridgeUserAgreement_Burn + release tracking) lands with #359.
+		return relayer.StepResult{}, fmt.Errorf("xreserve withdrawals are not supported yet")
+	default:
+		return relayer.StepResult{}, fmt.Errorf("unknown direction %q", t.Direction)
+	}
+}
+
+func (b *Bridge) stepDeposit(ctx context.Context, rt *tokenRuntime, t *relayer.Transfer) (relayer.StepResult, error) {
+	switch t.Stage {
+	case "":
+		return b.snapshotBaseline(ctx, rt, t)
+	case StageAwaitingAttestation:
+		return b.pollAttestation(ctx, rt, t)
+	case StageAwaitingMint:
+		return b.checkMinted(ctx, rt, t)
+	default:
+		return relayer.StepResult{}, fmt.Errorf("unknown deposit stage %q", t.Stage)
+	}
+}
+
+// snapshotBaseline records the recipient's pre-mint balance so mint arrival
+// is detectable as a balance increase, then moves to attestation polling.
+func (b *Bridge) snapshotBaseline(ctx context.Context, rt *tokenRuntime, t *relayer.Transfer) (relayer.StepResult, error) {
+	baseline, err := partyBalance(ctx, b.holdings, t.Recipient, rt.cfg.InstrumentAdmin, rt.cfg.InstrumentID)
+	if err != nil {
+		return relayer.StepResult{}, err
+	}
+
+	return relayer.StepResult{
+		Status:     relayer.TransferStatusInProgress,
+		Stage:      StageAwaitingAttestation,
+		Metadata:   map[string]string{metaBaselineBalance: baseline.String()},
+		RetryAfter: rt.attestationPollInterval(),
+	}, nil
+}
+
+// pollAttestation asks Circle whether the deposit is attested yet. Not-ready
+// and transient service failures both keep polling; only unexpected responses
+// surface as step errors.
+func (b *Bridge) pollAttestation(ctx context.Context, rt *tokenRuntime, t *relayer.Transfer) (relayer.StepResult, error) {
+	att, err := rt.circle.GetAttestation(ctx, t.SourceTxHash)
+	switch {
+	case errors.Is(err, ErrAttestationNotReady):
+		return relayer.StepResult{
+			Status:     relayer.TransferStatusInProgress,
+			Stage:      StageAwaitingAttestation,
+			RetryAfter: rt.attestationPollInterval(),
+		}, nil
+	case errors.Is(err, ErrAttestationUnavailable):
+		b.logger.Warn("Attestation service unavailable, will keep polling",
+			zap.String("id", t.ID), zap.String("token", rt.symbol), zap.Error(err))
+		return relayer.StepResult{
+			Status:     relayer.TransferStatusInProgress,
+			Stage:      StageAwaitingAttestation,
+			RetryAfter: rt.attestationPollInterval(),
+		}, nil
+	case err != nil:
+		return relayer.StepResult{}, err
+	}
+
+	return relayer.StepResult{
+		Status:     relayer.TransferStatusInProgress,
+		Stage:      StageAwaitingMint,
+		Metadata:   map[string]string{metaAttestationID: att.ID},
+		RetryAfter: rt.mintPollInterval(),
+	}, nil
+}
+
+// checkMinted completes the transfer once the recipient's balance has grown
+// by the deposited amount over the recorded baseline. The mint itself is
+// performed by the recipient's pre-approved BridgeUserAgreement, not by us.
+func (b *Bridge) checkMinted(ctx context.Context, rt *tokenRuntime, t *relayer.Transfer) (relayer.StepResult, error) {
+	baseline, err := decimal.NewFromString(t.Metadata[metaBaselineBalance])
+	if err != nil {
+		return relayer.StepResult{}, fmt.Errorf("invalid baseline balance %q: %w", t.Metadata[metaBaselineBalance], err)
+	}
+	amount, err := decimal.NewFromString(t.Amount)
+	if err != nil {
+		return relayer.StepResult{}, fmt.Errorf("invalid transfer amount %q: %w", t.Amount, err)
+	}
+
+	current, err := partyBalance(ctx, b.holdings, t.Recipient, rt.cfg.InstrumentAdmin, rt.cfg.InstrumentID)
+	if err != nil {
+		return relayer.StepResult{}, err
+	}
+
+	if current.LessThan(baseline.Add(amount)) {
+		return relayer.StepResult{
+			Status:     relayer.TransferStatusInProgress,
+			Stage:      StageAwaitingMint,
+			RetryAfter: rt.mintPollInterval(),
+		}, nil
+	}
+
+	return relayer.StepResult{
+		Status: relayer.TransferStatusCompleted,
+		Stage:  StageMinted,
+	}, nil
+}
+
+func (rt *tokenRuntime) attestationPollInterval() time.Duration {
+	if rt.cfg.AttestationPollInterval > 0 {
+		return rt.cfg.AttestationPollInterval
+	}
+	return defaultAttestationPollInterval
+}
+
+func (rt *tokenRuntime) mintPollInterval() time.Duration {
+	if rt.cfg.MintPollInterval > 0 {
+		return rt.cfg.MintPollInterval
+	}
+	return defaultMintPollInterval
+}

--- a/pkg/relayer/bridges/xreserve/bridge.go
+++ b/pkg/relayer/bridges/xreserve/bridge.go
@@ -180,7 +180,7 @@ func (b *Bridge) snapshotBaseline(ctx context.Context, rt *tokenRuntime, t *rela
 	}
 
 	return relayer.StepResult{
-		Status:     relayer.TransferStatusInProgress,
+		Status:     relayer.TransferStatusPending,
 		Stage:      StageAwaitingAttestation,
 		Metadata:   map[string]string{metaBaselineBalance: baseline.String()},
 		RetryAfter: rt.attestationPollInterval(),
@@ -195,7 +195,7 @@ func (b *Bridge) pollAttestation(ctx context.Context, rt *tokenRuntime, t *relay
 	switch {
 	case errors.Is(err, ErrAttestationNotReady):
 		return relayer.StepResult{
-			Status:     relayer.TransferStatusInProgress,
+			Status:     relayer.TransferStatusPending,
 			Stage:      StageAwaitingAttestation,
 			RetryAfter: rt.attestationPollInterval(),
 		}, nil
@@ -203,7 +203,7 @@ func (b *Bridge) pollAttestation(ctx context.Context, rt *tokenRuntime, t *relay
 		b.logger.Warn("Attestation service unavailable, will keep polling",
 			zap.String("id", t.ID), zap.String("token", rt.symbol), zap.Error(err))
 		return relayer.StepResult{
-			Status:     relayer.TransferStatusInProgress,
+			Status:     relayer.TransferStatusPending,
 			Stage:      StageAwaitingAttestation,
 			RetryAfter: rt.attestationPollInterval(),
 		}, nil
@@ -212,7 +212,7 @@ func (b *Bridge) pollAttestation(ctx context.Context, rt *tokenRuntime, t *relay
 	}
 
 	return relayer.StepResult{
-		Status:     relayer.TransferStatusInProgress,
+		Status:     relayer.TransferStatusPending,
 		Stage:      StageAwaitingMint,
 		Metadata:   map[string]string{metaAttestationID: att.ID},
 		RetryAfter: rt.mintPollInterval(),
@@ -239,7 +239,7 @@ func (b *Bridge) checkMinted(ctx context.Context, rt *tokenRuntime, t *relayer.T
 
 	if current.LessThan(baseline.Add(amount)) {
 		return relayer.StepResult{
-			Status:     relayer.TransferStatusInProgress,
+			Status:     relayer.TransferStatusPending,
 			Stage:      StageAwaitingMint,
 			RetryAfter: rt.mintPollInterval(),
 		}, nil

--- a/pkg/relayer/bridges/xreserve/bridge.go
+++ b/pkg/relayer/bridges/xreserve/bridge.go
@@ -1,21 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
-// Package xreserve implements the TokenBridge adapter for tokens bridged by
-// Circle xReserve (USDCx). It is an observer mechanism: Circle executes the
-// bridge, so the adapter exposes no event sources and never submits anything
-// for deposits — transfers are registered at initiation time via the relayer
-// API and Step only tracks their progress.
+// Package xreserve is the TokenBridge adapter for USDCx (Circle xReserve).
+// It's an observer: Circle runs the bridge, so there are no event sources —
+// transfers are registered when initiated and Step just tracks them.
 //
-// Deposit stage sequence:
+// Deposit: "" -> awaiting_attestation -> awaiting_mint -> completed ("minted").
+// Mint detection snapshots the recipient balance on the first step (before
+// finality, so before any mint) and completes once it grows by the amount.
 //
-//	"" -> awaiting_attestation -> awaiting_mint -> completed (stage "minted")
-//
-// Mint detection is balance-based: the recipient's instrument balance is
-// snapshotted on the first step (before Ethereum finality, so before any mint
-// for this deposit can exist) and the transfer completes once the balance has
-// grown by the deposited amount. This assumes the transfer is registered
-// promptly after the deposit transaction is sent, well within the ~15 minute
-// attestation window.
+// Limitation (#360, needs real mint-event data): balance-delta can't tie a
+// mint to a specific deposit, so two concurrent same-recipient deposits (or an
+// unrelated credit) can complete the wrong one. Bounded for now by rejecting
+// non-positive amounts and failing anything past depositCompletionDeadline.
 package xreserve
 
 import (
@@ -51,6 +47,11 @@ const (
 	defaultAttestationPollInterval = time.Minute
 	defaultMintPollInterval        = 15 * time.Second
 	defaultHTTPTimeout             = 10 * time.Second
+
+	// depositCompletionDeadline reaps deposits that never mint (bogus hashes,
+	// never-attested). Well past finality+attestation (~15 min) so a healthy
+	// deposit always completes first.
+	depositCompletionDeadline = 2 * time.Hour
 )
 
 // tokenRuntime is one configured xreserve token with its attestation client.
@@ -159,6 +160,18 @@ func (b *Bridge) Step(ctx context.Context, t *relayer.Transfer) (relayer.StepRes
 }
 
 func (b *Bridge) stepDeposit(ctx context.Context, rt *tokenRuntime, t *relayer.Transfer) (relayer.StepResult, error) {
+	// Past the deadline it's never going to mint; fail it so the driver stops
+	// reloading it forever.
+	if !t.CreatedAt.IsZero() && time.Since(t.CreatedAt) > depositCompletionDeadline {
+		b.logger.Warn("Deposit exceeded completion deadline, failing",
+			zap.String("id", t.ID), zap.String("token", rt.symbol), zap.String("stage", t.Stage))
+		return relayer.StepResult{
+			Status: relayer.TransferStatusFailed,
+			Stage:  t.Stage,
+			Reason: fmt.Sprintf("deposit not minted within %s", depositCompletionDeadline),
+		}, nil
+	}
+
 	switch t.Stage {
 	case "":
 		return b.snapshotBaseline(ctx, rt, t)

--- a/pkg/relayer/bridges/xreserve/bridge_test.go
+++ b/pkg/relayer/bridges/xreserve/bridge_test.go
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package xreserve
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/chainsafe/canton-middleware/pkg/cantonsdk/token"
+	"github.com/chainsafe/canton-middleware/pkg/relayer"
+)
+
+// fakeAttester returns a fixed attestation result.
+type fakeAttester struct {
+	att   *Attestation
+	err   error
+	calls int
+}
+
+func (f *fakeAttester) GetAttestation(context.Context, string) (*Attestation, error) {
+	f.calls++
+	return f.att, f.err
+}
+
+// fakeHoldings returns its fixed holdings list filtered by owner.
+type fakeHoldings struct {
+	holdings []*token.Holding
+	err      error
+}
+
+func (f *fakeHoldings) GetHoldingsByParty(_ context.Context, ownerParty, _ string) ([]*token.Holding, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	out := make([]*token.Holding, 0, len(f.holdings))
+	for _, h := range f.holdings {
+		if h.Owner == ownerParty {
+			out = append(out, h)
+		}
+	}
+	return out, nil
+}
+
+const (
+	testSymbol          = "USDCX"
+	testInstrumentAdmin = "circle::admin"
+	testInstrumentID    = "USDCx"
+	testRecipient       = "party::recipient"
+)
+
+func testTokens() map[string]relayer.TokenConfig {
+	return map[string]relayer.TokenConfig{
+		testSymbol: {
+			Mechanism:  Mechanism,
+			EVMAddress: "0xusdc",
+			Decimals:   6,
+			XReserve: &relayer.XReserveConfig{
+				AttestationURL:          "http://attestation.local",
+				InstrumentAdmin:         testInstrumentAdmin,
+				InstrumentID:            testInstrumentID,
+				AttestationPollInterval: 30 * time.Second,
+				MintPollInterval:        5 * time.Second,
+			},
+		},
+	}
+}
+
+func newTestBridge(t *testing.T, circle AttestationClient, holdings HoldingLister) *Bridge {
+	t.Helper()
+	b, err := New(testTokens(), holdings, zap.NewNop(), WithAttestationClient(circle))
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+	return b
+}
+
+func holding(amount string) *token.Holding {
+	return &token.Holding{
+		ContractID:      "cid-" + amount,
+		Owner:           testRecipient,
+		Amount:          amount,
+		InstrumentAdmin: testInstrumentAdmin,
+		InstrumentID:    testInstrumentID,
+	}
+}
+
+func depositTransfer(stage string, metadata map[string]string) *relayer.Transfer {
+	return &relayer.Transfer{
+		ID:           "0xdeposit",
+		BridgeKey:    Mechanism,
+		TokenSymbol:  testSymbol,
+		Direction:    relayer.DirectionEthereumToCanton,
+		Status:       relayer.TransferStatusPending,
+		Stage:        stage,
+		SourceTxHash: "0xdeposit",
+		Amount:       "12.5",
+		Recipient:    testRecipient,
+		Metadata:     metadata,
+	}
+}
+
+func TestBridge_KeyAndSources(t *testing.T) {
+	b := newTestBridge(t, &fakeAttester{}, &fakeHoldings{})
+
+	if b.Key() != Mechanism {
+		t.Fatalf("Key() = %q, want %q", b.Key(), Mechanism)
+	}
+	sources, err := b.Sources(context.Background())
+	if err != nil || len(sources) != 0 {
+		t.Fatalf("Sources() = %v, %v; want empty (observer mechanism)", sources, err)
+	}
+}
+
+func TestBridge_New_RequiresXReserveBlock(t *testing.T) {
+	tokens := testTokens()
+	tc := tokens[testSymbol]
+	tc.XReserve = nil
+	tokens[testSymbol] = tc
+
+	if _, err := New(tokens, &fakeHoldings{}, zap.NewNop(), WithAttestationClient(&fakeAttester{})); err == nil {
+		t.Fatalf("New without xreserve block should fail")
+	}
+}
+
+func TestBridge_New_RequiresTokens(t *testing.T) {
+	empty := map[string]relayer.TokenConfig{}
+	if _, err := New(empty, &fakeHoldings{}, zap.NewNop(), WithAttestationClient(&fakeAttester{})); err == nil {
+		t.Fatalf("New without tokens should fail")
+	}
+}
+
+func TestBridge_Step_FirstStep_SnapshotsBaseline(t *testing.T) {
+	holdings := &fakeHoldings{holdings: []*token.Holding{
+		holding("100"),
+		holding("2.5"),
+		// Different admin: same instrument id from another registrar must not count.
+		{ContractID: "cid-x", Owner: testRecipient, Amount: "999", InstrumentAdmin: "other::admin", InstrumentID: testInstrumentID},
+	}}
+
+	b := newTestBridge(t, &fakeAttester{}, holdings)
+	res, err := b.Step(context.Background(), depositTransfer("", nil))
+	if err != nil {
+		t.Fatalf("Step failed: %v", err)
+	}
+
+	if res.Status != relayer.TransferStatusInProgress || res.Stage != StageAwaitingAttestation {
+		t.Fatalf("status/stage = %s/%s, want in_progress/%s", res.Status, res.Stage, StageAwaitingAttestation)
+	}
+	if res.Metadata[metaBaselineBalance] != "102.5" {
+		t.Fatalf("baseline = %q, want 102.5", res.Metadata[metaBaselineBalance])
+	}
+	if res.RetryAfter != 30*time.Second {
+		t.Fatalf("RetryAfter = %v, want 30s", res.RetryAfter)
+	}
+}
+
+func TestBridge_Step_AttestationNotReady_KeepsPolling(t *testing.T) {
+	circle := &fakeAttester{err: ErrAttestationNotReady}
+
+	b := newTestBridge(t, circle, &fakeHoldings{})
+	res, err := b.Step(context.Background(), depositTransfer(StageAwaitingAttestation, map[string]string{metaBaselineBalance: "0"}))
+	if err != nil {
+		t.Fatalf("Step failed: %v", err)
+	}
+	if res.Status != relayer.TransferStatusInProgress || res.Stage != StageAwaitingAttestation {
+		t.Fatalf("status/stage = %s/%s, want in_progress/%s", res.Status, res.Stage, StageAwaitingAttestation)
+	}
+	if circle.calls != 1 {
+		t.Fatalf("GetAttestation called %d times, want 1", circle.calls)
+	}
+}
+
+func TestBridge_Step_AttestationUnavailable_KeepsPollingWithoutError(t *testing.T) {
+	circle := &fakeAttester{err: errors.Join(ErrAttestationUnavailable, errors.New("503"))}
+
+	b := newTestBridge(t, circle, &fakeHoldings{})
+	res, err := b.Step(context.Background(), depositTransfer(StageAwaitingAttestation, map[string]string{metaBaselineBalance: "0"}))
+	if err != nil {
+		t.Fatalf("transient unavailability must not be a step error, got: %v", err)
+	}
+	if res.Stage != StageAwaitingAttestation {
+		t.Fatalf("stage = %s, want %s", res.Stage, StageAwaitingAttestation)
+	}
+}
+
+func TestBridge_Step_AttestationReady_MovesToAwaitingMint(t *testing.T) {
+	circle := &fakeAttester{att: &Attestation{ID: "att-1", Status: "complete"}}
+
+	b := newTestBridge(t, circle, &fakeHoldings{})
+	res, err := b.Step(context.Background(), depositTransfer(StageAwaitingAttestation, map[string]string{metaBaselineBalance: "100"}))
+	if err != nil {
+		t.Fatalf("Step failed: %v", err)
+	}
+	if res.Status != relayer.TransferStatusInProgress || res.Stage != StageAwaitingMint {
+		t.Fatalf("status/stage = %s/%s, want in_progress/%s", res.Status, res.Stage, StageAwaitingMint)
+	}
+	if res.Metadata[metaAttestationID] != "att-1" {
+		t.Fatalf("attestation id = %q, want att-1", res.Metadata[metaAttestationID])
+	}
+	if res.RetryAfter != 5*time.Second {
+		t.Fatalf("RetryAfter = %v, want 5s", res.RetryAfter)
+	}
+}
+
+func TestBridge_Step_MintNotArrived_KeepsWaiting(t *testing.T) {
+	holdings := &fakeHoldings{holdings: []*token.Holding{holding("100")}}
+
+	b := newTestBridge(t, &fakeAttester{}, holdings)
+	res, err := b.Step(context.Background(), depositTransfer(StageAwaitingMint, map[string]string{metaBaselineBalance: "100"}))
+	if err != nil {
+		t.Fatalf("Step failed: %v", err)
+	}
+	if res.Status != relayer.TransferStatusInProgress || res.Stage != StageAwaitingMint {
+		t.Fatalf("status/stage = %s/%s, want in_progress/%s", res.Status, res.Stage, StageAwaitingMint)
+	}
+}
+
+func TestBridge_Step_MintArrived_Completes(t *testing.T) {
+	holdings := &fakeHoldings{holdings: []*token.Holding{holding("100"), holding("12.5")}}
+
+	b := newTestBridge(t, &fakeAttester{}, holdings)
+	res, err := b.Step(context.Background(), depositTransfer(StageAwaitingMint, map[string]string{metaBaselineBalance: "100"}))
+	if err != nil {
+		t.Fatalf("Step failed: %v", err)
+	}
+	if res.Status != relayer.TransferStatusCompleted || res.Stage != StageMinted {
+		t.Fatalf("status/stage = %s/%s, want completed/%s", res.Status, res.Stage, StageMinted)
+	}
+}
+
+func TestBridge_Step_UnknownToken_Fails(t *testing.T) {
+	b := newTestBridge(t, &fakeAttester{}, &fakeHoldings{})
+
+	transfer := depositTransfer("", nil)
+	transfer.TokenSymbol = "UNKNOWN"
+	if _, err := b.Step(context.Background(), transfer); err == nil {
+		t.Fatalf("Step with unconfigured token should fail")
+	}
+}
+
+func TestBridge_Step_UnknownStage_Fails(t *testing.T) {
+	b := newTestBridge(t, &fakeAttester{}, &fakeHoldings{})
+
+	if _, err := b.Step(context.Background(), depositTransfer("bogus", nil)); err == nil {
+		t.Fatalf("Step with unknown stage should fail")
+	}
+}
+
+func TestBridge_Step_WithdrawalsNotSupportedYet(t *testing.T) {
+	b := newTestBridge(t, &fakeAttester{}, &fakeHoldings{})
+
+	transfer := depositTransfer("", nil)
+	transfer.Direction = relayer.DirectionCantonToEthereum
+	if _, err := b.Step(context.Background(), transfer); err == nil {
+		t.Fatalf("withdrawal Step should fail until #359 lands")
+	}
+}

--- a/pkg/relayer/bridges/xreserve/bridge_test.go
+++ b/pkg/relayer/bridges/xreserve/bridge_test.go
@@ -147,8 +147,8 @@ func TestBridge_Step_FirstStep_SnapshotsBaseline(t *testing.T) {
 		t.Fatalf("Step failed: %v", err)
 	}
 
-	if res.Status != relayer.TransferStatusInProgress || res.Stage != StageAwaitingAttestation {
-		t.Fatalf("status/stage = %s/%s, want in_progress/%s", res.Status, res.Stage, StageAwaitingAttestation)
+	if res.Status != relayer.TransferStatusPending || res.Stage != StageAwaitingAttestation {
+		t.Fatalf("status/stage = %s/%s, want pending/%s", res.Status, res.Stage, StageAwaitingAttestation)
 	}
 	if res.Metadata[metaBaselineBalance] != "102.5" {
 		t.Fatalf("baseline = %q, want 102.5", res.Metadata[metaBaselineBalance])
@@ -166,8 +166,8 @@ func TestBridge_Step_AttestationNotReady_KeepsPolling(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Step failed: %v", err)
 	}
-	if res.Status != relayer.TransferStatusInProgress || res.Stage != StageAwaitingAttestation {
-		t.Fatalf("status/stage = %s/%s, want in_progress/%s", res.Status, res.Stage, StageAwaitingAttestation)
+	if res.Status != relayer.TransferStatusPending || res.Stage != StageAwaitingAttestation {
+		t.Fatalf("status/stage = %s/%s, want pending/%s", res.Status, res.Stage, StageAwaitingAttestation)
 	}
 	if circle.calls != 1 {
 		t.Fatalf("GetAttestation called %d times, want 1", circle.calls)
@@ -195,8 +195,8 @@ func TestBridge_Step_AttestationReady_MovesToAwaitingMint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Step failed: %v", err)
 	}
-	if res.Status != relayer.TransferStatusInProgress || res.Stage != StageAwaitingMint {
-		t.Fatalf("status/stage = %s/%s, want in_progress/%s", res.Status, res.Stage, StageAwaitingMint)
+	if res.Status != relayer.TransferStatusPending || res.Stage != StageAwaitingMint {
+		t.Fatalf("status/stage = %s/%s, want pending/%s", res.Status, res.Stage, StageAwaitingMint)
 	}
 	if res.Metadata[metaAttestationID] != "att-1" {
 		t.Fatalf("attestation id = %q, want att-1", res.Metadata[metaAttestationID])
@@ -214,8 +214,8 @@ func TestBridge_Step_MintNotArrived_KeepsWaiting(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Step failed: %v", err)
 	}
-	if res.Status != relayer.TransferStatusInProgress || res.Stage != StageAwaitingMint {
-		t.Fatalf("status/stage = %s/%s, want in_progress/%s", res.Status, res.Stage, StageAwaitingMint)
+	if res.Status != relayer.TransferStatusPending || res.Stage != StageAwaitingMint {
+		t.Fatalf("status/stage = %s/%s, want pending/%s", res.Status, res.Stage, StageAwaitingMint)
 	}
 }
 

--- a/pkg/relayer/bridges/xreserve/circle.go
+++ b/pkg/relayer/bridges/xreserve/circle.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package xreserve
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// ErrAttestationNotReady means Circle has not (yet) attested the deposit —
+// expected during the source-chain finality window (~15 min on Ethereum).
+var ErrAttestationNotReady = errors.New("attestation not ready")
+
+// ErrAttestationUnavailable means the attestation service could not be
+// reached or answered with a server error. Transient by definition: the
+// adapter keeps polling instead of burning transfer retries.
+var ErrAttestationUnavailable = errors.New("attestation service unavailable")
+
+const maxAttestationResponseBytes = 1 << 20 // 1MB
+
+// attestationStatusComplete is the terminal attestation status.
+const attestationStatusComplete = "complete"
+
+// Attestation is Circle's signed confirmation that a deposit into the
+// xReserve contract is final.
+type Attestation struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+}
+
+// AttestationClient fetches deposit attestations from Circle's xReserve API.
+type AttestationClient interface {
+	// GetAttestation returns the attestation for a deposit transaction hash.
+	// Returns ErrAttestationNotReady while Circle has not attested and
+	// ErrAttestationUnavailable on transient service failures.
+	GetAttestation(ctx context.Context, depositTxHash string) (*Attestation, error)
+}
+
+// HTTPAttestationClient talks to the xReserve attestation REST API.
+//
+// The path and response shape follow the devstack attestation stub; Circle's
+// production API schema must be confirmed before mainnet enablement (#360).
+type HTTPAttestationClient struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+// NewAttestationClient creates an attestation client for the given base URL.
+// A nil httpClient falls back to a default client; callers are expected to
+// inject one with a timeout.
+func NewAttestationClient(baseURL string, httpClient *http.Client) (*HTTPAttestationClient, error) {
+	parsed, err := url.Parse(baseURL)
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" {
+		return nil, fmt.Errorf("invalid attestation base URL %q", baseURL)
+	}
+	if httpClient == nil {
+		httpClient = &http.Client{}
+	}
+	return &HTTPAttestationClient{
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		httpClient: httpClient,
+	}, nil
+}
+
+// GetAttestation fetches the attestation for a deposit tx hash.
+func (c *HTTPAttestationClient) GetAttestation(ctx context.Context, depositTxHash string) (*Attestation, error) {
+	reqURL := c.baseURL + "/v1/attestations/" + url.PathEscape(depositTxHash)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build attestation request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrAttestationUnavailable, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxAttestationResponseBytes))
+	if err != nil {
+		return nil, fmt.Errorf("%w: read response: %w", ErrAttestationUnavailable, err)
+	}
+
+	switch {
+	case resp.StatusCode == http.StatusNotFound:
+		return nil, ErrAttestationNotReady
+	case resp.StatusCode >= http.StatusInternalServerError:
+		return nil, fmt.Errorf("%w: status %d: %s", ErrAttestationUnavailable, resp.StatusCode, body)
+	case resp.StatusCode != http.StatusOK:
+		return nil, fmt.Errorf("attestation service returned %d: %s", resp.StatusCode, body)
+	}
+
+	var att Attestation
+	if err := json.Unmarshal(body, &att); err != nil {
+		return nil, fmt.Errorf("parse attestation response: %w", err)
+	}
+	if !strings.EqualFold(att.Status, attestationStatusComplete) {
+		return nil, ErrAttestationNotReady
+	}
+	return &att, nil
+}

--- a/pkg/relayer/bridges/xreserve/circle.go
+++ b/pkg/relayer/bridges/xreserve/circle.go
@@ -17,15 +17,21 @@ import (
 // expected during the source-chain finality window (~15 min on Ethereum).
 var ErrAttestationNotReady = errors.New("attestation not ready")
 
-// ErrAttestationUnavailable means the attestation service could not be
-// reached or answered with a server error. Transient by definition: the
-// adapter keeps polling instead of burning transfer retries.
+// ErrAttestationUnavailable means the service was unreachable or 5xx'd —
+// transient, so the adapter keeps polling instead of burning retries.
 var ErrAttestationUnavailable = errors.New("attestation service unavailable")
 
 const maxAttestationResponseBytes = 1 << 20 // 1MB
 
 // attestationStatusComplete is the terminal attestation status.
 const attestationStatusComplete = "complete"
+
+// isTransientStatus reports statuses worth retrying rather than failing on.
+func isTransientStatus(code int) bool {
+	return code >= http.StatusInternalServerError ||
+		code == http.StatusTooManyRequests ||
+		code == http.StatusRequestTimeout
+}
 
 // Attestation is Circle's signed confirmation that a deposit into the
 // xReserve contract is final.
@@ -43,9 +49,7 @@ type AttestationClient interface {
 }
 
 // HTTPAttestationClient talks to the xReserve attestation REST API.
-//
-// The path and response shape follow the devstack attestation stub; Circle's
-// production API schema must be confirmed before mainnet enablement (#360).
+// Paths/shapes match the devstack stub; confirm against Circle before mainnet (#360).
 type HTTPAttestationClient struct {
 	baseURL    string
 	httpClient *http.Client
@@ -91,7 +95,7 @@ func (c *HTTPAttestationClient) GetAttestation(ctx context.Context, depositTxHas
 	switch {
 	case resp.StatusCode == http.StatusNotFound:
 		return nil, ErrAttestationNotReady
-	case resp.StatusCode >= http.StatusInternalServerError:
+	case isTransientStatus(resp.StatusCode): // 5xx / 429 / 408: keep polling
 		return nil, fmt.Errorf("%w: status %d: %s", ErrAttestationUnavailable, resp.StatusCode, body)
 	case resp.StatusCode != http.StatusOK:
 		return nil, fmt.Errorf("attestation service returned %d: %s", resp.StatusCode, body)

--- a/pkg/relayer/bridges/xreserve/circle_test.go
+++ b/pkg/relayer/bridges/xreserve/circle_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package xreserve
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func attestationServer(t *testing.T, status int, body string) *HTTPAttestationClient {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/attestations/0xdeposit" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := NewAttestationClient(srv.URL, srv.Client())
+	if err != nil {
+		t.Fatalf("NewAttestationClient failed: %v", err)
+	}
+	return client
+}
+
+func TestAttestationClient_Complete(t *testing.T) {
+	client := attestationServer(t, http.StatusOK, `{"id":"att-1","status":"complete"}`)
+
+	att, err := client.GetAttestation(context.Background(), "0xdeposit")
+	if err != nil {
+		t.Fatalf("GetAttestation failed: %v", err)
+	}
+	if att.ID != "att-1" {
+		t.Fatalf("attestation id = %q, want att-1", att.ID)
+	}
+}
+
+func TestAttestationClient_PendingStatus_NotReady(t *testing.T) {
+	client := attestationServer(t, http.StatusOK, `{"id":"att-1","status":"pending"}`)
+
+	if _, err := client.GetAttestation(context.Background(), "0xdeposit"); !errors.Is(err, ErrAttestationNotReady) {
+		t.Fatalf("err = %v, want ErrAttestationNotReady", err)
+	}
+}
+
+func TestAttestationClient_NotFound_NotReady(t *testing.T) {
+	client := attestationServer(t, http.StatusNotFound, `{}`)
+
+	if _, err := client.GetAttestation(context.Background(), "0xdeposit"); !errors.Is(err, ErrAttestationNotReady) {
+		t.Fatalf("err = %v, want ErrAttestationNotReady", err)
+	}
+}
+
+func TestAttestationClient_ServerError_Unavailable(t *testing.T) {
+	client := attestationServer(t, http.StatusServiceUnavailable, "down")
+
+	if _, err := client.GetAttestation(context.Background(), "0xdeposit"); !errors.Is(err, ErrAttestationUnavailable) {
+		t.Fatalf("err = %v, want ErrAttestationUnavailable", err)
+	}
+}
+
+func TestAttestationClient_ClientError_IsHardError(t *testing.T) {
+	client := attestationServer(t, http.StatusBadRequest, "bad request")
+
+	_, err := client.GetAttestation(context.Background(), "0xdeposit")
+	if err == nil || errors.Is(err, ErrAttestationNotReady) || errors.Is(err, ErrAttestationUnavailable) {
+		t.Fatalf("err = %v, want a hard error", err)
+	}
+}
+
+func TestAttestationClient_ConnectionRefused_Unavailable(t *testing.T) {
+	client, err := NewAttestationClient("http://127.0.0.1:1", nil)
+	if err != nil {
+		t.Fatalf("NewAttestationClient failed: %v", err)
+	}
+
+	if _, err = client.GetAttestation(context.Background(), "0xdeposit"); !errors.Is(err, ErrAttestationUnavailable) {
+		t.Fatalf("err = %v, want ErrAttestationUnavailable", err)
+	}
+}
+
+func TestNewAttestationClient_RejectsInvalidURL(t *testing.T) {
+	for _, bad := range []string{"", "not-a-url", "ftp://host", "http://"} {
+		if _, err := NewAttestationClient(bad, nil); err == nil {
+			t.Fatalf("NewAttestationClient(%q) should fail", bad)
+		}
+	}
+}

--- a/pkg/relayer/bridges/xreserve/holdings.go
+++ b/pkg/relayer/bridges/xreserve/holdings.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package xreserve
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/chainsafe/canton-middleware/pkg/cantonsdk/token"
+)
+
+// HoldingLister is the narrow slice of token.Token the adapter needs to
+// observe a recipient's USDCx holdings on Canton.
+//
+// Reads are authorized by the query's party filter combined with the
+// relayer's Canton auth token, so the relayer user must carry read rights
+// over user parties (e.g. CanReadAsAnyParty, as the indexer already requires).
+type HoldingLister interface {
+	GetHoldingsByParty(ctx context.Context, ownerParty, instrumentID string) ([]*token.Holding, error)
+}
+
+// partyBalance sums the party's holdings of the given instrument (matched on
+// both instrument id and admin party) as a decimal in token units. Locked
+// holdings count: a freshly minted amount is a balance increase regardless of
+// later locks.
+func partyBalance(
+	ctx context.Context,
+	holdings HoldingLister,
+	ownerParty, instrumentAdmin, instrumentID string,
+) (decimal.Decimal, error) {
+	list, err := holdings.GetHoldingsByParty(ctx, ownerParty, instrumentID)
+	if err != nil {
+		return decimal.Zero, fmt.Errorf("list holdings for %s: %w", ownerParty, err)
+	}
+
+	total := decimal.Zero
+	for _, h := range list {
+		if h.InstrumentAdmin != instrumentAdmin {
+			continue
+		}
+		amount, parseErr := decimal.NewFromString(h.Amount)
+		if parseErr != nil {
+			return decimal.Zero, fmt.Errorf("parse holding %s amount %q: %w", h.ContractID, h.Amount, parseErr)
+		}
+		total = total.Add(amount)
+	}
+	return total, nil
+}

--- a/pkg/relayer/config.go
+++ b/pkg/relayer/config.go
@@ -38,4 +38,24 @@ type TokenConfig struct {
 	EVMAddress string `yaml:"evm_address" validate:"required"`
 	// Decimals is the token's on-chain decimal precision.
 	Decimals int `yaml:"decimals" validate:"required,gt=0"`
+
+	// XReserve carries the Circle xReserve settings; required when
+	// mechanism is "xreserve" (enforced by the adapter constructor).
+	XReserve *XReserveConfig `yaml:"xreserve" default:"-"`
+}
+
+// XReserveConfig configures tracking for a token bridged by Circle xReserve.
+type XReserveConfig struct {
+	// AttestationURL is the base URL of the attestation API (Circle's in
+	// production, the devstack stub locally).
+	AttestationURL string `yaml:"attestation_url" validate:"required"`
+	// InstrumentAdmin is the Canton party administering the instrument
+	// (e.g. Circle's decentralized-usdc-interchain-rep party).
+	InstrumentAdmin string `yaml:"instrument_admin" validate:"required"`
+	// InstrumentID is the Canton token-standard instrument id (e.g. "USDCx").
+	InstrumentID string `yaml:"instrument_id" validate:"required"`
+	// AttestationPollInterval paces attestation polling (default 60s).
+	AttestationPollInterval time.Duration `yaml:"attestation_poll_interval"`
+	// MintPollInterval paces post-attestation mint detection (default 15s).
+	MintPollInterval time.Duration `yaml:"mint_poll_interval"`
 }

--- a/pkg/relayer/service/http.go
+++ b/pkg/relayer/service/http.go
@@ -4,6 +4,7 @@ package service
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -11,9 +12,13 @@ import (
 
 	apperrors "github.com/chainsafe/canton-middleware/pkg/app/errors"
 	apphttp "github.com/chainsafe/canton-middleware/pkg/app/http"
+	"github.com/chainsafe/canton-middleware/pkg/relayer"
 )
 
-const defaultLimitForListTransfer = 100
+const (
+	defaultLimitForListTransfer = 100
+	maxRequestBodyBytes         = 1 << 20 // 1MB
+)
 
 // Engine is the interface for checking relayer readiness.
 type Engine interface {
@@ -34,6 +39,9 @@ func RegisterRoutes(r chi.Router, svc Service, engine Engine, logger *zap.Logger
 	r.Get("/ready", h.ready)
 	r.Route("/api/v1", func(r chi.Router) {
 		r.Get("/transfers", apphttp.HandleError(h.listTransfers))
+		// Internal registration endpoint for observer-mechanism transfers
+		// (called by the api-server at initiation time, not by end users).
+		r.Post("/transfers", apphttp.HandleError(h.registerTransfer))
 		r.Get("/transfers/{id}", apphttp.HandleError(h.getTransfer))
 		r.Get("/status", apphttp.HandleError(h.getStatus))
 	})
@@ -72,6 +80,25 @@ func (h *HTTP) getTransfer(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	h.writeJSON(w, http.StatusOK, transfer)
+	return nil
+}
+
+func (h *HTTP) registerTransfer(w http.ResponseWriter, r *http.Request) error {
+	var req relayer.RegisterTransferRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, maxRequestBodyBytes)).Decode(&req); err != nil {
+		return apperrors.BadRequestError(err, "invalid JSON")
+	}
+
+	resp, err := h.service.RegisterTransfer(r.Context(), &req)
+	if err != nil {
+		return err
+	}
+
+	status := http.StatusOK
+	if resp.Created {
+		status = http.StatusCreated
+	}
+	h.writeJSON(w, status, resp)
 	return nil
 }
 

--- a/pkg/relayer/service/http.go
+++ b/pkg/relayer/service/http.go
@@ -3,9 +3,11 @@
 package service
 
 import (
+	"crypto/subtle"
 	"encoding/json"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"go.uber.org/zap"
@@ -30,11 +32,16 @@ type HTTP struct {
 	service Service
 	engine  Engine
 	logger  *zap.Logger
+	// registrationToken, when non-empty, is the bearer token required to call
+	// the internal transfer-registration endpoint.
+	registrationToken string
 }
 
-// RegisterRoutes registers relayer HTTP endpoints on the given chi router.
-func RegisterRoutes(r chi.Router, svc Service, engine Engine, logger *zap.Logger) {
-	h := &HTTP{service: svc, engine: engine, logger: logger}
+// RegisterRoutes registers relayer HTTP endpoints. A non-empty
+// registrationToken requires callers of the registration endpoint to present
+// it as a bearer token; empty disables the guard (single-host/dev).
+func RegisterRoutes(r chi.Router, svc Service, engine Engine, registrationToken string, logger *zap.Logger) {
+	h := &HTTP{service: svc, engine: engine, logger: logger, registrationToken: registrationToken}
 
 	r.Get("/ready", h.ready)
 	r.Route("/api/v1", func(r chi.Router) {
@@ -45,6 +52,18 @@ func RegisterRoutes(r chi.Router, svc Service, engine Engine, logger *zap.Logger
 		r.Get("/transfers/{id}", apphttp.HandleError(h.getTransfer))
 		r.Get("/status", apphttp.HandleError(h.getStatus))
 	})
+}
+
+// authorizeRegistration checks the bearer token when one is configured.
+func (h *HTTP) authorizeRegistration(r *http.Request) error {
+	if h.registrationToken == "" {
+		return nil
+	}
+	presented := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+	if subtle.ConstantTimeCompare([]byte(presented), []byte(h.registrationToken)) != 1 {
+		return apperrors.UnAuthorizedError(nil, "invalid or missing registration token")
+	}
+	return nil
 }
 
 func (h *HTTP) ready(w http.ResponseWriter, _ *http.Request) {
@@ -84,6 +103,10 @@ func (h *HTTP) getTransfer(w http.ResponseWriter, r *http.Request) error {
 }
 
 func (h *HTTP) registerTransfer(w http.ResponseWriter, r *http.Request) error {
+	if err := h.authorizeRegistration(r); err != nil {
+		return err
+	}
+
 	var req relayer.RegisterTransferRequest
 	if err := json.NewDecoder(io.LimitReader(r.Body, maxRequestBodyBytes)).Decode(&req); err != nil {
 		return apperrors.BadRequestError(err, "invalid JSON")

--- a/pkg/relayer/service/log.go
+++ b/pkg/relayer/service/log.go
@@ -50,6 +50,38 @@ func (ls *logService) ListTransfers(ctx context.Context, limit int) (transfers [
 	return ls.svc.ListTransfers(ctx, limit)
 }
 
+func (ls *logService) RegisterTransfer(
+	ctx context.Context,
+	req *relayer.RegisterTransferRequest,
+) (resp *relayer.RegisterTransferResponse, err error) {
+	start := time.Now()
+	ls.logger.Info("RegisterTransfer started",
+		zap.String("service", serviceName),
+		zap.String("bridge_key", req.BridgeKey),
+		zap.String("token", req.TokenSymbol),
+		zap.String("source_tx_hash", req.SourceTxHash),
+	)
+	defer func() {
+		duration := time.Since(start)
+		if err != nil {
+			ls.logger.Error("RegisterTransfer failed",
+				zap.String("service", serviceName),
+				zap.String("source_tx_hash", req.SourceTxHash),
+				zap.Duration("duration", duration),
+				zap.Error(err),
+			)
+		} else {
+			ls.logger.Info("RegisterTransfer completed",
+				zap.String("service", serviceName),
+				zap.String("id", resp.Transfer.ID),
+				zap.Bool("created", resp.Created),
+				zap.Duration("duration", duration),
+			)
+		}
+	}()
+	return ls.svc.RegisterTransfer(ctx, req)
+}
+
 func (ls *logService) GetTransfer(ctx context.Context, id string) (transfer *relayer.Transfer, err error) {
 	start := time.Now()
 	ls.logger.Info("GetTransfer started",

--- a/pkg/relayer/service/mocks/mock_service.go
+++ b/pkg/relayer/service/mocks/mock_service.go
@@ -140,6 +140,65 @@ func (_c *Service_ListTransfers_Call) RunAndReturn(run func(context.Context, int
 	return _c
 }
 
+// RegisterTransfer provides a mock function with given fields: ctx, req
+func (_m *Service) RegisterTransfer(ctx context.Context, req *relayer.RegisterTransferRequest) (*relayer.RegisterTransferResponse, error) {
+	ret := _m.Called(ctx, req)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RegisterTransfer")
+	}
+
+	var r0 *relayer.RegisterTransferResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *relayer.RegisterTransferRequest) (*relayer.RegisterTransferResponse, error)); ok {
+		return rf(ctx, req)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *relayer.RegisterTransferRequest) *relayer.RegisterTransferResponse); ok {
+		r0 = rf(ctx, req)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*relayer.RegisterTransferResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *relayer.RegisterTransferRequest) error); ok {
+		r1 = rf(ctx, req)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Service_RegisterTransfer_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RegisterTransfer'
+type Service_RegisterTransfer_Call struct {
+	*mock.Call
+}
+
+// RegisterTransfer is a helper method to define mock.On call
+//   - ctx context.Context
+//   - req *relayer.RegisterTransferRequest
+func (_e *Service_Expecter) RegisterTransfer(ctx interface{}, req interface{}) *Service_RegisterTransfer_Call {
+	return &Service_RegisterTransfer_Call{Call: _e.mock.On("RegisterTransfer", ctx, req)}
+}
+
+func (_c *Service_RegisterTransfer_Call) Run(run func(ctx context.Context, req *relayer.RegisterTransferRequest)) *Service_RegisterTransfer_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*relayer.RegisterTransferRequest))
+	})
+	return _c
+}
+
+func (_c *Service_RegisterTransfer_Call) Return(_a0 *relayer.RegisterTransferResponse, _a1 error) *Service_RegisterTransfer_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Service_RegisterTransfer_Call) RunAndReturn(run func(context.Context, *relayer.RegisterTransferRequest) (*relayer.RegisterTransferResponse, error)) *Service_RegisterTransfer_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewService creates a new instance of Service. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewService(t interface {

--- a/pkg/relayer/service/mocks/mock_store.go
+++ b/pkg/relayer/service/mocks/mock_store.go
@@ -22,6 +22,63 @@ func (_m *Store) EXPECT() *Store_Expecter {
 	return &Store_Expecter{mock: &_m.Mock}
 }
 
+// CreateTransfer provides a mock function with given fields: ctx, transfer
+func (_m *Store) CreateTransfer(ctx context.Context, transfer *relayer.Transfer) (bool, error) {
+	ret := _m.Called(ctx, transfer)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateTransfer")
+	}
+
+	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *relayer.Transfer) (bool, error)); ok {
+		return rf(ctx, transfer)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *relayer.Transfer) bool); ok {
+		r0 = rf(ctx, transfer)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *relayer.Transfer) error); ok {
+		r1 = rf(ctx, transfer)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Store_CreateTransfer_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateTransfer'
+type Store_CreateTransfer_Call struct {
+	*mock.Call
+}
+
+// CreateTransfer is a helper method to define mock.On call
+//   - ctx context.Context
+//   - transfer *relayer.Transfer
+func (_e *Store_Expecter) CreateTransfer(ctx interface{}, transfer interface{}) *Store_CreateTransfer_Call {
+	return &Store_CreateTransfer_Call{Call: _e.mock.On("CreateTransfer", ctx, transfer)}
+}
+
+func (_c *Store_CreateTransfer_Call) Run(run func(ctx context.Context, transfer *relayer.Transfer)) *Store_CreateTransfer_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*relayer.Transfer))
+	})
+	return _c
+}
+
+func (_c *Store_CreateTransfer_Call) Return(_a0 bool, _a1 error) *Store_CreateTransfer_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Store_CreateTransfer_Call) RunAndReturn(run func(context.Context, *relayer.Transfer) (bool, error)) *Store_CreateTransfer_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetTransfer provides a mock function with given fields: ctx, id
 func (_m *Store) GetTransfer(ctx context.Context, id string) (*relayer.Transfer, error) {
 	ret := _m.Called(ctx, id)

--- a/pkg/relayer/service/service.go
+++ b/pkg/relayer/service/service.go
@@ -5,7 +5,10 @@ package service
 
 import (
 	"context"
+	"fmt"
+	"slices"
 
+	apperrors "github.com/chainsafe/canton-middleware/pkg/app/errors"
 	"github.com/chainsafe/canton-middleware/pkg/relayer"
 )
 
@@ -15,23 +18,29 @@ import (
 type Store interface {
 	ListTransfers(ctx context.Context, limit int) ([]*relayer.Transfer, error)
 	GetTransfer(ctx context.Context, id string) (*relayer.Transfer, error)
+	CreateTransfer(ctx context.Context, transfer *relayer.Transfer) (bool, error)
 }
 
-// Service defines the interface for relayer query operations.
+// Service defines the interface for relayer query and registration operations.
 //
 //go:generate mockery --name Service --output mocks --outpkg mocks --filename mock_service.go --with-expecter
 type Service interface {
 	ListTransfers(ctx context.Context, limit int) ([]*relayer.Transfer, error)
 	GetTransfer(ctx context.Context, id string) (*relayer.Transfer, error)
+	RegisterTransfer(ctx context.Context, req *relayer.RegisterTransferRequest) (*relayer.RegisterTransferResponse, error)
 }
 
 type relayerService struct {
 	store Store
+	// bridgeKeys are the registered TokenBridge adapters; registration is
+	// rejected for keys no adapter owns, since nothing would ever step them.
+	bridgeKeys []string
 }
 
-// NewService creates a new relayer service.
-func NewService(store Store) Service {
-	return &relayerService{store: store}
+// NewService creates a new relayer service. bridgeKeys is the set of
+// registered TokenBridge adapter keys accepted for transfer registration.
+func NewService(store Store, bridgeKeys []string) Service {
+	return &relayerService{store: store, bridgeKeys: bridgeKeys}
 }
 
 func (s *relayerService) ListTransfers(ctx context.Context, limit int) ([]*relayer.Transfer, error) {
@@ -40,4 +49,74 @@ func (s *relayerService) ListTransfers(ctx context.Context, limit int) ([]*relay
 
 func (s *relayerService) GetTransfer(ctx context.Context, id string) (*relayer.Transfer, error) {
 	return s.store.GetTransfer(ctx, id)
+}
+
+func (s *relayerService) RegisterTransfer(
+	ctx context.Context,
+	req *relayer.RegisterTransferRequest,
+) (*relayer.RegisterTransferResponse, error) {
+	if err := s.validateRegistration(req); err != nil {
+		return nil, err
+	}
+
+	transfer := relayer.TransferFromEvent(req.BridgeKey, &relayer.Event{
+		ID:           req.ID,
+		TokenSymbol:  req.TokenSymbol,
+		Direction:    req.Direction,
+		SourceChain:  sourceChain(req.Direction),
+		SourceTxHash: req.SourceTxHash,
+		TokenAddress: req.TokenAddress,
+		Amount:       req.Amount,
+		Sender:       req.Sender,
+		Recipient:    req.Recipient,
+	})
+	transfer.DestinationChain = destinationChain(req.Direction)
+	transfer.Metadata = req.Metadata
+
+	created, err := s.store.CreateTransfer(ctx, transfer)
+	if err != nil {
+		return nil, fmt.Errorf("register transfer: %w", err)
+	}
+
+	if !created {
+		existing, getErr := s.store.GetTransfer(ctx, transfer.ID)
+		if getErr != nil {
+			return nil, fmt.Errorf("load existing transfer: %w", getErr)
+		}
+		return &relayer.RegisterTransferResponse{Transfer: existing, Created: false}, nil
+	}
+	return &relayer.RegisterTransferResponse{Transfer: transfer, Created: true}, nil
+}
+
+func (s *relayerService) validateRegistration(req *relayer.RegisterTransferRequest) error {
+	if req.SourceTxHash == "" {
+		return apperrors.BadRequestError(nil, "source_tx_hash is required")
+	}
+	if req.ID == "" {
+		req.ID = req.SourceTxHash
+	}
+	if req.TokenSymbol == "" || req.Amount == "" || req.Recipient == "" {
+		return apperrors.BadRequestError(nil, "token_symbol, amount, and recipient are required")
+	}
+	if req.Direction != relayer.DirectionEthereumToCanton && req.Direction != relayer.DirectionCantonToEthereum {
+		return apperrors.BadRequestError(nil, "direction must be ethereum_to_canton or canton_to_ethereum")
+	}
+	if !slices.Contains(s.bridgeKeys, req.BridgeKey) {
+		return apperrors.BadRequestError(nil, fmt.Sprintf("unknown bridge key %q", req.BridgeKey))
+	}
+	return nil
+}
+
+func sourceChain(direction relayer.TransferDirection) string {
+	if direction == relayer.DirectionEthereumToCanton {
+		return relayer.ChainEthereum
+	}
+	return relayer.ChainCanton
+}
+
+func destinationChain(direction relayer.TransferDirection) string {
+	if direction == relayer.DirectionEthereumToCanton {
+		return relayer.ChainCanton
+	}
+	return relayer.ChainEthereum
 }

--- a/pkg/relayer/service/service.go
+++ b/pkg/relayer/service/service.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/shopspring/decimal"
+
 	apperrors "github.com/chainsafe/canton-middleware/pkg/app/errors"
 	"github.com/chainsafe/canton-middleware/pkg/relayer"
 )
@@ -83,6 +85,11 @@ func (s *relayerService) RegisterTransfer(
 		if getErr != nil {
 			return nil, fmt.Errorf("load existing transfer: %w", getErr)
 		}
+		// Only replay for the same owner; a mismatch means the id collides with
+		// someone else's row (or a legacy one), so 409 instead of leaking it.
+		if existing == nil || existing.BridgeKey != req.BridgeKey || existing.Sender != req.Sender {
+			return nil, apperrors.ConflictError(nil, "a transfer with this id already exists")
+		}
 		return &relayer.RegisterTransferResponse{Transfer: existing, Created: false}, nil
 	}
 	return &relayer.RegisterTransferResponse{Transfer: transfer, Created: true}, nil
@@ -97,6 +104,10 @@ func (s *relayerService) validateRegistration(req *relayer.RegisterTransferReque
 	}
 	if req.TokenSymbol == "" || req.Amount == "" || req.Recipient == "" {
 		return apperrors.BadRequestError(nil, "token_symbol, amount, and recipient are required")
+	}
+	// Non-positive amounts would let mint detection "complete" with no mint.
+	if amt, err := decimal.NewFromString(req.Amount); err != nil || !amt.IsPositive() {
+		return apperrors.BadRequestError(nil, "amount must be a positive decimal number")
 	}
 	if req.Direction != relayer.DirectionEthereumToCanton && req.Direction != relayer.DirectionCantonToEthereum {
 		return apperrors.BadRequestError(nil, "direction must be ethereum_to_canton or canton_to_ethereum")

--- a/pkg/relayer/service/service_test.go
+++ b/pkg/relayer/service/service_test.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package service
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+
+	"github.com/chainsafe/canton-middleware/pkg/relayer"
+	"github.com/chainsafe/canton-middleware/pkg/relayer/service/mocks"
+)
+
+func validRegistration() *relayer.RegisterTransferRequest {
+	return &relayer.RegisterTransferRequest{
+		BridgeKey:    "xreserve",
+		TokenSymbol:  "USDCX",
+		Direction:    relayer.DirectionEthereumToCanton,
+		SourceTxHash: "0xdeposit",
+		TokenAddress: "0xusdc",
+		Amount:       "12.5",
+		Sender:       "0xsender",
+		Recipient:    "party::recipient",
+		Metadata:     map[string]string{"quote_id": "q-1"},
+	}
+}
+
+func TestRegisterTransfer_CreatesPendingTransfer(t *testing.T) {
+	store := mocks.NewStore(t)
+	store.EXPECT().CreateTransfer(mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, tr *relayer.Transfer) (bool, error) {
+			if tr.ID != "0xdeposit" {
+				t.Errorf("ID = %q, want default to source tx hash", tr.ID)
+			}
+			if tr.BridgeKey != "xreserve" || tr.Status != relayer.TransferStatusPending || tr.Stage != "" {
+				t.Errorf("unexpected transfer: %+v", tr)
+			}
+			if tr.SourceChain != relayer.ChainEthereum || tr.DestinationChain != relayer.ChainCanton {
+				t.Errorf("chains = %s -> %s, want ethereum -> canton", tr.SourceChain, tr.DestinationChain)
+			}
+			if tr.Metadata["quote_id"] != "q-1" {
+				t.Errorf("metadata not carried: %+v", tr.Metadata)
+			}
+			return true, nil
+		}).Once()
+
+	svc := NewService(store, []string{"xreserve"})
+	resp, err := svc.RegisterTransfer(context.Background(), validRegistration())
+	if err != nil {
+		t.Fatalf("RegisterTransfer failed: %v", err)
+	}
+	if !resp.Created || resp.Transfer == nil {
+		t.Fatalf("resp = %+v, want created transfer", resp)
+	}
+}
+
+func TestRegisterTransfer_IdempotentReplayReturnsExisting(t *testing.T) {
+	existing := &relayer.Transfer{ID: "0xdeposit", Status: relayer.TransferStatusInProgress, Stage: "awaiting_mint"}
+
+	store := mocks.NewStore(t)
+	store.EXPECT().CreateTransfer(mock.Anything, mock.Anything).Return(false, nil).Once()
+	store.EXPECT().GetTransfer(mock.Anything, "0xdeposit").Return(existing, nil).Once()
+
+	svc := NewService(store, []string{"xreserve"})
+	resp, err := svc.RegisterTransfer(context.Background(), validRegistration())
+	if err != nil {
+		t.Fatalf("RegisterTransfer failed: %v", err)
+	}
+	if resp.Created {
+		t.Fatalf("replay should report created=false")
+	}
+	if resp.Transfer.Stage != "awaiting_mint" {
+		t.Fatalf("replay should return the existing transfer, got %+v", resp.Transfer)
+	}
+}
+
+func TestRegisterTransfer_Validation(t *testing.T) {
+	svc := NewService(mocks.NewStore(t), []string{"xreserve"})
+
+	cases := []struct {
+		name    string
+		mutate  func(*relayer.RegisterTransferRequest)
+		wantErr string
+	}{
+		{"missing source tx", func(r *relayer.RegisterTransferRequest) { r.SourceTxHash = "" }, "source_tx_hash"},
+		{"missing amount", func(r *relayer.RegisterTransferRequest) { r.Amount = "" }, "amount"},
+		{"missing recipient", func(r *relayer.RegisterTransferRequest) { r.Recipient = "" }, "recipient"},
+		{"bad direction", func(r *relayer.RegisterTransferRequest) { r.Direction = "sideways" }, "direction"},
+		{"unknown bridge key", func(r *relayer.RegisterTransferRequest) { r.BridgeKey = "wayfinder" }, "unknown bridge key"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := validRegistration()
+			tc.mutate(req)
+			_, err := svc.RegisterTransfer(context.Background(), req)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("err = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/relayer/service/service_test.go
+++ b/pkg/relayer/service/service_test.go
@@ -57,7 +57,7 @@ func TestRegisterTransfer_CreatesPendingTransfer(t *testing.T) {
 }
 
 func TestRegisterTransfer_IdempotentReplayReturnsExisting(t *testing.T) {
-	existing := &relayer.Transfer{ID: "0xdeposit", Status: relayer.TransferStatusInProgress, Stage: "awaiting_mint"}
+	existing := &relayer.Transfer{ID: "0xdeposit", Status: relayer.TransferStatusPending, Stage: "awaiting_mint"}
 
 	store := mocks.NewStore(t)
 	store.EXPECT().CreateTransfer(mock.Anything, mock.Anything).Return(false, nil).Once()

--- a/pkg/relayer/service/service_test.go
+++ b/pkg/relayer/service/service_test.go
@@ -4,11 +4,14 @@ package service
 
 import (
 	"context"
+	"errors"
+	"net/http"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
 
+	apperrors "github.com/chainsafe/canton-middleware/pkg/app/errors"
 	"github.com/chainsafe/canton-middleware/pkg/relayer"
 	"github.com/chainsafe/canton-middleware/pkg/relayer/service/mocks"
 )
@@ -57,7 +60,14 @@ func TestRegisterTransfer_CreatesPendingTransfer(t *testing.T) {
 }
 
 func TestRegisterTransfer_IdempotentReplayReturnsExisting(t *testing.T) {
-	existing := &relayer.Transfer{ID: "0xdeposit", Status: relayer.TransferStatusPending, Stage: "awaiting_mint"}
+	// Same owner (bridge_key + sender) replay: returns the existing row.
+	existing := &relayer.Transfer{
+		ID:        "0xdeposit",
+		BridgeKey: "xreserve",
+		Sender:    "0xsender",
+		Status:    relayer.TransferStatusPending,
+		Stage:     "awaiting_mint",
+	}
 
 	store := mocks.NewStore(t)
 	store.EXPECT().CreateTransfer(mock.Anything, mock.Anything).Return(false, nil).Once()
@@ -73,6 +83,47 @@ func TestRegisterTransfer_IdempotentReplayReturnsExisting(t *testing.T) {
 	}
 	if resp.Transfer.Stage != "awaiting_mint" {
 		t.Fatalf("replay should return the existing transfer, got %+v", resp.Transfer)
+	}
+}
+
+func TestRegisterTransfer_ConflictOnForeignRowDoesNotLeak(t *testing.T) {
+	// Existing row under the same id belongs to a different pipeline/caller:
+	// the response must be a conflict, never the foreign record.
+	foreign := &relayer.Transfer{
+		ID:        "0xdeposit",
+		BridgeKey: "wayfinder",
+		Sender:    "0xvictim",
+		Recipient: "party::victim",
+		Amount:    "999",
+	}
+
+	store := mocks.NewStore(t)
+	store.EXPECT().CreateTransfer(mock.Anything, mock.Anything).Return(false, nil).Once()
+	store.EXPECT().GetTransfer(mock.Anything, "0xdeposit").Return(foreign, nil).Once()
+
+	svc := NewService(store, []string{"xreserve"})
+	resp, err := svc.RegisterTransfer(context.Background(), validRegistration())
+	if err == nil {
+		t.Fatalf("foreign-row registration should error")
+	}
+	var svcErr *apperrors.ServiceError
+	if !errors.As(err, &svcErr) || svcErr.StatusCode() != http.StatusConflict {
+		t.Fatalf("err = %v, want a 409 conflict ServiceError", err)
+	}
+	if resp != nil {
+		t.Fatalf("no response should be returned on conflict, got %+v", resp)
+	}
+}
+
+func TestRegisterTransfer_RejectsNonPositiveAmount(t *testing.T) {
+	svc := NewService(mocks.NewStore(t), []string{"xreserve"})
+
+	for _, amt := range []string{"0", "-100", "notanumber"} {
+		req := validRegistration()
+		req.Amount = amt
+		if _, err := svc.RegisterTransfer(context.Background(), req); err == nil {
+			t.Fatalf("amount %q should be rejected", amt)
+		}
 	}
 }
 

--- a/pkg/relayer/types.go
+++ b/pkg/relayer/types.go
@@ -73,6 +73,32 @@ type Transfer struct {
 	NextStepAt *time.Time `json:"next_step_at,omitempty"`
 }
 
+// RegisterTransferRequest registers an externally-initiated transfer for
+// observer-mechanism tracking (e.g. an xreserve deposit the dapp just sent).
+type RegisterTransferRequest struct {
+	// ID uniquely identifies the transfer; defaults to SourceTxHash.
+	ID          string            `json:"id"`
+	BridgeKey   string            `json:"bridge_key"`
+	TokenSymbol string            `json:"token_symbol"`
+	Direction   TransferDirection `json:"direction"`
+	// SourceTxHash is the initiating transaction (EVM tx hash for deposits,
+	// burn identifier for withdrawals).
+	SourceTxHash string `json:"source_tx_hash"`
+	TokenAddress string `json:"token_address"`
+	// Amount is a decimal string in token units (not base units).
+	Amount    string            `json:"amount"`
+	Sender    string            `json:"sender"`
+	Recipient string            `json:"recipient"`
+	Metadata  map[string]string `json:"metadata,omitempty"`
+}
+
+// RegisterTransferResponse reports the registered transfer and whether this
+// call created it (false when the registration was an idempotent replay).
+type RegisterTransferResponse struct {
+	Transfer *Transfer `json:"transfer"`
+	Created  bool      `json:"created"`
+}
+
 // ChainState tracks the last processed offset for a chain.
 type ChainState struct {
 	ChainID   string


### PR DESCRIPTION
Part of #357 and epic #361. **Stacked on #373** (TokenBridge foundation) — review the last commit only until #373 merges.

## What

The first `TokenBridge` adapter: `bridges/xreserve` tracks USDCx deposits (Ethereum USDC → Canton USDCx via Circle xReserve), plus the relayer registration endpoint observer mechanisms need.

## Design

xreserve is an **observer** mechanism — Circle executes the bridge, we are never in the critical path:

- `Sources()` returns nothing; transfers are registered at initiation via the new internal `POST /api/v1/transfers` (called by the api-server when the dapp submits `depositToRemote`; #358 adds that caller). Registration is idempotent and rejects bridge keys no adapter owns.
- `Step` stage machine: `"" → awaiting_attestation → awaiting_mint → completed` (stage `minted`).
  - First step snapshots the recipient's instrument balance (matched on instrument **admin + id** via `token.Token.GetHoldingsByParty`, the Splice HoldingV1 interface query) — before Ethereum finality, so before any mint for this deposit can exist.
  - Attestation polling distinguishes *not ready* (finality window, keep polling) from *unavailable* (Circle outage — keep polling, log, don't burn transfer retries) from hard errors (step error → retry/backoff machinery).
  - Completion = balance grew by the deposited amount over the baseline; the mint itself is done by the recipient's pre-approved `BridgeUserAgreement`, never by us. Relayer downtime cannot affect bridging, only status display.

## Config

```yaml
bridge:
  tokens:
    USDCX:
      mechanism: xreserve
      evm_address: "0x..."
      decimals: 6
      xreserve:
        attestation_url: "http://usdcx-attestation:8091"
        instrument_admin: "${CANTON_USDCX_ISSUER_PARTY}"
        instrument_id: "USDCx"
```

## Notes / caveats for review

- **Read rights**: holding detection requires the relayer's Canton token to read user parties (`CanReadAsAnyParty`, same as the indexer). Devnet config change, called out in the deploy notes.
- **Attestation API schema** is pinned to the shape the devstack stub will implement; Circle's production schema is an explicit #360 work item.
- Baseline-based mint detection assumes registration happens promptly after the deposit tx is sent (well within the ~15 min attestation window) — documented in the package comment.

## Remaining on #357 (follow-ups, not this PR)

- `BridgeUserAgreement` onboarding w/ pre-approval at user registration (shares the DA Utilities burn-mint-factory plumbing with #359)
- Devstack attestation stub + e2e for the full stage machine

## Testing

- Adapter: full stage-machine coverage incl. admin-mismatch filtering, transient-vs-hard attestation errors, unknown token/stage, withdrawal guard
- Attestation client: httptest coverage for complete/pending/404/5xx/4xx/connection-refused
- Service: registration create/idempotent-replay/validation matrix
- `golangci-lint` clean; existing tests pass
