### PR TITLE
feat: USDCx outbound — burn + release tracking

### DIFF
--- a/pkg/app/api/server.go
+++ b/pkg/app/api/server.go
@@ -303,7 +303,7 @@ func initServices(
 		cantonClient.Token, userStore, instrumentedCache, cfg.Token, indexerClient, cantonClient.Identity,
 	)
 
-	bridgeSvc, err := buildBridgeService(cfg, userStore, logger)
+	bridgeSvc, err := buildBridgeService(cfg, userStore, cantonClient.Token, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -320,7 +320,9 @@ func initServices(
 // buildBridgeService constructs the bridge API service when the optional
 // `bridge` config block is present. The allowance checker is optional: with
 // no eth_rpc_url, quotes always include the approve step.
-func buildBridgeService(cfg *config.APIServer, userStore userstore.Store, logger *zap.Logger) (bridgeapi.Service, error) {
+func buildBridgeService(
+	cfg *config.APIServer, userStore userstore.Store, cantonToken cantontkn.Token, logger *zap.Logger,
+) (bridgeapi.Service, error) {
 	if cfg.Bridge == nil {
 		return nil, nil
 	}
@@ -337,7 +339,7 @@ func buildBridgeService(cfg *config.APIServer, userStore userstore.Store, logger
 		}
 	}
 
-	svc, err := bridgeapi.NewService(cfg.Bridge, userStore, relayerClient, allowance, logger)
+	svc, err := bridgeapi.NewService(cfg.Bridge, userStore, relayerClient, allowance, cantonToken, logger)
 	if err != nil {
 		return nil, fmt.Errorf("create bridge service: %w", err)
 	}

--- a/pkg/bridgeapi/config.go
+++ b/pkg/bridgeapi/config.go
@@ -36,7 +36,7 @@ type TokenConfig struct {
 	XReserve *XReserveTokenConfig `yaml:"xreserve" default:"-"`
 }
 
-// XReserveTokenConfig carries the Circle xReserve deposit-call parameters.
+// XReserveTokenConfig carries the Circle xReserve bridge parameters.
 type XReserveTokenConfig struct {
 	// Contract is the xReserve contract address on the EVM chain.
 	Contract string `yaml:"contract" validate:"required"`
@@ -45,6 +45,14 @@ type XReserveTokenConfig struct {
 	RemoteDomain uint32 `yaml:"remote_domain" validate:"required"`
 	// MaxFee is the depositToRemote maxFee argument in token base units.
 	MaxFee string `yaml:"max_fee"`
+	// InstrumentAdmin is the Canton party administering the instrument
+	// (selects the burn registry via the token client's external_tokens map).
+	InstrumentAdmin string `yaml:"instrument_admin" validate:"required"`
+	// InstrumentID is the Canton token-standard instrument id (e.g. "USDCx").
+	InstrumentID string `yaml:"instrument_id" validate:"required"`
+	// WithdrawDestinationDomain is the xReserve domain burns release to
+	// (0 = Ethereum).
+	WithdrawDestinationDomain int64 `yaml:"withdraw_destination_domain"`
 }
 
 // Validate performs the cross-field checks the tag validator cannot express.

--- a/pkg/bridgeapi/http.go
+++ b/pkg/bridgeapi/http.go
@@ -34,6 +34,9 @@ func RegisterRoutes(r chi.Router, svc Service, logger *zap.Logger) {
 	r.Post("/api/v2/bridge/deposit/quote", apphttp.HandleError(h.depositQuote))
 	r.Post("/api/v2/bridge/deposits", apphttp.HandleError(h.registerDeposit))
 	r.Get("/api/v2/bridge/transfers/{id}", apphttp.HandleError(h.getTransfer))
+	r.Post("/api/v2/bridge/withdraw/prepare", apphttp.HandleError(h.withdrawPrepare))
+	r.Post("/api/v2/bridge/withdraw/execute", apphttp.HandleError(h.withdrawExecute))
+	r.Post("/api/v2/bridge/withdraw/custodial", apphttp.HandleError(h.withdrawCustodial))
 }
 
 func (h *httpHandler) tokens(w http.ResponseWriter, r *http.Request) error {
@@ -104,6 +107,75 @@ func (h *httpHandler) getTransfer(w http.ResponseWriter, r *http.Request) error 
 	}
 
 	h.writeJSON(w, http.StatusOK, transfer)
+	return nil
+}
+
+func (h *httpHandler) withdrawPrepare(w http.ResponseWriter, r *http.Request) error {
+	evmAddr, err := authenticateEVM(r)
+	if err != nil {
+		return err
+	}
+
+	var req WithdrawRequest
+	if jsonErr := readJSON(r, &req); jsonErr != nil {
+		return jsonErr
+	}
+	if req.Token == "" || req.Amount == "" || req.Recipient == "" {
+		return apperrors.BadRequestError(nil, "token, amount, and recipient are required")
+	}
+
+	resp, err := h.svc.WithdrawPrepare(r.Context(), evmAddr, &req)
+	if err != nil {
+		return err
+	}
+
+	h.writeJSON(w, http.StatusOK, resp)
+	return nil
+}
+
+func (h *httpHandler) withdrawExecute(w http.ResponseWriter, r *http.Request) error {
+	evmAddr, err := authenticateEVM(r)
+	if err != nil {
+		return err
+	}
+
+	var req WithdrawExecuteRequest
+	if jsonErr := readJSON(r, &req); jsonErr != nil {
+		return jsonErr
+	}
+	if req.TransferID == "" || req.Signature == "" || req.SignedBy == "" {
+		return apperrors.BadRequestError(nil, "transfer_id, signature, and signed_by are required")
+	}
+
+	resp, err := h.svc.WithdrawExecute(r.Context(), evmAddr, &req)
+	if err != nil {
+		return err
+	}
+
+	h.writeJSON(w, http.StatusCreated, resp)
+	return nil
+}
+
+func (h *httpHandler) withdrawCustodial(w http.ResponseWriter, r *http.Request) error {
+	evmAddr, err := authenticateEVM(r)
+	if err != nil {
+		return err
+	}
+
+	var req WithdrawRequest
+	if jsonErr := readJSON(r, &req); jsonErr != nil {
+		return jsonErr
+	}
+	if req.Token == "" || req.Amount == "" || req.Recipient == "" {
+		return apperrors.BadRequestError(nil, "token, amount, and recipient are required")
+	}
+
+	resp, err := h.svc.WithdrawCustodial(r.Context(), evmAddr, &req)
+	if err != nil {
+		return err
+	}
+
+	h.writeJSON(w, http.StatusCreated, resp)
 	return nil
 }
 

--- a/pkg/bridgeapi/service.go
+++ b/pkg/bridgeapi/service.go
@@ -42,23 +42,30 @@ type Service interface {
 	DepositQuote(ctx context.Context, evmAddress string, req *QuoteRequest) (*Quote, error)
 	RegisterDeposit(ctx context.Context, evmAddress string, req *RegisterDepositRequest) (*relayer.RegisterTransferResponse, error)
 	GetTransfer(ctx context.Context, id string) (*relayer.Transfer, error)
+	WithdrawPrepare(ctx context.Context, evmAddress string, req *WithdrawRequest) (*WithdrawPrepareResponse, error)
+	WithdrawExecute(ctx context.Context, evmAddress string, req *WithdrawExecuteRequest) (*relayer.RegisterTransferResponse, error)
+	WithdrawCustodial(ctx context.Context, evmAddress string, req *WithdrawRequest) (*relayer.RegisterTransferResponse, error)
 }
 
 type bridgeService struct {
 	cfg       *Config
 	quoters   map[string]DepositQuoter // keyed by mechanism
+	burns     *burnStore
 	userStore UserStore
 	relayer   RelayerClient
+	canton    CantonBurner // nil disables withdrawals
 	logger    *zap.Logger
 }
 
 // NewService builds the bridge service from config. allowance may be nil, in
-// which case quotes always include the approve step.
+// which case quotes always include the approve step; canton may be nil, which
+// disables withdrawals.
 func NewService(
 	cfg *Config,
 	userStore UserStore,
 	relayerClient RelayerClient,
 	allowance AllowanceChecker,
+	canton CantonBurner,
 	logger *zap.Logger,
 ) (Service, error) {
 	if err := cfg.Validate(); err != nil {
@@ -80,8 +87,10 @@ func NewService(
 	return &bridgeService{
 		cfg:       cfg,
 		quoters:   quoters,
+		burns:     newBurnStore(),
 		userStore: userStore,
 		relayer:   relayerClient,
+		canton:    canton,
 		logger:    logger,
 	}, nil
 }

--- a/pkg/bridgeapi/service_test.go
+++ b/pkg/bridgeapi/service_test.go
@@ -33,15 +33,29 @@ func (f *fakeUserStore) GetUserByEVMAddress(_ context.Context, evmAddress string
 type fakeRelayer struct {
 	registered *relayer.RegisterTransferRequest
 	transfer   *relayer.Transfer
+	// seen models the relayer's idempotent CreateTransfer: a repeated id
+	// returns created=false, as the real ON CONFLICT DO NOTHING would.
+	seen         map[string]bool
+	registerErr  error
+	registerHits int
 }
 
 func (f *fakeRelayer) RegisterTransfer(
 	_ context.Context, req *relayer.RegisterTransferRequest,
 ) (*relayer.RegisterTransferResponse, error) {
+	f.registerHits++
+	if f.registerErr != nil {
+		return nil, f.registerErr
+	}
 	f.registered = req
+	if f.seen == nil {
+		f.seen = map[string]bool{}
+	}
+	created := !f.seen[req.ID]
+	f.seen[req.ID] = true
 	return &relayer.RegisterTransferResponse{
 		Transfer: &relayer.Transfer{ID: req.ID, Status: relayer.TransferStatusPending},
-		Created:  true,
+		Created:  created,
 	}, nil
 }
 

--- a/pkg/bridgeapi/service_test.go
+++ b/pkg/bridgeapi/service_test.go
@@ -8,6 +8,7 @@ import (
 
 	"go.uber.org/zap"
 
+	cantontkn "github.com/chainsafe/canton-middleware/pkg/cantonsdk/token"
 	"github.com/chainsafe/canton-middleware/pkg/relayer"
 	"github.com/chainsafe/canton-middleware/pkg/user"
 )
@@ -58,12 +59,43 @@ func testConfig() *Config {
 	}
 }
 
+// fakeBurner records burn calls and returns canned results.
+type fakeBurner struct {
+	prepared    *cantontkn.PreparedTransfer
+	prepareErr  error
+	burnReq     *cantontkn.PrepareBurnRequest
+	executed    *cantontkn.ExecuteTransferRequest
+	burnErr     error
+	executeErr  error
+	customCalls int
+}
+
+func (f *fakeBurner) PrepareBurn(_ context.Context, req *cantontkn.PrepareBurnRequest) (*cantontkn.PreparedTransfer, error) {
+	f.burnReq = req
+	return f.prepared, f.prepareErr
+}
+
+func (f *fakeBurner) BurnByPartyID(_ context.Context, req *cantontkn.PrepareBurnRequest) error {
+	f.customCalls++
+	f.burnReq = req
+	return f.burnErr
+}
+
+func (f *fakeBurner) ExecuteTransfer(_ context.Context, req *cantontkn.ExecuteTransferRequest) error {
+	f.executed = req
+	return f.executeErr
+}
+
 func newTestService(t *testing.T, rc RelayerClient) Service {
 	t.Helper()
-	users := &fakeUserStore{users: map[string]*user.User{
+	return newTestServiceWithUsers(t, rc, &fakeBurner{}, map[string]*user.User{
 		testEVMAddress: {EVMAddress: testEVMAddress, CantonParty: testParty},
-	}}
-	svc, err := NewService(testConfig(), users, rc, nil, zap.NewNop())
+	})
+}
+
+func newTestServiceWithUsers(t *testing.T, rc RelayerClient, burner CantonBurner, users map[string]*user.User) Service {
+	t.Helper()
+	svc, err := NewService(testConfig(), &fakeUserStore{users: users}, rc, nil, burner, zap.NewNop())
 	if err != nil {
 		t.Fatalf("NewService failed: %v", err)
 	}
@@ -82,7 +114,7 @@ func TestService_Tokens(t *testing.T) {
 func TestService_DepositQuote_HappyPath(t *testing.T) {
 	svc := newTestService(t, &fakeRelayer{})
 
-	quote, err := svc.DepositQuote(context.Background(), testEVMAddress, &QuoteRequest{Token: testTokenSym, Amount: "12.5"})
+	quote, err := svc.DepositQuote(context.Background(), testEVMAddress, &QuoteRequest{Token: testTokenSym, Amount: testAmount})
 	if err != nil {
 		t.Fatalf("DepositQuote failed: %v", err)
 	}
@@ -126,7 +158,7 @@ func TestService_RegisterDeposit_DerivesRecipientFromSession(t *testing.T) {
 
 	resp, err := svc.RegisterDeposit(context.Background(), testEVMAddress, &RegisterDepositRequest{
 		Token:  testTokenSym,
-		Amount: "12.5",
+		Amount: testAmount,
 		TxHash: testTxHash,
 	})
 	if err != nil {
@@ -143,7 +175,7 @@ func TestService_RegisterDeposit_DerivesRecipientFromSession(t *testing.T) {
 	// Recipient and mechanism come from the session/config, never the caller;
 	// the id is namespaced so it cannot collide with observer ids.
 	if reg.BridgeKey != MechanismXReserve || reg.TokenSymbol != testTokenSym ||
-		reg.Amount != "12.5" || reg.Recipient != testParty ||
+		reg.Amount != testAmount || reg.Recipient != testParty ||
 		reg.Sender != testEVMAddress || reg.SourceTxHash != testTxHash {
 		t.Fatalf("registered = %+v", reg)
 	}
@@ -179,3 +211,5 @@ func TestService_RegisterDeposit_Validation(t *testing.T) {
 		})
 	}
 }
+
+const testAmount = "12.5"

--- a/pkg/bridgeapi/withdraw.go
+++ b/pkg/bridgeapi/withdraw.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 
 	apperrors "github.com/chainsafe/canton-middleware/pkg/app/errors"
@@ -20,10 +19,6 @@ import (
 	"github.com/chainsafe/canton-middleware/pkg/relayer"
 	"github.com/chainsafe/canton-middleware/pkg/user"
 )
-
-// metaBurnRequestID correlates the Canton burn with Circle's release; the
-// relayer's xreserve adapter polls release status by this id.
-const metaBurnRequestID = "burn_request_id"
 
 // CantonBurner is the slice of the Canton token client the withdraw flow
 // needs: burn preparation/execution for external keys and direct burns for
@@ -42,6 +37,8 @@ type WithdrawRequest struct {
 	Amount string `json:"amount"`
 	// Recipient is the destination EVM address.
 	Recipient string `json:"recipient"`
+	// IdempotencyKey ties a retry to the same burn so it never burns twice. Required.
+	IdempotencyKey string `json:"idempotency_key"`
 }
 
 // WithdrawPrepareResponse carries the hash an external-key user signs.
@@ -95,6 +92,18 @@ func (s *burnStore) Put(b *preparedBurn) {
 	s.burns[b.Prepared.TransferID] = b
 }
 
+// Peek returns the prepared burn without consuming it, so callers can validate
+// before the single-use Take.
+func (s *burnStore) Peek(transferID string) (*preparedBurn, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	b, ok := s.burns[transferID]
+	if !ok || s.now().After(b.Prepared.ExpiresAt) {
+		return nil, false
+	}
+	return b, true
+}
+
 // Take removes and returns the prepared burn if present and unexpired.
 func (s *burnStore) Take(transferID string) (*preparedBurn, bool) {
 	s.mu.Lock()
@@ -126,7 +135,8 @@ func (s *bridgeService) WithdrawPrepare(
 		return nil, apperrors.BadRequestError(nil, "custodial users must use the custodial withdraw endpoint")
 	}
 
-	requestID := uuid.NewString()
+	// Use the idempotency key as the stable request id so a re-prepare dedupes.
+	requestID := req.IdempotencyKey
 	prepared, err := s.canton.PrepareBurn(ctx, burnRequest(tc, usr.CantonParty, req, requestID))
 	if err != nil {
 		return nil, fmt.Errorf("prepare burn: %w", err)
@@ -150,12 +160,13 @@ func (s *bridgeService) WithdrawPrepare(
 	}, nil
 }
 
-// WithdrawExecute submits the user-signed burn and registers the transfer
-// with the relayer for release tracking.
+// WithdrawExecute submits the user-signed burn and tracks it. It validates
+// (via Peek) before consuming the burn, so a bad request can't destroy it, and
+// registers before submitting so a crash never leaves an untracked burn.
 func (s *bridgeService) WithdrawExecute(
 	ctx context.Context, evmAddress string, req *WithdrawExecuteRequest,
 ) (*relayer.RegisterTransferResponse, error) {
-	burn, ok := s.burns.Take(req.TransferID)
+	burn, ok := s.burns.Peek(req.TransferID)
 	if !ok {
 		return nil, apperrors.ResourceNotFoundError(nil, "unknown or expired transfer_id")
 	}
@@ -176,6 +187,20 @@ func (s *bridgeService) WithdrawExecute(
 		return nil, apperrors.BadRequestError(err, "invalid DER signature")
 	}
 
+	// Consume the single-use burn; a concurrent duplicate loses this race.
+	if _, ok = s.burns.Take(req.TransferID); !ok {
+		return nil, apperrors.ResourceNotFoundError(nil, "transfer already executed")
+	}
+
+	resp, created, err := s.registerWithdrawal(ctx, burn.TokenSymbol, burn.TokenAddress,
+		burn.Amount, burn.Sender, burn.Recipient, burn.RequestID)
+	if err != nil {
+		return nil, err
+	}
+	if !created {
+		return resp, nil // already submitted under this id; don't burn again
+	}
+
 	if err = s.canton.ExecuteTransfer(ctx, &cantontkn.ExecuteTransferRequest{
 		PreparedTransfer: burn.Prepared,
 		Signature:        sigBytes,
@@ -183,13 +208,12 @@ func (s *bridgeService) WithdrawExecute(
 	}); err != nil {
 		return nil, fmt.Errorf("execute burn: %w", err)
 	}
-
-	return s.registerWithdrawal(ctx, burn.TokenSymbol, burn.TokenAddress,
-		burn.Amount, burn.Sender, burn.Recipient, burn.RequestID)
+	return resp, nil
 }
 
-// WithdrawCustodial burns server-side for a custodial user and registers the
-// transfer for release tracking.
+// WithdrawCustodial burns server-side for a custodial user. It registers
+// (keyed by the idempotency key) before burning, so a retry of a lost-response
+// call returns the existing transfer instead of burning twice.
 func (s *bridgeService) WithdrawCustodial(
 	ctx context.Context, evmAddress string, req *WithdrawRequest,
 ) (*relayer.RegisterTransferResponse, error) {
@@ -201,13 +225,20 @@ func (s *bridgeService) WithdrawCustodial(
 		return nil, apperrors.BadRequestError(nil, "only custodial users can use this endpoint")
 	}
 
-	requestID := uuid.NewString()
+	requestID := req.IdempotencyKey
+	resp, created, err := s.registerWithdrawal(ctx, req.Token, tc.EVMAddress,
+		req.Amount, usr.CantonParty, req.Recipient, requestID)
+	if err != nil {
+		return nil, err
+	}
+	if !created {
+		return resp, nil // retry: already submitted under this id, don't burn again
+	}
+
 	if err = s.canton.BurnByPartyID(ctx, burnRequest(tc, usr.CantonParty, req, requestID)); err != nil {
 		return nil, fmt.Errorf("burn: %w", err)
 	}
-
-	return s.registerWithdrawal(ctx, req.Token, tc.EVMAddress,
-		req.Amount, usr.CantonParty, req.Recipient, requestID)
+	return resp, nil
 }
 
 // validateWithdraw shares the request/token/user checks between the
@@ -232,6 +263,9 @@ func (s *bridgeService) validateWithdraw(
 		return TokenConfig{}, nil, apperrors.BadRequestError(nil,
 			"invalid recipient: must be a 0x-prefixed 40-hex-char EVM address")
 	}
+	if req.IdempotencyKey == "" {
+		return TokenConfig{}, nil, apperrors.BadRequestError(nil, "idempotency_key is required")
+	}
 
 	usr, err := s.userStore.GetUserByEVMAddress(ctx, evmAddress)
 	if err != nil {
@@ -254,14 +288,16 @@ func burnRequest(tc TokenConfig, partyID string, req *WithdrawRequest, requestID
 	}
 }
 
-// registerWithdrawal records the burn with the relayer so the xreserve
-// adapter can track Circle's release.
+// registerWithdrawal records the pending withdrawal (before the burn) so the
+// adapter can track the release. Its created result drives idempotency: false
+// means this id was already registered (a retry), so don't burn again.
 func (s *bridgeService) registerWithdrawal(
 	ctx context.Context,
 	tokenSymbol, tokenAddress, amount, senderParty, recipient, requestID string,
-) (*relayer.RegisterTransferResponse, error) {
-	resp, err := s.relayer.RegisterTransfer(ctx, &relayer.RegisterTransferRequest{
-		ID:           requestID,
+) (resp *relayer.RegisterTransferResponse, created bool, err error) {
+	id := registrationID(MechanismXReserve, requestID)
+	resp, err = s.relayer.RegisterTransfer(ctx, &relayer.RegisterTransferRequest{
+		ID:           id,
 		BridgeKey:    MechanismXReserve,
 		TokenSymbol:  tokenSymbol,
 		Direction:    relayer.DirectionCantonToEthereum,
@@ -270,13 +306,10 @@ func (s *bridgeService) registerWithdrawal(
 		Amount:       amount,
 		Sender:       senderParty,
 		Recipient:    recipient,
-		Metadata:     map[string]string{metaBurnRequestID: requestID},
+		Metadata:     map[string]string{relayer.MetaBurnRequestID: requestID},
 	})
 	if err != nil {
-		// The burn already settled on Canton; registration is status
-		// tracking only, so surface the failure without implying the
-		// withdrawal itself failed.
-		return nil, fmt.Errorf("burn submitted but status registration failed: %w", err)
+		return nil, false, fmt.Errorf("register withdrawal: %w", err)
 	}
-	return resp, nil
+	return resp, resp.Created, nil
 }

--- a/pkg/bridgeapi/withdraw.go
+++ b/pkg/bridgeapi/withdraw.go
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package bridgeapi
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	apperrors "github.com/chainsafe/canton-middleware/pkg/app/errors"
+	"github.com/chainsafe/canton-middleware/pkg/auth"
+	cantontkn "github.com/chainsafe/canton-middleware/pkg/cantonsdk/token"
+	"github.com/chainsafe/canton-middleware/pkg/relayer"
+	"github.com/chainsafe/canton-middleware/pkg/user"
+)
+
+// metaBurnRequestID correlates the Canton burn with Circle's release; the
+// relayer's xreserve adapter polls release status by this id.
+const metaBurnRequestID = "burn_request_id"
+
+// CantonBurner is the slice of the Canton token client the withdraw flow
+// needs: burn preparation/execution for external keys and direct burns for
+// custodial parties.
+type CantonBurner interface {
+	PrepareBurn(ctx context.Context, req *cantontkn.PrepareBurnRequest) (*cantontkn.PreparedTransfer, error)
+	BurnByPartyID(ctx context.Context, req *cantontkn.PrepareBurnRequest) error
+	ExecuteTransfer(ctx context.Context, req *cantontkn.ExecuteTransferRequest) error
+}
+
+// WithdrawRequest asks to bridge Amount of Token from the authenticated
+// user's Canton holdings back to an EVM address.
+type WithdrawRequest struct {
+	Token string `json:"token"`
+	// Amount is a decimal string in token units.
+	Amount string `json:"amount"`
+	// Recipient is the destination EVM address.
+	Recipient string `json:"recipient"`
+}
+
+// WithdrawPrepareResponse carries the hash an external-key user signs.
+type WithdrawPrepareResponse struct {
+	TransferID      string    `json:"transfer_id"`
+	TransactionHash string    `json:"transaction_hash"`
+	ExpiresAt       time.Time `json:"expires_at"`
+}
+
+// WithdrawExecuteRequest completes a prepared withdrawal with the user's
+// signature over the transaction hash.
+type WithdrawExecuteRequest struct {
+	TransferID string `json:"transfer_id"`
+	Signature  string `json:"signature"`
+	SignedBy   string `json:"signed_by"`
+}
+
+// preparedBurn holds a prepared-but-unsigned burn between prepare and execute.
+type preparedBurn struct {
+	Prepared     *cantontkn.PreparedTransfer
+	Owner        string // authenticated EVM address
+	TokenSymbol  string
+	TokenAddress string
+	Amount       string
+	Recipient    string // destination EVM address
+	Sender       string // Canton party performing the burn
+	RequestID    string
+}
+
+// burnStore is the in-memory holding pen for prepared burns, mirroring the
+// quote store's process-local semantics.
+type burnStore struct {
+	mu    sync.Mutex
+	burns map[string]*preparedBurn
+	now   func() time.Time
+}
+
+func newBurnStore() *burnStore {
+	return &burnStore{burns: make(map[string]*preparedBurn), now: time.Now}
+}
+
+func (s *burnStore) Put(b *preparedBurn) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := s.now()
+	for id, stored := range s.burns {
+		if now.After(stored.Prepared.ExpiresAt) {
+			delete(s.burns, id)
+		}
+	}
+	s.burns[b.Prepared.TransferID] = b
+}
+
+// Take removes and returns the prepared burn if present and unexpired.
+func (s *burnStore) Take(transferID string) (*preparedBurn, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	b, ok := s.burns[transferID]
+	if !ok {
+		return nil, false
+	}
+	delete(s.burns, transferID)
+	if s.now().After(b.Prepared.ExpiresAt) {
+		return nil, false
+	}
+	return b, true
+}
+
+// WithdrawPrepare builds a BridgeUserAgreement_Burn for an external-key user
+// and returns the hash to sign.
+func (s *bridgeService) WithdrawPrepare(
+	ctx context.Context, evmAddress string, req *WithdrawRequest,
+) (*WithdrawPrepareResponse, error) {
+	tc, usr, err := s.validateWithdraw(ctx, evmAddress, req)
+	if err != nil {
+		return nil, err
+	}
+	if usr.KeyMode != user.KeyModeCustodial && usr.KeyMode != user.KeyModeExternal {
+		return nil, apperrors.BadRequestError(nil, fmt.Sprintf("unknown key mode %q", usr.KeyMode))
+	}
+	if usr.KeyMode == user.KeyModeCustodial {
+		return nil, apperrors.BadRequestError(nil, "custodial users must use the custodial withdraw endpoint")
+	}
+
+	requestID := uuid.NewString()
+	prepared, err := s.canton.PrepareBurn(ctx, burnRequest(tc, usr.CantonParty, req, requestID))
+	if err != nil {
+		return nil, fmt.Errorf("prepare burn: %w", err)
+	}
+
+	s.burns.Put(&preparedBurn{
+		Prepared:     prepared,
+		Owner:        evmAddress,
+		TokenSymbol:  req.Token,
+		TokenAddress: tc.EVMAddress,
+		Amount:       req.Amount,
+		Recipient:    req.Recipient,
+		Sender:       usr.CantonParty,
+		RequestID:    requestID,
+	})
+
+	return &WithdrawPrepareResponse{
+		TransferID:      prepared.TransferID,
+		TransactionHash: "0x" + hex.EncodeToString(prepared.TransactionHash),
+		ExpiresAt:       prepared.ExpiresAt,
+	}, nil
+}
+
+// WithdrawExecute submits the user-signed burn and registers the transfer
+// with the relayer for release tracking.
+func (s *bridgeService) WithdrawExecute(
+	ctx context.Context, evmAddress string, req *WithdrawExecuteRequest,
+) (*relayer.RegisterTransferResponse, error) {
+	burn, ok := s.burns.Take(req.TransferID)
+	if !ok {
+		return nil, apperrors.ResourceNotFoundError(nil, "unknown or expired transfer_id")
+	}
+	if burn.Owner != evmAddress {
+		return nil, apperrors.UnAuthorizedError(nil, "transfer belongs to a different address")
+	}
+
+	usr, err := s.userStore.GetUserByEVMAddress(ctx, evmAddress)
+	if err != nil {
+		return nil, apperrors.UnAuthorizedError(err, "user not found")
+	}
+	if usr.CantonPublicKeyFingerprint != req.SignedBy {
+		return nil, apperrors.ForbiddenError(nil, "signature fingerprint does not match registered key")
+	}
+
+	sigBytes, err := hex.DecodeString(strings.TrimPrefix(req.Signature, "0x"))
+	if err != nil {
+		return nil, apperrors.BadRequestError(err, "invalid DER signature")
+	}
+
+	if err = s.canton.ExecuteTransfer(ctx, &cantontkn.ExecuteTransferRequest{
+		PreparedTransfer: burn.Prepared,
+		Signature:        sigBytes,
+		SignedBy:         req.SignedBy,
+	}); err != nil {
+		return nil, fmt.Errorf("execute burn: %w", err)
+	}
+
+	return s.registerWithdrawal(ctx, burn.TokenSymbol, burn.TokenAddress,
+		burn.Amount, burn.Sender, burn.Recipient, burn.RequestID)
+}
+
+// WithdrawCustodial burns server-side for a custodial user and registers the
+// transfer for release tracking.
+func (s *bridgeService) WithdrawCustodial(
+	ctx context.Context, evmAddress string, req *WithdrawRequest,
+) (*relayer.RegisterTransferResponse, error) {
+	tc, usr, err := s.validateWithdraw(ctx, evmAddress, req)
+	if err != nil {
+		return nil, err
+	}
+	if usr.KeyMode != user.KeyModeCustodial {
+		return nil, apperrors.BadRequestError(nil, "only custodial users can use this endpoint")
+	}
+
+	requestID := uuid.NewString()
+	if err = s.canton.BurnByPartyID(ctx, burnRequest(tc, usr.CantonParty, req, requestID)); err != nil {
+		return nil, fmt.Errorf("burn: %w", err)
+	}
+
+	return s.registerWithdrawal(ctx, req.Token, tc.EVMAddress,
+		req.Amount, usr.CantonParty, req.Recipient, requestID)
+}
+
+// validateWithdraw shares the request/token/user checks between the
+// external-key and custodial withdraw paths.
+func (s *bridgeService) validateWithdraw(
+	ctx context.Context, evmAddress string, req *WithdrawRequest,
+) (TokenConfig, *user.User, error) {
+	tc, ok := s.cfg.Tokens[req.Token]
+	if !ok || tc.Mechanism != MechanismXReserve || tc.XReserve == nil {
+		return TokenConfig{}, nil, apperrors.BadRequestError(nil,
+			fmt.Sprintf("token %q does not support bridged withdrawals", req.Token))
+	}
+	if s.canton == nil {
+		return TokenConfig{}, nil, errors.New("withdrawals are not configured (no canton client)")
+	}
+
+	amount, err := decimal.NewFromString(req.Amount)
+	if err != nil || !amount.IsPositive() {
+		return TokenConfig{}, nil, apperrors.BadRequestError(nil, "invalid amount: must be a positive decimal number")
+	}
+	if !auth.ValidateEVMAddress(req.Recipient) {
+		return TokenConfig{}, nil, apperrors.BadRequestError(nil,
+			"invalid recipient: must be a 0x-prefixed 40-hex-char EVM address")
+	}
+
+	usr, err := s.userStore.GetUserByEVMAddress(ctx, evmAddress)
+	if err != nil {
+		return TokenConfig{}, nil, apperrors.ResourceNotFoundError(err, "user is not registered")
+	}
+	return tc, usr, nil
+}
+
+func burnRequest(tc TokenConfig, partyID string, req *WithdrawRequest, requestID string) *cantontkn.PrepareBurnRequest {
+	return &cantontkn.PrepareBurnRequest{
+		PartyID: partyID,
+		// The Canton instrument id, not the API symbol: holdings selection
+		// queries the Splice HoldingV1 interface by instrument.
+		TokenSymbol:       tc.XReserve.InstrumentID,
+		Amount:            req.Amount,
+		InstrumentAdmin:   tc.XReserve.InstrumentAdmin,
+		DestinationDomain: tc.XReserve.WithdrawDestinationDomain,
+		EvmRecipient:      req.Recipient,
+		RequestID:         requestID,
+	}
+}
+
+// registerWithdrawal records the burn with the relayer so the xreserve
+// adapter can track Circle's release.
+func (s *bridgeService) registerWithdrawal(
+	ctx context.Context,
+	tokenSymbol, tokenAddress, amount, senderParty, recipient, requestID string,
+) (*relayer.RegisterTransferResponse, error) {
+	resp, err := s.relayer.RegisterTransfer(ctx, &relayer.RegisterTransferRequest{
+		ID:           requestID,
+		BridgeKey:    MechanismXReserve,
+		TokenSymbol:  tokenSymbol,
+		Direction:    relayer.DirectionCantonToEthereum,
+		SourceTxHash: requestID,
+		TokenAddress: tokenAddress,
+		Amount:       amount,
+		Sender:       senderParty,
+		Recipient:    recipient,
+		Metadata:     map[string]string{metaBurnRequestID: requestID},
+	})
+	if err != nil {
+		// The burn already settled on Canton; registration is status
+		// tracking only, so surface the failure without implying the
+		// withdrawal itself failed.
+		return nil, fmt.Errorf("burn submitted but status registration failed: %w", err)
+	}
+	return resp, nil
+}

--- a/pkg/bridgeapi/withdraw_test.go
+++ b/pkg/bridgeapi/withdraw_test.go
@@ -46,7 +46,12 @@ func preparedBurnTransfer() *cantontkn.PreparedTransfer {
 }
 
 func withdrawReq() *WithdrawRequest {
-	return &WithdrawRequest{Token: "USDCX", Amount: testAmount, Recipient: testEVMRecipient}
+	return &WithdrawRequest{
+		Token:          "USDCX",
+		Amount:         testAmount,
+		Recipient:      testEVMRecipient,
+		IdempotencyKey: "idem-1",
+	}
 }
 
 func TestWithdrawPrepare_ExternalKey(t *testing.T) {
@@ -136,7 +141,7 @@ func TestWithdrawExecute_SubmitsAndRegisters(t *testing.T) {
 	if reg.Direction != relayer.DirectionCantonToEthereum || reg.BridgeKey != MechanismXReserve {
 		t.Fatalf("registered = %+v", reg)
 	}
-	if reg.Metadata[metaBurnRequestID] == "" || reg.SourceTxHash != reg.Metadata[metaBurnRequestID] {
+	if reg.Metadata[relayer.MetaBurnRequestID] == "" || reg.SourceTxHash != reg.Metadata[relayer.MetaBurnRequestID] {
 		t.Fatalf("burn request id not propagated: %+v", reg)
 	}
 	if reg.Recipient != testEVMRecipient || reg.Sender != "party::external" || reg.Amount != testAmount {
@@ -211,5 +216,64 @@ func TestWithdrawCustodial_ExternalUserRejected(t *testing.T) {
 
 	if _, err := svc.WithdrawCustodial(context.Background(), testExternalAddr, withdrawReq()); err == nil {
 		t.Fatalf("external-key user on custodial endpoint should fail")
+	}
+}
+
+// TestWithdrawCustodial_RetryDoesNotDoubleBurn is the O1 regression: a retry
+// with the same idempotency key must not trigger a second on-chain burn.
+func TestWithdrawCustodial_RetryDoesNotDoubleBurn(t *testing.T) {
+	burner := &fakeBurner{}
+	rc := &fakeRelayer{}
+	svc := newTestServiceWithUsers(t, rc, burner, withdrawUsers())
+	ctx := context.Background()
+
+	if _, err := svc.WithdrawCustodial(ctx, testCustodialAddr, withdrawReq()); err != nil {
+		t.Fatalf("first WithdrawCustodial failed: %v", err)
+	}
+	// Same idempotency key: the relayer reports the row already exists, so the
+	// second call must return without burning again.
+	resp, err := svc.WithdrawCustodial(ctx, testCustodialAddr, withdrawReq())
+	if err != nil {
+		t.Fatalf("retry WithdrawCustodial failed: %v", err)
+	}
+	if resp.Created {
+		t.Fatalf("retry should report created=false")
+	}
+	if burner.customCalls != 1 {
+		t.Fatalf("burn executed %d times, want exactly 1", burner.customCalls)
+	}
+}
+
+// TestWithdrawExecute_FailedValidationPreservesBurn is the O2 regression: a
+// validation failure (wrong fingerprint) must not consume the prepared burn,
+// so a subsequent correct execute still succeeds.
+func TestWithdrawExecute_FailedValidationPreservesBurn(t *testing.T) {
+	burner := &fakeBurner{prepared: preparedBurnTransfer()}
+	svc := newTestServiceWithUsers(t, &fakeRelayer{}, burner, withdrawUsers())
+	ctx := context.Background()
+
+	prep, err := svc.WithdrawPrepare(ctx, testExternalAddr, withdrawReq())
+	if err != nil {
+		t.Fatalf("prepare failed: %v", err)
+	}
+
+	// Wrong fingerprint: must fail without consuming the burn.
+	if _, err = svc.WithdrawExecute(ctx, testExternalAddr, &WithdrawExecuteRequest{
+		TransferID: prep.TransferID, Signature: "0xabcd", SignedBy: "1220wrong",
+	}); err == nil {
+		t.Fatalf("wrong fingerprint should fail")
+	}
+	if burner.executed != nil {
+		t.Fatalf("burn must not have been executed on a failed validation")
+	}
+
+	// The correct execute still works: the burn was preserved.
+	if _, err = svc.WithdrawExecute(ctx, testExternalAddr, &WithdrawExecuteRequest{
+		TransferID: prep.TransferID, Signature: "0xabcd", SignedBy: testFingerprint,
+	}); err != nil {
+		t.Fatalf("execute after a failed attempt should succeed: %v", err)
+	}
+	if burner.executed == nil {
+		t.Fatalf("burn should have executed on the valid attempt")
 	}
 }

--- a/pkg/bridgeapi/withdraw_test.go
+++ b/pkg/bridgeapi/withdraw_test.go
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package bridgeapi
+
+import (
+	"context"
+	"encoding/hex"
+	"testing"
+	"time"
+
+	cantontkn "github.com/chainsafe/canton-middleware/pkg/cantonsdk/token"
+	"github.com/chainsafe/canton-middleware/pkg/relayer"
+	"github.com/chainsafe/canton-middleware/pkg/user"
+)
+
+const (
+	testExternalAddr  = "0x00000000000000000000000000000000000000ee"
+	testCustodialAddr = "0x00000000000000000000000000000000000000cc"
+	testEVMRecipient  = "0x1111111111111111111111111111111111111111"
+	testFingerprint   = "1220fingerprint"
+)
+
+func withdrawUsers() map[string]*user.User {
+	return map[string]*user.User{
+		testExternalAddr: {
+			EVMAddress:                 testExternalAddr,
+			CantonParty:                "party::external",
+			KeyMode:                    user.KeyModeExternal,
+			CantonPublicKeyFingerprint: testFingerprint,
+		},
+		testCustodialAddr: {
+			EVMAddress:  testCustodialAddr,
+			CantonParty: "party::custodial",
+			KeyMode:     user.KeyModeCustodial,
+		},
+	}
+}
+
+func preparedBurnTransfer() *cantontkn.PreparedTransfer {
+	return &cantontkn.PreparedTransfer{
+		TransferID:      "burn-1",
+		TransactionHash: []byte{0xde, 0xad},
+		PartyID:         "party::external",
+		ExpiresAt:       time.Now().Add(time.Minute),
+	}
+}
+
+func withdrawReq() *WithdrawRequest {
+	return &WithdrawRequest{Token: "USDCX", Amount: testAmount, Recipient: testEVMRecipient}
+}
+
+func TestWithdrawPrepare_ExternalKey(t *testing.T) {
+	burner := &fakeBurner{prepared: preparedBurnTransfer()}
+	svc := newTestServiceWithUsers(t, &fakeRelayer{}, burner, withdrawUsers())
+
+	resp, err := svc.WithdrawPrepare(context.Background(), testExternalAddr, withdrawReq())
+	if err != nil {
+		t.Fatalf("WithdrawPrepare failed: %v", err)
+	}
+	if resp.TransferID != "burn-1" || resp.TransactionHash != "0x"+hex.EncodeToString([]byte{0xde, 0xad}) {
+		t.Fatalf("resp = %+v", resp)
+	}
+
+	req := burner.burnReq
+	if req == nil {
+		t.Fatalf("PrepareBurn never called")
+	}
+	if req.PartyID != "party::external" || req.TokenSymbol != "USDCx" ||
+		req.InstrumentAdmin != "circle::admin" || req.EvmRecipient != testEVMRecipient ||
+		req.Amount != testAmount || req.RequestID == "" {
+		t.Fatalf("burn request = %+v", req)
+	}
+}
+
+func TestWithdrawPrepare_CustodialUserRejected(t *testing.T) {
+	svc := newTestServiceWithUsers(t, &fakeRelayer{}, &fakeBurner{}, withdrawUsers())
+
+	if _, err := svc.WithdrawPrepare(context.Background(), testCustodialAddr, withdrawReq()); err == nil {
+		t.Fatalf("custodial user on prepare endpoint should fail")
+	}
+}
+
+func TestWithdrawPrepare_Validation(t *testing.T) {
+	svc := newTestServiceWithUsers(t, &fakeRelayer{}, &fakeBurner{prepared: preparedBurnTransfer()}, withdrawUsers())
+	ctx := context.Background()
+
+	cases := []struct {
+		name   string
+		mutate func(*WithdrawRequest)
+	}{
+		{"unsupported token", func(r *WithdrawRequest) { r.Token = "DOGE" }},
+		{"bad amount", func(r *WithdrawRequest) { r.Amount = "-3" }},
+		{"bad recipient", func(r *WithdrawRequest) { r.Recipient = "not-an-address" }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := withdrawReq()
+			tc.mutate(req)
+			if _, err := svc.WithdrawPrepare(ctx, testExternalAddr, req); err == nil {
+				t.Fatalf("expected error")
+			}
+		})
+	}
+}
+
+func TestWithdrawExecute_SubmitsAndRegisters(t *testing.T) {
+	burner := &fakeBurner{prepared: preparedBurnTransfer()}
+	rc := &fakeRelayer{}
+	svc := newTestServiceWithUsers(t, rc, burner, withdrawUsers())
+	ctx := context.Background()
+
+	prep, err := svc.WithdrawPrepare(ctx, testExternalAddr, withdrawReq())
+	if err != nil {
+		t.Fatalf("WithdrawPrepare failed: %v", err)
+	}
+
+	resp, err := svc.WithdrawExecute(ctx, testExternalAddr, &WithdrawExecuteRequest{
+		TransferID: prep.TransferID,
+		Signature:  "0xabcdef",
+		SignedBy:   testFingerprint,
+	})
+	if err != nil {
+		t.Fatalf("WithdrawExecute failed: %v", err)
+	}
+	if !resp.Created {
+		t.Fatalf("resp = %+v", resp)
+	}
+	if burner.executed == nil || burner.executed.SignedBy != testFingerprint {
+		t.Fatalf("ExecuteTransfer not called correctly: %+v", burner.executed)
+	}
+
+	reg := rc.registered
+	if reg == nil {
+		t.Fatalf("relayer never called")
+	}
+	if reg.Direction != relayer.DirectionCantonToEthereum || reg.BridgeKey != MechanismXReserve {
+		t.Fatalf("registered = %+v", reg)
+	}
+	if reg.Metadata[metaBurnRequestID] == "" || reg.SourceTxHash != reg.Metadata[metaBurnRequestID] {
+		t.Fatalf("burn request id not propagated: %+v", reg)
+	}
+	if reg.Recipient != testEVMRecipient || reg.Sender != "party::external" || reg.Amount != testAmount {
+		t.Fatalf("registered = %+v", reg)
+	}
+
+	// The prepared burn is single-use.
+	if _, err = svc.WithdrawExecute(ctx, testExternalAddr, &WithdrawExecuteRequest{
+		TransferID: prep.TransferID, Signature: "0xabcdef", SignedBy: testFingerprint,
+	}); err == nil {
+		t.Fatalf("replayed execute should fail")
+	}
+}
+
+func TestWithdrawExecute_Guards(t *testing.T) {
+	burner := &fakeBurner{prepared: preparedBurnTransfer()}
+	svc := newTestServiceWithUsers(t, &fakeRelayer{}, burner, withdrawUsers())
+	ctx := context.Background()
+
+	// Unknown transfer id.
+	if _, err := svc.WithdrawExecute(ctx, testExternalAddr, &WithdrawExecuteRequest{
+		TransferID: "nope", Signature: "0x1", SignedBy: testFingerprint,
+	}); err == nil {
+		t.Fatalf("unknown transfer should fail")
+	}
+
+	// Foreign owner.
+	prep, err := svc.WithdrawPrepare(ctx, testExternalAddr, withdrawReq())
+	if err != nil {
+		t.Fatalf("prepare failed: %v", err)
+	}
+	if _, err = svc.WithdrawExecute(ctx, testCustodialAddr, &WithdrawExecuteRequest{
+		TransferID: prep.TransferID, Signature: "0x1", SignedBy: testFingerprint,
+	}); err == nil {
+		t.Fatalf("foreign owner should fail")
+	}
+
+	// Fingerprint mismatch.
+	prep, err = svc.WithdrawPrepare(ctx, testExternalAddr, withdrawReq())
+	if err != nil {
+		t.Fatalf("prepare failed: %v", err)
+	}
+	if _, err = svc.WithdrawExecute(ctx, testExternalAddr, &WithdrawExecuteRequest{
+		TransferID: prep.TransferID, Signature: "0x1", SignedBy: "1220other",
+	}); err == nil {
+		t.Fatalf("fingerprint mismatch should fail")
+	}
+}
+
+func TestWithdrawCustodial_BurnsAndRegisters(t *testing.T) {
+	burner := &fakeBurner{}
+	rc := &fakeRelayer{}
+	svc := newTestServiceWithUsers(t, rc, burner, withdrawUsers())
+
+	resp, err := svc.WithdrawCustodial(context.Background(), testCustodialAddr, withdrawReq())
+	if err != nil {
+		t.Fatalf("WithdrawCustodial failed: %v", err)
+	}
+	if !resp.Created || burner.customCalls != 1 {
+		t.Fatalf("resp = %+v, burn calls = %d", resp, burner.customCalls)
+	}
+	if burner.burnReq.PartyID != "party::custodial" {
+		t.Fatalf("burn request = %+v", burner.burnReq)
+	}
+	if rc.registered == nil || rc.registered.Sender != "party::custodial" {
+		t.Fatalf("registered = %+v", rc.registered)
+	}
+}
+
+func TestWithdrawCustodial_ExternalUserRejected(t *testing.T) {
+	svc := newTestServiceWithUsers(t, &fakeRelayer{}, &fakeBurner{}, withdrawUsers())
+
+	if _, err := svc.WithdrawCustodial(context.Background(), testExternalAddr, withdrawReq()); err == nil {
+		t.Fatalf("external-key user on custodial endpoint should fail")
+	}
+}

--- a/pkg/bridgeapi/xreserve_test.go
+++ b/pkg/bridgeapi/xreserve_test.go
@@ -40,9 +40,11 @@ func xreserveToken() TokenConfig {
 		EVMAddress: testTokenAddr,
 		Decimals:   6,
 		XReserve: &XReserveTokenConfig{
-			Contract:     testContractAddr,
-			RemoteDomain: 10001,
-			MaxFee:       "50000",
+			Contract:        testContractAddr,
+			RemoteDomain:    10001,
+			MaxFee:          "50000",
+			InstrumentAdmin: "circle::admin",
+			InstrumentID:    "USDCx",
 		},
 	}
 }

--- a/pkg/cantonsdk/token/burn.go
+++ b/pkg/cantonsdk/token/burn.go
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package token
+
+import (
+	"context"
+	"fmt"
+
+	lapiv2 "github.com/chainsafe/canton-middleware/pkg/cantonsdk/lapi/v2"
+	"github.com/chainsafe/canton-middleware/pkg/cantonsdk/values"
+)
+
+// xReserve burn (USDCx outbound): the user party exercises
+// BridgeUserAgreement_Burn on their own BridgeUserAgreement contract; Circle
+// validates the burn and releases the asset on the destination chain. The
+// factory contract id, choice context, and disclosed contracts come from the
+// registrar's burn-mint registry endpoint.
+//
+// The choice name and argument field names follow DA's devnet xReserve
+// documentation and the devstack stub; they must be confirmed against the
+// production utility-bridge DAR before mainnet enablement (#360).
+const (
+	burnChoice          = "BridgeUserAgreement_Burn"
+	burnAgreementEntity = "BridgeUserAgreement"
+)
+
+// findBridgeUserAgreement locates the party's BridgeUserAgreement contract.
+// Its absence means the party has not been onboarded for bridging.
+func (c *Client) findBridgeUserAgreement(ctx context.Context, partyID string) (string, error) {
+	end, err := c.ledger.GetLedgerEnd(ctx)
+	if err != nil {
+		return "", fmt.Errorf("get ledger end: %w", err)
+	}
+	if end == 0 {
+		return "", fmt.Errorf("ledger is empty")
+	}
+
+	tid := &lapiv2.Identifier{
+		PackageId:  c.cfg.BurnMintPackageID,
+		ModuleName: c.cfg.BurnMintModule,
+		EntityName: burnAgreementEntity,
+	}
+	events, err := c.ledger.GetActiveContractsByTemplate(ctx, end, []string{partyID}, tid)
+	if err != nil {
+		return "", fmt.Errorf("query BridgeUserAgreement contracts: %w", err)
+	}
+	if len(events) == 0 {
+		return "", fmt.Errorf("party %s has no BridgeUserAgreement (bridge onboarding required)", partyID)
+	}
+	return events[0].ContractId, nil
+}
+
+// buildBurnCommand assembles the BridgeUserAgreement_Burn exercise: holdings
+// selection, burn-mint factory + choice context from the registrar, and the
+// choice argument. Returns the command, disclosed contracts, and the
+// agreement contract id.
+func (c *Client) buildBurnCommand(
+	ctx context.Context, req *PrepareBurnRequest,
+) (*lapiv2.Command, []*lapiv2.DisclosedContract, string, error) {
+	if c.cfg.BurnMintPackageID == "" || c.cfg.BurnMintModule == "" {
+		return nil, nil, "", fmt.Errorf("burn is not configured: set burn_mint_package_id and burn_mint_module")
+	}
+	if c.registryClient == nil {
+		return nil, nil, "", fmt.Errorf("no registry client configured for burn")
+	}
+	extCfg, ok := c.cfg.ExternalTokens[req.InstrumentAdmin]
+	if !ok {
+		return nil, nil, "", fmt.Errorf("unsupported external token issuer: %s", req.InstrumentAdmin)
+	}
+
+	agreementCID, err := c.findBridgeUserAgreement(ctx, req.PartyID)
+	if err != nil {
+		return nil, nil, "", err
+	}
+
+	holdings, err := c.GetHoldings(ctx, req.PartyID, req.TokenSymbol)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("list holdings: %w", err)
+	}
+	selected, err := selectHoldingsForTransfer(holdings, req.Amount)
+	if err != nil {
+		return nil, nil, "", err
+	}
+
+	factoryResp, err := c.registryClient.GetBurnMintFactory(
+		ctx, extCfg.RegistryURL, req.InstrumentAdmin, &RegistryRequest{ExcludeDebugFields: true})
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("get burn-mint factory: %w", err)
+	}
+
+	anyCtx, err := ConvertAnyValueChoiceContext(factoryResp.ChoiceContext)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("convert burn choice context: %w", err)
+	}
+	ctxValue, err := encodeChoiceContextRecord(anyCtx)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("encode burn choice context: %w", err)
+	}
+	extraArgs := &lapiv2.Value{
+		Sum: &lapiv2.Value_Record{
+			Record: &lapiv2.Record{
+				Fields: []*lapiv2.RecordField{
+					{Label: "context", Value: ctxValue},
+					{Label: "meta", Value: values.EmptyMetadata()},
+				},
+			},
+		},
+	}
+
+	disclosed, err := ConvertDisclosedContracts(factoryResp.DisclosedContracts, c.cfg.DomainID)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("convert disclosed contracts: %w", err)
+	}
+
+	cmd := &lapiv2.Command{
+		Command: &lapiv2.Command_Exercise{
+			Exercise: &lapiv2.ExerciseCommand{
+				TemplateId: &lapiv2.Identifier{
+					PackageId:  c.cfg.BurnMintPackageID,
+					ModuleName: c.cfg.BurnMintModule,
+					EntityName: burnAgreementEntity,
+				},
+				ContractId: agreementCID,
+				Choice:     burnChoice,
+				ChoiceArgument: &lapiv2.Value{
+					Sum: &lapiv2.Value_Record{
+						Record: encodeBurnArgs(req, factoryResp.FactoryID, selected.CIDs, extraArgs),
+					},
+				},
+			},
+		},
+	}
+	return cmd, disclosed, agreementCID, nil
+}
+
+// encodeBurnArgs builds the BridgeUserAgreement_Burn choice argument. Field
+// names are pinned to the devstack stub (see package comment above).
+func encodeBurnArgs(
+	req *PrepareBurnRequest, factoryCID string, holdingCIDs []string, extraArgs *lapiv2.Value,
+) *lapiv2.Record {
+	holdingValues := make([]*lapiv2.Value, len(holdingCIDs))
+	for i, cid := range holdingCIDs {
+		holdingValues[i] = values.ContractIDValue(cid)
+	}
+
+	return &lapiv2.Record{
+		Fields: []*lapiv2.RecordField{
+			{Label: "factoryCid", Value: values.ContractIDValue(factoryCID)},
+			{Label: "destinationDomain", Value: values.Int64Value(req.DestinationDomain)},
+			{Label: "amount", Value: values.NumericValue(req.Amount)},
+			{Label: "recipient", Value: values.TextValue(req.EvmRecipient)},
+			{Label: "requestId", Value: values.TextValue(req.RequestID)},
+			{Label: "inputHoldingCids", Value: values.ListValue(holdingValues)},
+			{Label: "extraArgs", Value: extraArgs},
+		},
+	}
+}
+
+func (req *PrepareBurnRequest) validate() error {
+	if req.PartyID == "" || req.TokenSymbol == "" || req.Amount == "" ||
+		req.InstrumentAdmin == "" || req.EvmRecipient == "" || req.RequestID == "" {
+		return fmt.Errorf("party_id, token_symbol, amount, instrument_admin, evm_recipient, and request_id are required")
+	}
+	return nil
+}
+
+// PrepareBurn builds a BridgeUserAgreement_Burn for a non-custodial party and
+// returns the hash the party signs externally. Use ExecuteTransfer to
+// complete it.
+func (c *Client) PrepareBurn(ctx context.Context, req *PrepareBurnRequest) (*PreparedTransfer, error) {
+	if err := req.validate(); err != nil {
+		return nil, err
+	}
+	cmd, disclosed, agreementCID, err := c.buildBurnCommand(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return c.prepareInstructionTx(ctx, req.PartyID, agreementCID, cmd, disclosed)
+}
+
+// BurnByPartyID burns on behalf of a custodial party, signing with the
+// middleware-held key via Interactive Submission.
+func (c *Client) BurnByPartyID(ctx context.Context, req *PrepareBurnRequest) error {
+	if err := req.validate(); err != nil {
+		return err
+	}
+	cmd, disclosed, _, err := c.buildBurnCommand(ctx, req)
+	if err != nil {
+		return err
+	}
+	return c.exerciseInstructionAsCustodial(ctx, req.PartyID, cmd, disclosed)
+}

--- a/pkg/cantonsdk/token/burn.go
+++ b/pkg/cantonsdk/token/burn.go
@@ -11,14 +11,11 @@ import (
 )
 
 // xReserve burn (USDCx outbound): the user party exercises
-// BridgeUserAgreement_Burn on their own BridgeUserAgreement contract; Circle
-// validates the burn and releases the asset on the destination chain. The
-// factory contract id, choice context, and disclosed contracts come from the
-// registrar's burn-mint registry endpoint.
+// BridgeUserAgreement_Burn on its agreement; Circle then releases on the
+// destination chain. Factory + choice context come from the burn-mint registry.
 //
-// The choice name and argument field names follow DA's devnet xReserve
-// documentation and the devstack stub; they must be confirmed against the
-// production utility-bridge DAR before mainnet enablement (#360).
+// Choice/arg names follow the devstack stub; confirm against the production
+// utility-bridge DAR before mainnet (#360).
 const (
 	burnChoice          = "BridgeUserAgreement_Burn"
 	burnAgreementEntity = "BridgeUserAgreement"
@@ -46,6 +43,10 @@ func (c *Client) findBridgeUserAgreement(ctx context.Context, partyID string) (s
 	}
 	if len(events) == 0 {
 		return "", fmt.Errorf("party %s has no BridgeUserAgreement (bridge onboarding required)", partyID)
+	}
+	if len(events) > 1 {
+		// Don't guess which agreement to burn against.
+		return "", fmt.Errorf("party %s has %d BridgeUserAgreements; expected exactly one", partyID, len(events))
 	}
 	return events[0].ContractId, nil
 }
@@ -77,7 +78,15 @@ func (c *Client) buildBurnCommand(
 	if err != nil {
 		return nil, nil, "", fmt.Errorf("list holdings: %w", err)
 	}
-	selected, err := selectHoldingsForTransfer(holdings, req.Amount)
+	// GetHoldings matches instrument id only; scope to the admin too so we
+	// don't pick a same-id instrument from another issuer.
+	scoped := make([]*Holding, 0, len(holdings))
+	for _, h := range holdings {
+		if h.InstrumentAdmin == req.InstrumentAdmin {
+			scoped = append(scoped, h)
+		}
+	}
+	selected, err := selectHoldingsForTransfer(scoped, req.Amount)
 	if err != nil {
 		return nil, nil, "", err
 	}

--- a/pkg/cantonsdk/token/client.go
+++ b/pkg/cantonsdk/token/client.go
@@ -153,6 +153,14 @@ type Token interface {
 	PrepareWithdrawTransfer(
 		ctx context.Context, partyID, instructionCID, instrumentAdmin string,
 	) (*PreparedTransfer, error)
+
+	// PrepareBurn builds an xReserve BridgeUserAgreement_Burn for a
+	// non-custodial party and returns the hash to sign externally. Use
+	// ExecuteTransfer to complete it.
+	PrepareBurn(ctx context.Context, req *PrepareBurnRequest) (*PreparedTransfer, error)
+
+	// BurnByPartyID burns on behalf of a custodial party (middleware-held key).
+	BurnByPartyID(ctx context.Context, req *PrepareBurnRequest) error
 }
 
 // Client implements CIP-56 token operations.

--- a/pkg/cantonsdk/token/config.go
+++ b/pkg/cantonsdk/token/config.go
@@ -30,6 +30,12 @@ type Config struct {
 	// Tokens whose InstrumentAdmin matches IssuerParty use local ACS-based factory discovery.
 	// Tokens whose InstrumentAdmin is in this map use the external registry API.
 	ExternalTokens map[string]ExternalTokenConfig `yaml:"external_tokens"`
+
+	// BurnMintPackageID/BurnMintModule identify the utility-bridge package
+	// hosting BridgeUserAgreement (xReserve burn/mint). Both must be set to
+	// enable outbound burns; values come from the utility-bridge DAR.
+	BurnMintPackageID string `yaml:"burn_mint_package_id"`
+	BurnMintModule    string `yaml:"burn_mint_module"`
 }
 
 func (c *Config) validate() error {

--- a/pkg/cantonsdk/token/registry_client.go
+++ b/pkg/cantonsdk/token/registry_client.go
@@ -21,6 +21,9 @@ const (
 	// choiceContextPathFmt is the registrar's per-instruction choice-context
 	// endpoint. The final %s is the action ("accept" or "withdraw").
 	choiceContextPathFmt = "/api/token-standard/v0/registrars/%s/registry/transfer-instruction/v1/%s/choice-contexts/%s"
+	// burnMintFactoryPathFmt is the registrar's xReserve burn-mint factory
+	// endpoint (see GetBurnMintFactory for the mainnet-path caveat).
+	burnMintFactoryPathFmt = "/api/token-standard/v0/registrars/%s/registry/burn-mint-instruction/v0/burn-mint-factory"
 )
 
 // RegistryClient calls the Splice Transfer Factory Registry API to discover
@@ -131,47 +134,57 @@ type registryDisclosedContract struct {
 func (rc *RegistryClient) GetTransferFactory(
 	ctx context.Context, registryBaseURL, registrarParty string, req *RegistryRequest,
 ) (*RegistryResponse, error) {
+	reqURL := strings.TrimRight(registryBaseURL, "/") + fmt.Sprintf(registryPathFmt, url.PathEscape(registrarParty))
+	return rc.postFactoryEndpoint(ctx, reqURL, req, "registry")
+}
+
+// postFactoryEndpoint POSTs a RegistryRequest to a factory-discovery endpoint
+// and lifts the nested choiceContext wrapper into the flat RegistryResponse
+// shape the SDK's converters understand. Shared by the transfer-factory and
+// burn-mint-factory endpoints, whose response envelopes are identical.
+//
+// DA's hosted registry wraps `choiceContextData` and `disclosedContracts`
+// inside `choiceContext` — a null/absent choiceContext leaves both fields
+// empty, which the converters short-circuit.
+func (rc *RegistryClient) postFactoryEndpoint(
+	ctx context.Context, reqURL string, req *RegistryRequest, label string,
+) (*RegistryResponse, error) {
 	body, err := json.Marshal(req)
 	if err != nil {
-		return nil, fmt.Errorf("marshal registry request: %w", err)
+		return nil, fmt.Errorf("marshal %s request: %w", label, err)
 	}
 
-	reqURL := strings.TrimRight(registryBaseURL, "/") + fmt.Sprintf(registryPathFmt, url.PathEscape(registrarParty))
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewReader(body))
 	if err != nil {
-		return nil, fmt.Errorf("create registry request: %w", err)
+		return nil, fmt.Errorf("create %s request: %w", label, err)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 
 	resp, err := rc.httpClient.Do(httpReq)
 	if err != nil {
-		return nil, fmt.Errorf("registry request failed: %w", err)
+		return nil, fmt.Errorf("%s request failed: %w", label, err)
 	}
 	defer resp.Body.Close()
 
 	const maxResponseBytes = 1 << 20 // 1 MB
 	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
 	if err != nil {
-		return nil, fmt.Errorf("read registry response: %w", err)
+		return nil, fmt.Errorf("read %s response: %w", label, err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("registry returned %d: %s", resp.StatusCode, string(respBody))
+		return nil, fmt.Errorf("%s returned %d: %s", label, resp.StatusCode, string(respBody))
 	}
 
 	var wire registryWireResponse
 	if err := json.Unmarshal(respBody, &wire); err != nil {
-		return nil, fmt.Errorf("parse registry response: %w", err)
+		return nil, fmt.Errorf("parse %s response: %w", label, err)
 	}
 
-	// DA's hosted registry wraps `choiceContextData` and `disclosedContracts`
-	// inside `choiceContext` — lift them out so callers see the legacy flat
-	// shape the SDK's converters already understand. A null/absent
-	// choiceContext leaves both fields empty, which the converters short-circuit.
 	var inner registryWireChoiceContext
 	if len(wire.ChoiceContext) > 0 && string(wire.ChoiceContext) != jsonNull {
 		if err := json.Unmarshal(wire.ChoiceContext, &inner); err != nil {
-			return nil, fmt.Errorf("parse choiceContext wrapper: %w", err)
+			return nil, fmt.Errorf("parse %s choiceContext wrapper: %w", label, err)
 		}
 	}
 
@@ -306,6 +319,19 @@ func (rc *RegistryClient) GetWithdrawChoiceContext(
 	ctx context.Context, registryBaseURL, registrarParty, instructionCID string,
 ) (*AcceptContextResponse, error) {
 	return rc.getChoiceContext(ctx, registryBaseURL, registrarParty, instructionCID, "withdraw")
+}
+
+// GetBurnMintFactory calls the registrar's burn-mint factory endpoint and
+// returns the factory contract id, choice context, and disclosed contracts
+// needed to exercise xReserve burn/mint choices. The path mirrors the
+// registrar prefix used by the transfer-instruction API (and the devstack
+// stub); DA's hosted Utilities backend may expose a different prefix — pin it
+// during mainnet enablement (#360).
+func (rc *RegistryClient) GetBurnMintFactory(
+	ctx context.Context, registryBaseURL, registrarParty string, req *RegistryRequest,
+) (*RegistryResponse, error) {
+	reqURL := strings.TrimRight(registryBaseURL, "/") + fmt.Sprintf(burnMintFactoryPathFmt, url.PathEscape(registrarParty))
+	return rc.postFactoryEndpoint(ctx, reqURL, req, "burn-mint registry")
 }
 
 // getChoiceContext fetches a per-instruction choice-context for the given action

--- a/pkg/cantonsdk/token/types.go
+++ b/pkg/cantonsdk/token/types.go
@@ -164,6 +164,23 @@ func (r *PrepareTransferRequest) validate() error {
 	return nil
 }
 
+// PrepareBurnRequest contains the parameters for an xReserve outbound burn
+// (BridgeUserAgreement_Burn).
+type PrepareBurnRequest struct {
+	PartyID     string
+	TokenSymbol string
+	// Amount is a decimal string in token units.
+	Amount string
+	// InstrumentAdmin selects the external token's registry (ExternalTokens key).
+	InstrumentAdmin string
+	// DestinationDomain is the xReserve destination domain (0 = Ethereum).
+	DestinationDomain int64
+	// EvmRecipient is the destination-chain address receiving the released asset.
+	EvmRecipient string
+	// RequestID is the caller-generated UUID correlating burn and release.
+	RequestID string
+}
+
 // PreparedTransfer holds the result of a prepare step for non-custodial signing.
 type PreparedTransfer struct {
 	TransferID           string                             // UUID

--- a/pkg/config/defaults/config.api-server.docker.yaml
+++ b/pkg/config/defaults/config.api-server.docker.yaml
@@ -58,6 +58,10 @@ canton:
     external_tokens:
       "${CANTON_USDCX_ISSUER_PARTY}":
         registry_url: "http://usdcx-registry:8090"
+    # Enables USDCx outbound burns (BridgeUserAgreement_Burn). Package is the
+    # utility-bridge DAR; uncomment with the confirmed module name (#360).
+    # burn_mint_package_id: "#utility-bridge-v0"
+    # burn_mint_module: "Utility.Bridge.V0.Model"
 
   bridge:
     package_id: "#bridge-wayfinder"
@@ -115,6 +119,9 @@ bridge:
       xreserve:
         contract: "0x0000000000000000000000000000000000000000"
         remote_domain: 10001
+        instrument_admin: "${CANTON_USDCX_ISSUER_PARTY}"
+        instrument_id: "USDCx"
+        withdraw_destination_domain: 0  # 0 = Ethereum
 
 # JWKS endpoint for JWT validation (optional - if not using EVM signatures)
 monitoring:

--- a/pkg/custodial/mocks/mock_canton_token.go
+++ b/pkg/custodial/mocks/mock_canton_token.go
@@ -120,6 +120,53 @@ func (_c *Token_Burn_Call) RunAndReturn(run func(context.Context, *token.BurnReq
 	return _c
 }
 
+// BurnByPartyID provides a mock function with given fields: ctx, req
+func (_m *Token) BurnByPartyID(ctx context.Context, req *token.PrepareBurnRequest) error {
+	ret := _m.Called(ctx, req)
+
+	if len(ret) == 0 {
+		panic("no return value specified for BurnByPartyID")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *token.PrepareBurnRequest) error); ok {
+		r0 = rf(ctx, req)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Token_BurnByPartyID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BurnByPartyID'
+type Token_BurnByPartyID_Call struct {
+	*mock.Call
+}
+
+// BurnByPartyID is a helper method to define mock.On call
+//   - ctx context.Context
+//   - req *token.PrepareBurnRequest
+func (_e *Token_Expecter) BurnByPartyID(ctx interface{}, req interface{}) *Token_BurnByPartyID_Call {
+	return &Token_BurnByPartyID_Call{Call: _e.mock.On("BurnByPartyID", ctx, req)}
+}
+
+func (_c *Token_BurnByPartyID_Call) Run(run func(ctx context.Context, req *token.PrepareBurnRequest)) *Token_BurnByPartyID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*token.PrepareBurnRequest))
+	})
+	return _c
+}
+
+func (_c *Token_BurnByPartyID_Call) Return(_a0 error) *Token_BurnByPartyID_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Token_BurnByPartyID_Call) RunAndReturn(run func(context.Context, *token.PrepareBurnRequest) error) *Token_BurnByPartyID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ExecuteTransfer provides a mock function with given fields: ctx, req
 func (_m *Token) ExecuteTransfer(ctx context.Context, req *token.ExecuteTransferRequest) error {
 	ret := _m.Called(ctx, req)
@@ -864,6 +911,65 @@ func (_c *Token_PrepareAcceptTransfer_Call) Return(_a0 *token.PreparedTransfer, 
 }
 
 func (_c *Token_PrepareAcceptTransfer_Call) RunAndReturn(run func(context.Context, string, string, string) (*token.PreparedTransfer, error)) *Token_PrepareAcceptTransfer_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// PrepareBurn provides a mock function with given fields: ctx, req
+func (_m *Token) PrepareBurn(ctx context.Context, req *token.PrepareBurnRequest) (*token.PreparedTransfer, error) {
+	ret := _m.Called(ctx, req)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PrepareBurn")
+	}
+
+	var r0 *token.PreparedTransfer
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *token.PrepareBurnRequest) (*token.PreparedTransfer, error)); ok {
+		return rf(ctx, req)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *token.PrepareBurnRequest) *token.PreparedTransfer); ok {
+		r0 = rf(ctx, req)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*token.PreparedTransfer)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *token.PrepareBurnRequest) error); ok {
+		r1 = rf(ctx, req)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Token_PrepareBurn_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PrepareBurn'
+type Token_PrepareBurn_Call struct {
+	*mock.Call
+}
+
+// PrepareBurn is a helper method to define mock.On call
+//   - ctx context.Context
+//   - req *token.PrepareBurnRequest
+func (_e *Token_Expecter) PrepareBurn(ctx interface{}, req interface{}) *Token_PrepareBurn_Call {
+	return &Token_PrepareBurn_Call{Call: _e.mock.On("PrepareBurn", ctx, req)}
+}
+
+func (_c *Token_PrepareBurn_Call) Run(run func(ctx context.Context, req *token.PrepareBurnRequest)) *Token_PrepareBurn_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*token.PrepareBurnRequest))
+	})
+	return _c
+}
+
+func (_c *Token_PrepareBurn_Call) Return(_a0 *token.PreparedTransfer, _a1 error) *Token_PrepareBurn_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Token_PrepareBurn_Call) RunAndReturn(run func(context.Context, *token.PrepareBurnRequest) (*token.PreparedTransfer, error)) *Token_PrepareBurn_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/relayer/bridges/xreserve/bridge.go
+++ b/pkg/relayer/bridges/xreserve/bridge.go
@@ -37,10 +37,17 @@ const (
 	StageMinted              = "minted"
 )
 
+// Withdrawal stages.
+const (
+	StageAwaitingRelease = "awaiting_release"
+	StageReleased        = "released"
+)
+
 // Metadata keys accumulated on transfers.
 const (
 	metaBaselineBalance = "baseline_balance"
 	metaAttestationID   = "attestation_id"
+	metaBurnRequestID   = "burn_request_id"
 )
 
 const (
@@ -152,10 +159,55 @@ func (b *Bridge) Step(ctx context.Context, t *relayer.Transfer) (relayer.StepRes
 	case relayer.DirectionEthereumToCanton:
 		return b.stepDeposit(ctx, rt, t)
 	case relayer.DirectionCantonToEthereum:
-		// Outbound (BridgeUserAgreement_Burn + release tracking) lands with #359.
-		return relayer.StepResult{}, fmt.Errorf("xreserve withdrawals are not supported yet")
+		return b.stepWithdrawal(ctx, rt, t)
 	default:
 		return relayer.StepResult{}, fmt.Errorf("unknown direction %q", t.Direction)
+	}
+}
+
+// stepWithdrawal tracks a burn's destination-chain release. The burn itself
+// was already exercised by the api-server (BridgeUserAgreement_Burn is a
+// user-party choice); Circle controls the release timing, so this adapter
+// only observes.
+func (b *Bridge) stepWithdrawal(ctx context.Context, rt *tokenRuntime, t *relayer.Transfer) (relayer.StepResult, error) {
+	switch t.Stage {
+	case "", StageAwaitingRelease:
+		requestID := t.Metadata[metaBurnRequestID]
+		if requestID == "" {
+			return relayer.StepResult{}, fmt.Errorf("withdrawal is missing %s metadata", metaBurnRequestID)
+		}
+
+		st, err := rt.circle.GetBurnStatus(ctx, requestID)
+		switch {
+		case errors.Is(err, ErrReleasePending):
+			return relayer.StepResult{
+				Status:     relayer.TransferStatusPending,
+				Stage:      StageAwaitingRelease,
+				RetryAfter: rt.attestationPollInterval(),
+			}, nil
+		case errors.Is(err, ErrAttestationUnavailable):
+			b.logger.Warn("Burn-status service unavailable, will keep polling",
+				zap.String("id", t.ID), zap.String("token", rt.symbol), zap.Error(err))
+			return relayer.StepResult{
+				Status:     relayer.TransferStatusPending,
+				Stage:      StageAwaitingRelease,
+				RetryAfter: rt.attestationPollInterval(),
+			}, nil
+		case err != nil:
+			return relayer.StepResult{}, err
+		}
+
+		result := relayer.StepResult{
+			Status: relayer.TransferStatusCompleted,
+			Stage:  StageReleased,
+		}
+		if st.TxHash != "" {
+			txHash := st.TxHash
+			result.DestTxHash = &txHash
+		}
+		return result, nil
+	default:
+		return relayer.StepResult{}, fmt.Errorf("unknown withdrawal stage %q", t.Stage)
 	}
 }
 

--- a/pkg/relayer/bridges/xreserve/bridge.go
+++ b/pkg/relayer/bridges/xreserve/bridge.go
@@ -47,7 +47,8 @@ const (
 const (
 	metaBaselineBalance = "baseline_balance"
 	metaAttestationID   = "attestation_id"
-	metaBurnRequestID   = "burn_request_id"
+	// mirror the key the api-server writes, so the two can't drift
+	metaBurnRequestID = relayer.MetaBurnRequestID
 )
 
 const (
@@ -165,11 +166,20 @@ func (b *Bridge) Step(ctx context.Context, t *relayer.Transfer) (relayer.StepRes
 	}
 }
 
-// stepWithdrawal tracks a burn's destination-chain release. The burn itself
-// was already exercised by the api-server (BridgeUserAgreement_Burn is a
-// user-party choice); Circle controls the release timing, so this adapter
-// only observes.
+// stepWithdrawal tracks a burn's release. The api-server already exercised the
+// burn (a user-party choice) and Circle controls release timing, so we only observe.
 func (b *Bridge) stepWithdrawal(ctx context.Context, rt *tokenRuntime, t *relayer.Transfer) (relayer.StepResult, error) {
+	// Reap withdrawals that never release instead of polling forever.
+	if !t.CreatedAt.IsZero() && time.Since(t.CreatedAt) > depositCompletionDeadline {
+		b.logger.Warn("Withdrawal exceeded completion deadline, failing",
+			zap.String("id", t.ID), zap.String("token", rt.symbol), zap.String("stage", t.Stage))
+		return relayer.StepResult{
+			Status: relayer.TransferStatusFailed,
+			Stage:  t.Stage,
+			Reason: fmt.Sprintf("release not observed within %s", depositCompletionDeadline),
+		}, nil
+	}
+
 	switch t.Stage {
 	case "", StageAwaitingRelease:
 		requestID := t.Metadata[metaBurnRequestID]

--- a/pkg/relayer/bridges/xreserve/bridge_test.go
+++ b/pkg/relayer/bridges/xreserve/bridge_test.go
@@ -14,16 +14,25 @@ import (
 	"github.com/chainsafe/canton-middleware/pkg/relayer"
 )
 
-// fakeAttester returns a fixed attestation result.
+// fakeAttester returns fixed attestation / burn-status results.
 type fakeAttester struct {
 	att   *Attestation
 	err   error
 	calls int
+
+	burnStatus *BurnStatus
+	burnErr    error
+	burnCalls  int
 }
 
 func (f *fakeAttester) GetAttestation(context.Context, string) (*Attestation, error) {
 	f.calls++
 	return f.att, f.err
+}
+
+func (f *fakeAttester) GetBurnStatus(context.Context, string) (*BurnStatus, error) {
+	f.burnCalls++
+	return f.burnStatus, f.burnErr
 }
 
 // fakeHoldings returns its fixed holdings list filtered by owner.
@@ -250,12 +259,73 @@ func TestBridge_Step_UnknownStage_Fails(t *testing.T) {
 	}
 }
 
-func TestBridge_Step_WithdrawalsNotSupportedYet(t *testing.T) {
+func withdrawalTransfer(stage string, metadata map[string]string) *relayer.Transfer {
+	tr := depositTransfer(stage, metadata)
+	tr.Direction = relayer.DirectionCantonToEthereum
+	return tr
+}
+
+func TestBridge_StepWithdrawal_ReleasePending_KeepsPolling(t *testing.T) {
+	circle := &fakeAttester{burnErr: ErrReleasePending}
+
+	b := newTestBridge(t, circle, &fakeHoldings{})
+	res, err := b.Step(context.Background(),
+		withdrawalTransfer("", map[string]string{metaBurnRequestID: "req-1"}))
+	if err != nil {
+		t.Fatalf("Step failed: %v", err)
+	}
+	if res.Status != relayer.TransferStatusPending || res.Stage != StageAwaitingRelease {
+		t.Fatalf("status/stage = %s/%s, want pending/%s", res.Status, res.Stage, StageAwaitingRelease)
+	}
+	if circle.burnCalls != 1 {
+		t.Fatalf("GetBurnStatus called %d times, want 1", circle.burnCalls)
+	}
+}
+
+func TestBridge_StepWithdrawal_ServiceUnavailable_KeepsPollingWithoutError(t *testing.T) {
+	circle := &fakeAttester{burnErr: errors.Join(ErrAttestationUnavailable, errors.New("503"))}
+
+	b := newTestBridge(t, circle, &fakeHoldings{})
+	res, err := b.Step(context.Background(),
+		withdrawalTransfer(StageAwaitingRelease, map[string]string{metaBurnRequestID: "req-1"}))
+	if err != nil {
+		t.Fatalf("transient unavailability must not be a step error, got: %v", err)
+	}
+	if res.Stage != StageAwaitingRelease {
+		t.Fatalf("stage = %s, want %s", res.Stage, StageAwaitingRelease)
+	}
+}
+
+func TestBridge_StepWithdrawal_Released_Completes(t *testing.T) {
+	circle := &fakeAttester{burnStatus: &BurnStatus{Status: "released", TxHash: "0xrelease"}}
+
+	b := newTestBridge(t, circle, &fakeHoldings{})
+	res, err := b.Step(context.Background(),
+		withdrawalTransfer(StageAwaitingRelease, map[string]string{metaBurnRequestID: "req-1"}))
+	if err != nil {
+		t.Fatalf("Step failed: %v", err)
+	}
+	if res.Status != relayer.TransferStatusCompleted || res.Stage != StageReleased {
+		t.Fatalf("status/stage = %s/%s, want completed/%s", res.Status, res.Stage, StageReleased)
+	}
+	if res.DestTxHash == nil || *res.DestTxHash != "0xrelease" {
+		t.Fatalf("DestTxHash = %v, want 0xrelease", res.DestTxHash)
+	}
+}
+
+func TestBridge_StepWithdrawal_MissingRequestID_Fails(t *testing.T) {
 	b := newTestBridge(t, &fakeAttester{}, &fakeHoldings{})
 
-	transfer := depositTransfer("", nil)
-	transfer.Direction = relayer.DirectionCantonToEthereum
-	if _, err := b.Step(context.Background(), transfer); err == nil {
-		t.Fatalf("withdrawal Step should fail until #359 lands")
+	if _, err := b.Step(context.Background(), withdrawalTransfer("", nil)); err == nil {
+		t.Fatalf("withdrawal without burn_request_id should fail")
+	}
+}
+
+func TestBridge_StepWithdrawal_UnknownStage_Fails(t *testing.T) {
+	b := newTestBridge(t, &fakeAttester{}, &fakeHoldings{})
+
+	if _, err := b.Step(context.Background(),
+		withdrawalTransfer("bogus", map[string]string{metaBurnRequestID: "req-1"})); err == nil {
+		t.Fatalf("unknown withdrawal stage should fail")
 	}
 }

--- a/pkg/relayer/bridges/xreserve/circle.go
+++ b/pkg/relayer/bridges/xreserve/circle.go
@@ -26,6 +26,9 @@ const maxAttestationResponseBytes = 1 << 20 // 1MB
 // attestationStatusComplete is the terminal attestation status.
 const attestationStatusComplete = "complete"
 
+// ErrReleasePending means Circle has not yet released the burned amount.
+var ErrReleasePending = errors.New("release pending")
+
 // isTransientStatus reports statuses worth retrying rather than failing on.
 func isTransientStatus(code int) bool {
 	return code >= http.StatusInternalServerError ||
@@ -40,12 +43,26 @@ type Attestation struct {
 	Status string `json:"status"`
 }
 
-// AttestationClient fetches deposit attestations from Circle's xReserve API.
+// burnStatusReleased is the terminal burn status.
+const burnStatusReleased = "released"
+
+// BurnStatus reports the destination-chain release of a Canton burn.
+type BurnStatus struct {
+	Status string `json:"status"`
+	TxHash string `json:"tx_hash"`
+}
+
+// AttestationClient is the Circle xReserve API surface the adapter polls:
+// deposit attestations inbound, burn releases outbound.
 type AttestationClient interface {
 	// GetAttestation returns the attestation for a deposit transaction hash.
 	// Returns ErrAttestationNotReady while Circle has not attested and
 	// ErrAttestationUnavailable on transient service failures.
 	GetAttestation(ctx context.Context, depositTxHash string) (*Attestation, error)
+	// GetBurnStatus returns the release status for a burn request id.
+	// Returns ErrReleasePending until Circle has released and
+	// ErrAttestationUnavailable on transient service failures.
+	GetBurnStatus(ctx context.Context, burnRequestID string) (*BurnStatus, error)
 }
 
 // HTTPAttestationClient talks to the xReserve attestation REST API.
@@ -74,39 +91,63 @@ func NewAttestationClient(baseURL string, httpClient *http.Client) (*HTTPAttesta
 
 // GetAttestation fetches the attestation for a deposit tx hash.
 func (c *HTTPAttestationClient) GetAttestation(ctx context.Context, depositTxHash string) (*Attestation, error) {
-	reqURL := c.baseURL + "/v1/attestations/" + url.PathEscape(depositTxHash)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("build attestation request: %w", err)
-	}
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrAttestationUnavailable, err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxAttestationResponseBytes))
-	if err != nil {
-		return nil, fmt.Errorf("%w: read response: %w", ErrAttestationUnavailable, err)
-	}
-
-	switch {
-	case resp.StatusCode == http.StatusNotFound:
-		return nil, ErrAttestationNotReady
-	case isTransientStatus(resp.StatusCode): // 5xx / 429 / 408: keep polling
-		return nil, fmt.Errorf("%w: status %d: %s", ErrAttestationUnavailable, resp.StatusCode, body)
-	case resp.StatusCode != http.StatusOK:
-		return nil, fmt.Errorf("attestation service returned %d: %s", resp.StatusCode, body)
-	}
-
 	var att Attestation
-	if err := json.Unmarshal(body, &att); err != nil {
-		return nil, fmt.Errorf("parse attestation response: %w", err)
+	reqURL := c.baseURL + "/v1/attestations/" + url.PathEscape(depositTxHash)
+	if err := c.getJSON(ctx, reqURL, ErrAttestationNotReady, &att); err != nil {
+		return nil, err
 	}
 	if !strings.EqualFold(att.Status, attestationStatusComplete) {
 		return nil, ErrAttestationNotReady
 	}
 	return &att, nil
+}
+
+// GetBurnStatus fetches the release status for a burn request id.
+func (c *HTTPAttestationClient) GetBurnStatus(ctx context.Context, burnRequestID string) (*BurnStatus, error) {
+	var st BurnStatus
+	reqURL := c.baseURL + "/v1/burns/" + url.PathEscape(burnRequestID)
+	if err := c.getJSON(ctx, reqURL, ErrReleasePending, &st); err != nil {
+		return nil, err
+	}
+	if !strings.EqualFold(st.Status, burnStatusReleased) {
+		return nil, ErrReleasePending
+	}
+	return &st, nil
+}
+
+// getJSON GETs reqURL and decodes the 200 response into out. 404 maps to
+// notFoundErr (both polling endpoints treat it as "not yet"), 5xx and
+// transport failures to ErrAttestationUnavailable.
+func (c *HTTPAttestationClient) getJSON(ctx context.Context, reqURL string, notFoundErr error, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrAttestationUnavailable, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxAttestationResponseBytes))
+	if err != nil {
+		return fmt.Errorf("%w: read response: %w", ErrAttestationUnavailable, err)
+	}
+
+	switch {
+	case resp.StatusCode == http.StatusNotFound:
+		return notFoundErr
+	case isTransientStatus(resp.StatusCode):
+		// 5xx, 429 (rate limit), 408 (request timeout): transient. Keep
+		// polling rather than burning a transfer retry on a healthy transfer.
+		return fmt.Errorf("%w: status %d: %s", ErrAttestationUnavailable, resp.StatusCode, body)
+	case resp.StatusCode != http.StatusOK:
+		return fmt.Errorf("xreserve api returned %d: %s", resp.StatusCode, body)
+	}
+
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("parse response: %w", err)
+	}
+	return nil
 }

--- a/pkg/relayer/bridges/xreserve/circle_test.go
+++ b/pkg/relayer/bridges/xreserve/circle_test.go
@@ -91,3 +91,57 @@ func TestNewAttestationClient_RejectsInvalidURL(t *testing.T) {
 		}
 	}
 }
+
+func burnStatusServer(t *testing.T, status int, body string) *HTTPAttestationClient {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/burns/req-1" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := NewAttestationClient(srv.URL, srv.Client())
+	if err != nil {
+		t.Fatalf("NewAttestationClient failed: %v", err)
+	}
+	return client
+}
+
+func TestBurnStatus_Released(t *testing.T) {
+	client := burnStatusServer(t, http.StatusOK, `{"status":"released","tx_hash":"0xrelease"}`)
+
+	st, err := client.GetBurnStatus(context.Background(), "req-1")
+	if err != nil {
+		t.Fatalf("GetBurnStatus failed: %v", err)
+	}
+	if st.TxHash != "0xrelease" {
+		t.Fatalf("tx hash = %q", st.TxHash)
+	}
+}
+
+func TestBurnStatus_Pending(t *testing.T) {
+	client := burnStatusServer(t, http.StatusOK, `{"status":"pending"}`)
+
+	if _, err := client.GetBurnStatus(context.Background(), "req-1"); !errors.Is(err, ErrReleasePending) {
+		t.Fatalf("err = %v, want ErrReleasePending", err)
+	}
+}
+
+func TestBurnStatus_NotFound_Pending(t *testing.T) {
+	client := burnStatusServer(t, http.StatusNotFound, `{}`)
+
+	if _, err := client.GetBurnStatus(context.Background(), "req-1"); !errors.Is(err, ErrReleasePending) {
+		t.Fatalf("err = %v, want ErrReleasePending", err)
+	}
+}
+
+func TestBurnStatus_ServerError_Unavailable(t *testing.T) {
+	client := burnStatusServer(t, http.StatusBadGateway, "down")
+
+	if _, err := client.GetBurnStatus(context.Background(), "req-1"); !errors.Is(err, ErrAttestationUnavailable) {
+		t.Fatalf("err = %v, want ErrAttestationUnavailable", err)
+	}
+}

--- a/pkg/relayer/store/pg_test.go
+++ b/pkg/relayer/store/pg_test.go
@@ -431,7 +431,7 @@ func TestPGStore_ApplyStep(t *testing.T) {
 		Metadata: map[string]string{"attestation_id": "att-9"},
 	}, next)
 	if err != nil {
-		t.Fatalf("ApplyStep(in_progress) failed: %v", err)
+		t.Fatalf("ApplyStep(pending) failed: %v", err)
 	}
 
 	tr, err := store.GetTransfer(ctx, "step-1")
@@ -439,7 +439,7 @@ func TestPGStore_ApplyStep(t *testing.T) {
 		t.Fatalf("GetTransfer failed: %v", err)
 	}
 	if tr.Status != relayer.TransferStatusPending || tr.Stage != "awaiting_attestation" {
-		t.Fatalf("status/stage = %s/%s, want in_progress/awaiting_attestation", tr.Status, tr.Stage)
+		t.Fatalf("status/stage = %s/%s, want pending/awaiting_attestation", tr.Status, tr.Stage)
 	}
 	// Metadata is merged, not replaced.
 	if tr.Metadata["deposit_nonce"] != "7" || tr.Metadata["attestation_id"] != "att-9" {

--- a/pkg/relayer/types.go
+++ b/pkg/relayer/types.go
@@ -17,6 +17,10 @@ const OffsetBegin = "BEGIN"
 // default). The reconcile loop filters on it so it skips adapter rows.
 const LegacyBridgeKey = "wayfinder"
 
+// MetaBurnRequestID is the metadata key tying a burn to its release. The
+// api-server writes it; the xreserve adapter reads it to poll release status.
+const MetaBurnRequestID = "burn_request_id"
+
 // TransferStatus represents the current state of a cross-chain transfer.
 type TransferStatus string
 

--- a/pkg/token/mocks/mock_canton_token.go
+++ b/pkg/token/mocks/mock_canton_token.go
@@ -120,6 +120,53 @@ func (_c *Token_Burn_Call) RunAndReturn(run func(context.Context, *token.BurnReq
 	return _c
 }
 
+// BurnByPartyID provides a mock function with given fields: ctx, req
+func (_m *Token) BurnByPartyID(ctx context.Context, req *token.PrepareBurnRequest) error {
+	ret := _m.Called(ctx, req)
+
+	if len(ret) == 0 {
+		panic("no return value specified for BurnByPartyID")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *token.PrepareBurnRequest) error); ok {
+		r0 = rf(ctx, req)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Token_BurnByPartyID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BurnByPartyID'
+type Token_BurnByPartyID_Call struct {
+	*mock.Call
+}
+
+// BurnByPartyID is a helper method to define mock.On call
+//   - ctx context.Context
+//   - req *token.PrepareBurnRequest
+func (_e *Token_Expecter) BurnByPartyID(ctx interface{}, req interface{}) *Token_BurnByPartyID_Call {
+	return &Token_BurnByPartyID_Call{Call: _e.mock.On("BurnByPartyID", ctx, req)}
+}
+
+func (_c *Token_BurnByPartyID_Call) Run(run func(ctx context.Context, req *token.PrepareBurnRequest)) *Token_BurnByPartyID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*token.PrepareBurnRequest))
+	})
+	return _c
+}
+
+func (_c *Token_BurnByPartyID_Call) Return(_a0 error) *Token_BurnByPartyID_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Token_BurnByPartyID_Call) RunAndReturn(run func(context.Context, *token.PrepareBurnRequest) error) *Token_BurnByPartyID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ExecuteTransfer provides a mock function with given fields: ctx, req
 func (_m *Token) ExecuteTransfer(ctx context.Context, req *token.ExecuteTransferRequest) error {
 	ret := _m.Called(ctx, req)
@@ -864,6 +911,65 @@ func (_c *Token_PrepareAcceptTransfer_Call) Return(_a0 *token.PreparedTransfer, 
 }
 
 func (_c *Token_PrepareAcceptTransfer_Call) RunAndReturn(run func(context.Context, string, string, string) (*token.PreparedTransfer, error)) *Token_PrepareAcceptTransfer_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// PrepareBurn provides a mock function with given fields: ctx, req
+func (_m *Token) PrepareBurn(ctx context.Context, req *token.PrepareBurnRequest) (*token.PreparedTransfer, error) {
+	ret := _m.Called(ctx, req)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PrepareBurn")
+	}
+
+	var r0 *token.PreparedTransfer
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *token.PrepareBurnRequest) (*token.PreparedTransfer, error)); ok {
+		return rf(ctx, req)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *token.PrepareBurnRequest) *token.PreparedTransfer); ok {
+		r0 = rf(ctx, req)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*token.PreparedTransfer)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *token.PrepareBurnRequest) error); ok {
+		r1 = rf(ctx, req)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Token_PrepareBurn_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PrepareBurn'
+type Token_PrepareBurn_Call struct {
+	*mock.Call
+}
+
+// PrepareBurn is a helper method to define mock.On call
+//   - ctx context.Context
+//   - req *token.PrepareBurnRequest
+func (_e *Token_Expecter) PrepareBurn(ctx interface{}, req interface{}) *Token_PrepareBurn_Call {
+	return &Token_PrepareBurn_Call{Call: _e.mock.On("PrepareBurn", ctx, req)}
+}
+
+func (_c *Token_PrepareBurn_Call) Run(run func(ctx context.Context, req *token.PrepareBurnRequest)) *Token_PrepareBurn_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*token.PrepareBurnRequest))
+	})
+	return _c
+}
+
+func (_c *Token_PrepareBurn_Call) Return(_a0 *token.PreparedTransfer, _a1 error) *Token_PrepareBurn_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Token_PrepareBurn_Call) RunAndReturn(run func(context.Context, *token.PrepareBurnRequest) (*token.PreparedTransfer, error)) *Token_PrepareBurn_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/transfer/mocks/mock_canton_token.go
+++ b/pkg/transfer/mocks/mock_canton_token.go
@@ -120,6 +120,53 @@ func (_c *Token_Burn_Call) RunAndReturn(run func(context.Context, *token.BurnReq
 	return _c
 }
 
+// BurnByPartyID provides a mock function with given fields: ctx, req
+func (_m *Token) BurnByPartyID(ctx context.Context, req *token.PrepareBurnRequest) error {
+	ret := _m.Called(ctx, req)
+
+	if len(ret) == 0 {
+		panic("no return value specified for BurnByPartyID")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *token.PrepareBurnRequest) error); ok {
+		r0 = rf(ctx, req)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Token_BurnByPartyID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BurnByPartyID'
+type Token_BurnByPartyID_Call struct {
+	*mock.Call
+}
+
+// BurnByPartyID is a helper method to define mock.On call
+//   - ctx context.Context
+//   - req *token.PrepareBurnRequest
+func (_e *Token_Expecter) BurnByPartyID(ctx interface{}, req interface{}) *Token_BurnByPartyID_Call {
+	return &Token_BurnByPartyID_Call{Call: _e.mock.On("BurnByPartyID", ctx, req)}
+}
+
+func (_c *Token_BurnByPartyID_Call) Run(run func(ctx context.Context, req *token.PrepareBurnRequest)) *Token_BurnByPartyID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*token.PrepareBurnRequest))
+	})
+	return _c
+}
+
+func (_c *Token_BurnByPartyID_Call) Return(_a0 error) *Token_BurnByPartyID_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Token_BurnByPartyID_Call) RunAndReturn(run func(context.Context, *token.PrepareBurnRequest) error) *Token_BurnByPartyID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ExecuteTransfer provides a mock function with given fields: ctx, req
 func (_m *Token) ExecuteTransfer(ctx context.Context, req *token.ExecuteTransferRequest) error {
 	ret := _m.Called(ctx, req)
@@ -864,6 +911,65 @@ func (_c *Token_PrepareAcceptTransfer_Call) Return(_a0 *token.PreparedTransfer, 
 }
 
 func (_c *Token_PrepareAcceptTransfer_Call) RunAndReturn(run func(context.Context, string, string, string) (*token.PreparedTransfer, error)) *Token_PrepareAcceptTransfer_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// PrepareBurn provides a mock function with given fields: ctx, req
+func (_m *Token) PrepareBurn(ctx context.Context, req *token.PrepareBurnRequest) (*token.PreparedTransfer, error) {
+	ret := _m.Called(ctx, req)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PrepareBurn")
+	}
+
+	var r0 *token.PreparedTransfer
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *token.PrepareBurnRequest) (*token.PreparedTransfer, error)); ok {
+		return rf(ctx, req)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *token.PrepareBurnRequest) *token.PreparedTransfer); ok {
+		r0 = rf(ctx, req)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*token.PreparedTransfer)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *token.PrepareBurnRequest) error); ok {
+		r1 = rf(ctx, req)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Token_PrepareBurn_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PrepareBurn'
+type Token_PrepareBurn_Call struct {
+	*mock.Call
+}
+
+// PrepareBurn is a helper method to define mock.On call
+//   - ctx context.Context
+//   - req *token.PrepareBurnRequest
+func (_e *Token_Expecter) PrepareBurn(ctx interface{}, req interface{}) *Token_PrepareBurn_Call {
+	return &Token_PrepareBurn_Call{Call: _e.mock.On("PrepareBurn", ctx, req)}
+}
+
+func (_c *Token_PrepareBurn_Call) Run(run func(ctx context.Context, req *token.PrepareBurnRequest)) *Token_PrepareBurn_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*token.PrepareBurnRequest))
+	})
+	return _c
+}
+
+func (_c *Token_PrepareBurn_Call) Return(_a0 *token.PreparedTransfer, _a1 error) *Token_PrepareBurn_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Token_PrepareBurn_Call) RunAndReturn(run func(context.Context, *token.PrepareBurnRequest) (*token.PreparedTransfer, error)) *Token_PrepareBurn_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
Part of #359 and epic #361. **Stacked on #375** (bridge API) — review the last commit only until #375 merges.

## What

USDCx outbound: burn on Canton via `BridgeUserAgreement_Burn`, Circle releases USDC on Ethereum, the relayer tracks the release. Closes the loop — with this PR the full USDCx lifecycle (deposit quote → auto-mint tracking → withdraw → release tracking) is wired end to end.

## Token SDK (`pkg/cantonsdk/token`)

- **`PrepareBurn` / `BurnByPartyID`** exercise `BridgeUserAgreement_Burn` on the user's own agreement contract (a user-party choice — never operator-signed), reusing the existing machinery end to end: agreement discovery via ACS, holdings selection via the transfer path's UTXO picker, choice context + disclosed contracts via the AnyValue converters, external signing via `prepareInstructionTx`/`ExecuteTransfer`, custodial signing via `exerciseInstructionAsCustodial`.
- **`RegistryClient.GetBurnMintFactory`** — burn-mint factory discovery; response envelope is identical to the transfer factory, so both now share one parser (`postFactoryEndpoint`).
- Gated by new `burn_mint_package_id` / `burn_mint_module` token-client config (values come from the utility-bridge DAR).

## Bridge API (`pkg/bridgeapi`)

- `POST /api/v2/bridge/withdraw/prepare` + `/execute` (external keys, incl. the fingerprint-vs-`signed_by` check from the transfer flow; prepared burns are single-use) and `/withdraw/custodial`.
- Execute/custodial register the transfer with the relayer: `canton_to_ethereum`, `source_tx_hash` = burn request UUID, `burn_request_id` metadata. Registration failure after a successful burn is reported as a tracking failure, not a withdrawal failure.
- xreserve token config gains `instrument_admin`, `instrument_id`, `withdraw_destination_domain` (0 = Ethereum).

## Relayer (`bridges/xreserve`)

- `stepWithdrawal`: `"" / awaiting_release → completed(released)`, polling Circle's burn status by request id. Same observer discipline as deposits: pending and transient-outage responses keep polling without consuming transfer retries; `DestTxHash` records the release tx.

## Pinned-to-stub caveats (verify in #360)

- `BridgeUserAgreement_Burn` choice/argument field names follow DA's devnet xReserve docs and the devstack stub.
- Burn-status endpoint (`/v1/burns/{requestId}`) and burn-mint factory path mirror the registrar prefix the devstack stub implements; DA's hosted Utilities backend may differ.

## Testing

- SDK: burn arg encoding exercised through the shared converters (existing token tests still green; mocks regenerated for the 2 new interface methods)
- bridgeapi: prepare/execute/custodial flows, single-use + ownership + fingerprint guards, validation matrix
- xreserve: full withdrawal stage machine + burn-status client (released/pending/404/5xx)
- `golangci-lint` clean across all touched packages; whole-module `go test` green (except two pre-existing Docker-dependent tests that panic without a local Docker daemon — they run in CI)
